### PR TITLE
Fix minor syntax error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ class JPypeSetup(object):
 
         self.jdkInclude = "linux"
         self.libraries = ["dl"]
-        self.libraryDir = [os.path.join(self.javaHome, "lib"]
+        self.libraryDir = [os.path.join(self.javaHome, "lib")]
 
     def setupPlatform(self):
         if sys.platform == 'win32':


### PR DESCRIPTION
Syntax error prevented install. I haven't fully tested this but it installs now.
