### PR TITLE
[setup] Handle all mac versions > 10.5 the same way

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,8 @@ elif sys.platform == 'darwin':
             # call java_home detector 
             java_home = subprocess.check_output(['/usr/libexec/java_home']).strip()
 
-     else: # osx < 10.6
-            java_home = '/System/Library/Frameworks/JavaVM.framework/Home/'
+    else: # osx < 10.6
+        java_home = '/System/Library/Frameworks/JavaVM.framework/Home/'
 
     platform_specific['libraries'] = ['dl']
     # this raises warning:
@@ -109,9 +109,9 @@ else:
                 "pull request with a fix on github: "
                 "https://github.com/originell/jpype/"
                 % '\n'.join(possible_homes))
-             raise RuntimeError
+            raise RuntimeError
     platform_specific['libraries'] = ['dl']
-    platform_specific['library_dir'] = [os.path.join(java_home, 'lib')]
+    #platform_specific['library_dir'] = [os.path.join(java_home, 'lib')]
     platform_specific['include_dirs'] += [
         os.path.join(java_home, 'include'),
         os.path.join(java_home, 'include', 'linux'),


### PR DESCRIPTION
Handle all mac versions > 10.5 the same way, since they provide an utility named java_home to get the current JAVA_HOME. Added a little helper method to check if the given java_home contains a 'jni.h', so it is in fact a valid JDK. Provided a fallback path, if non has been provided and also check it if its a JDK. If nothing helps pretty print errors.
