### PR TITLE
Implement a build matrix for travis to test with/without numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 env:
   matrix:
     # one build with and without numpy support (opt numpy out)
-    - NUMPY="--install-option=disable-numpy"
+    - NUMPY="--install-option=--disable-numpy"
     - NUMPY=""
 
 before_install:


### PR DESCRIPTION
Don't know if this really works. Where can I see in the logs if numpy support is enabled or not?

By default no numpy package seems to be installed in travis. But with or without the package in the logs we always have `-DHAVE_NUMPY=1`
