### PR TITLE
FIX #62.

### DIFF
--- a/src/native/common/jp_primitivetypes_autogen.cpp
+++ b/src/native/common/jp_primitivetypes_autogen.cpp
@@ -43,6 +43,7 @@ setViaBuffer(jarray array, int start, int length, PyObject* sequence) {
 	// temporarily disabled until production stable
 	return false;
 
+#if (PY_VERSION_HEX >= 0x02070000)
 	//creates a PyBuffer from sequence check for typeError,
 	// if no underlying buff exists.
 	PyObject* memview = PyMemoryView_FromObject(sequence);
@@ -94,6 +95,7 @@ setViaBuffer(jarray array, int start, int length, PyObject* sequence) {
 		PyErr_Clear();
 	}
 	return false;
+#endif
 }
 
 jarray JPByteType::newArrayInstance(int sz)


### PR DESCRIPTION
Method setArrayRange in jp_primitivetypes leaked memory in Python code as an
temporary PythonObject has not been refcounted properly.

Reworked single array element setters/getters to avoid a copy of the whole array
in worst case (use jni Get/SetArrayRange functions).
