### PR TITLE
fix deprecated conversion from string constant to ‘char*'

### DIFF
--- a/src/native/common/include/jp_javaenv_autogen.h
+++ b/src/native/common/include/jp_javaenv_autogen.h
@@ -449,13 +449,13 @@ jobject GetObjectArrayElement(jobjectArray a0, int a1);
 /** GetObjectClass */
 jclass GetObjectClass(jobject a0);
 /** GetMethodID */
-jmethodID GetMethodID(jclass a0, char* a1, char* a2);
+jmethodID GetMethodID(jclass a0, const char* a1, const char* a2);
 /** GetStaticMethodID */
-jmethodID GetStaticMethodID(jclass a0, char* a1, char* a2);
+jmethodID GetStaticMethodID(jclass a0, const char* a1, const char* a2);
 /** GetFieldID */
-jfieldID GetFieldID(jclass a0, char* a1, char* a2);
+jfieldID GetFieldID(jclass a0, const char* a1, const char* a2);
 /** GetStaticFieldID */
-jfieldID GetStaticFieldID(jclass a0, char* a1, char* a2);
+jfieldID GetStaticFieldID(jclass a0, const char* a1, const char* a2);
 /** GetStringChars */
 const jchar* GetStringChars(jstring a0, jboolean* a1);
 /** ReleaseStringChars */

--- a/src/native/common/include/jp_utility.h
+++ b/src/native/common/include/jp_utility.h
@@ -23,7 +23,7 @@
 class JPypeException
 {
 public :
-	JPypeException(char* msn, const char* f, int l) 
+	JPypeException(const char* msn, const char* f, int l) 
 	{
 		file=f, line=l;
 		std::stringstream str;
@@ -31,7 +31,7 @@ public :
 		this->msg = str.str();
 	}
 
-	JPypeException(string msn, const char* f, int l)
+	JPypeException(const string& msn, const char* f, int l)
 	{
 		file=f, line=l;
 		std::stringstream str;

--- a/src/native/common/jp_javaenv_autogen.cpp
+++ b/src/native/common/jp_javaenv_autogen.cpp
@@ -1650,7 +1650,7 @@ jclass JPJavaEnv::GetObjectClass(jobject a0)
 
 }
 
-jmethodID JPJavaEnv::GetMethodID(jclass a0, char* a1, char* a2)
+jmethodID JPJavaEnv::GetMethodID(jclass a0, const char* a1, const char* a2)
 {     jmethodID res;
 
     JNIEnv* env = getJNIEnv();
@@ -1664,7 +1664,7 @@ jmethodID JPJavaEnv::GetMethodID(jclass a0, char* a1, char* a2)
 
 }
 
-jmethodID JPJavaEnv::GetStaticMethodID(jclass a0, char* a1, char* a2)
+jmethodID JPJavaEnv::GetStaticMethodID(jclass a0, const char* a1, const char* a2)
 {     jmethodID res;
 
     JNIEnv* env = getJNIEnv();
@@ -1678,7 +1678,7 @@ jmethodID JPJavaEnv::GetStaticMethodID(jclass a0, char* a1, char* a2)
 
 }
 
-jfieldID JPJavaEnv::GetFieldID(jclass a0, char* a1, char* a2)
+jfieldID JPJavaEnv::GetFieldID(jclass a0, const char* a1, const char* a2)
 {     jfieldID res;
 
     JNIEnv* env = getJNIEnv();
@@ -1692,7 +1692,7 @@ jfieldID JPJavaEnv::GetFieldID(jclass a0, char* a1, char* a2)
 
 }
 
-jfieldID JPJavaEnv::GetStaticFieldID(jclass a0, char* a1, char* a2)
+jfieldID JPJavaEnv::GetStaticFieldID(jclass a0, const char* a1,  const char* a2)
 {     jfieldID res;
 
     JNIEnv* env = getJNIEnv();

--- a/src/native/python/include/pythonenv.h
+++ b/src/native/python/include/pythonenv.h
@@ -73,32 +73,32 @@ class JPyArg : public JPythonEnvHelper
 {
 public :
 	template<typename T1>
-	static void parseTuple(PyObject* arg, char* pattern, T1 a1)
+	static void parseTuple(PyObject* arg, const char* pattern, T1 a1)
 	{
 		PY_CHECK( PyArg_ParseTuple(arg, pattern, a1) );
 	}
 
 	template<typename T1, typename T2>
-	static void parseTuple(PyObject* arg, char* pattern, T1 a1, T2 a2)
+	static void parseTuple(PyObject* arg, const char* pattern, T1 a1, T2 a2)
 	{
 		PY_CHECK( PyArg_ParseTuple(arg, pattern, a1, a2) );
 	}
 
 	template<typename T1, typename T2, typename T3>
-	static void parseTuple(PyObject* arg, char* pattern, T1 a1, T2 a2, T3 a3)
+	static void parseTuple(PyObject* arg, const char* pattern, T1 a1, T2 a2, T3 a3)
 	{
 		PY_CHECK( PyArg_ParseTuple(arg, pattern, a1, a2, a3) );
 	}
 
 	template<typename T1, typename T2, typename T3, typename T4>
-	static void parseTuple(PyObject* arg, char* pattern, T1 a1, T2 a2, T3 a3, T4 a4)
+	static void parseTuple(PyObject* arg, const char* pattern, T1 a1, T2 a2, T3 a3, T4 a4)
 	{
 		PY_CHECK( PyArg_ParseTuple(arg, pattern, a1, a2, a3, a4)) ;
 		
 	}
 
 	template<typename T1, typename T2, typename T3, typename T4, typename T5>
-	static void parseTuple(PyObject* arg, char* pattern, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
+	static void parseTuple(PyObject* arg, const char* pattern, T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
 	{
 		PY_CHECK( PyArg_ParseTuple(arg, pattern, a1, a2, a3, a4, a5)) ;
 		


### PR DESCRIPTION
added some missing const to char\* parameters to silence gcc warning about 'deprecated conversion from string constant to ‘char*’'
