### PR TITLE
[JVMFinder] in case a method raises, other methods were not being executed anymore.

### DIFF
--- a/jpype/_darwin.py
+++ b/jpype/_darwin.py
@@ -65,7 +65,7 @@ class DarwinJVMFinder(LinuxJVMFinder):
             else:
                 java_home = subprocess.Popen(['/usr/libexec/java_home'], stdout=subprocess.PIPE).communicate()[0]
             return java_home
-        return None
+        raise NotImplementedError
 
 # ------------------------------------------------------------------------------
 

--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -111,9 +111,11 @@ class JVMFinder(object):
         for method in self._methods:
             try:
                 jvm = method()
-
             except NotImplementedError:
                 # Ignore missing implementations
+                pass
+            except JVMNotFoundException:
+                # Ignore not successful methods
                 pass
 
             else:

--- a/jpype/_windows.py
+++ b/jpype/_windows.py
@@ -59,6 +59,5 @@ class WindowsJVMFinder(_jvmfinder.JVMFinder):
             return cv[0]
 
         except WindowsError:
-            pass
+            raise NotImplementedError
 
-        return None


### PR DESCRIPTION
this is due to the new exception type JVMNotFoundException, which I introduced after the cherry-pick of JVMFinder by Thomas Calmant.
