### PR TITLE
Ignore test artifacts and temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 dist/**
 MANIFEST
+*.pyc
+*~
+/test/classes/
+/build/


### PR DESCRIPTION
Wondering why these ignores haven't been added yet. Any reasons why not to merge this?
