### PR TITLE
Support for java.lang.Iterable

### DIFF
--- a/native/common/include/jp_hostenv.h
+++ b/native/common/include/jp_hostenv.h
@@ -124,7 +124,7 @@ public :
 	virtual jsize    getStringLength(HostRef*) = 0;
 	virtual string   stringAsString(HostRef*) = 0;
 	virtual JCharString  stringAsJCharString(HostRef*) = 0;
-	virtual HostRef* newStringFromUnicode(const jchar*, unsigned int) = 0;
+	virtual HostRef* newStringFromUTF16(const jchar*, unsigned int) = 0;
 	virtual HostRef* newStringFromASCII(const char*, unsigned int) = 0;
 	virtual bool     isByteString(HostRef*) = 0;
 	virtual bool     isUnicodeString(HostRef*) = 0;

--- a/native/common/jp_objecttypes.cpp
+++ b/native/common/jp_objecttypes.cpp
@@ -254,7 +254,7 @@ HostRef* JPStringType::asHostObject(jvalue val)
 		jboolean isCopy;
 		const jchar* str = JPEnv::getJava()->GetStringChars(v, &isCopy);
 
-		HostRef* res = JPEnv::getHost()->newStringFromUnicode(str, len);
+		HostRef* res = JPEnv::getHost()->newStringFromUTF16(str, len);
 		
 		JPEnv::getJava()->ReleaseStringChars(v, str);
 

--- a/native/common/jp_primitivetypes.cpp
+++ b/native/common/jp_primitivetypes.cpp
@@ -37,7 +37,7 @@ jobject JPPrimitiveType::convertToJavaObject(HostRef* obj)
 
 HostRef* JPByteType::asHostObject(jvalue val) 
 {
-	return JPEnv::getHost()->newInt(val.b);
+	return JPEnv::getHost()->newInt((unsigned char)val.b);
 }
 
 HostRef* JPByteType::asHostObjectFromObject(jvalue val)
@@ -545,7 +545,7 @@ HostRef* JPCharType::asHostObject(jvalue val)
 	str[0] = val.c;
 	str[1] = 0;
 	
-	return JPEnv::getHost()->newStringFromUnicode(str, 1);
+	return JPEnv::getHost()->newStringFromUTF16(str, 1);
 }
 
 HostRef* JPCharType::asHostObjectFromObject(jvalue val)
@@ -554,7 +554,7 @@ HostRef* JPCharType::asHostObjectFromObject(jvalue val)
 	str[0] = JPJni::charValue(val.l);
 	str[1] = 0;
 	
-	return JPEnv::getHost()->newStringFromUnicode(str, 1);
+	return JPEnv::getHost()->newStringFromUTF16(str, 1);
 } 
 
 EMatchType JPCharType::canConvertToJava(HostRef* obj)

--- a/native/python/include/py_hostenv.h
+++ b/native/python/include/py_hostenv.h
@@ -216,7 +216,7 @@ public :
 	virtual jsize getStringLength(HostRef*);
 	virtual string   stringAsString(HostRef*);
 	virtual JCharString stringAsJCharString(HostRef*);
-	virtual HostRef* newStringFromUnicode(const jchar*, unsigned int);
+	virtual HostRef* newStringFromUTF16(const jchar*, unsigned int);
 	virtual HostRef* newStringFromASCII(const char*, unsigned int);
 	virtual bool     isByteString(HostRef*);
 	virtual bool     isUnicodeString(HostRef* ref);

--- a/native/python/include/pythonenv.h
+++ b/native/python/include/pythonenv.h
@@ -137,7 +137,7 @@ public :
 	static Py_ssize_t AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *);
 	static Py_UNICODE* AsUnicode(PyObject *obj);
 
-	static PyObject* fromUnicode(const jchar*, int);
+	static PyObject* fromUTF16(const jchar*, int);
 	static PyObject* fromString(const char*);
 };
 

--- a/native/python/py_hostenv.cpp
+++ b/native/python/py_hostenv.cpp
@@ -440,10 +440,10 @@ JCharString PythonHostEnvironment::stringAsJCharString(HostRef* ref)
 	return JPyString::asJCharString(UNWRAP(ref));
 }
 
-HostRef* PythonHostEnvironment::newStringFromUnicode(const jchar* v, unsigned int l)
+HostRef* PythonHostEnvironment::newStringFromUTF16(const jchar* v, unsigned int l)
 {
-	TRACE_IN("PythonHostEnvironment::newStringFromUnicode");
-	return new HostRef(JPyString::fromUnicode(v, l), false);
+	TRACE_IN("PythonHostEnvironment::newStringFromUTF16");
+	return new HostRef(JPyString::fromUTF16(v, l), false);
 	TRACE_OUT;
 }
 

--- a/test/jpypetest/array.py
+++ b/test/jpypetest/array.py
@@ -234,7 +234,7 @@ class ArrayTestCase(common.JPypeTestCase):
     def testSetFromNPByteArray(self):
         import numpy as np
         n = 100
-        a = np.random.randint(-128, 127, size=n).astype(np.byte)
+        a = np.random.randint(-128, 127, size=n).astype('B')
         jarr = jpype.JArray(jpype.JByte)(n)
         jarr[:] = a
         self.assertCountEqual(a, jarr)

--- a/test/jpypetest/unicode.py
+++ b/test/jpypetest/unicode.py
@@ -1,0 +1,39 @@
+#*****************************************************************************
+#   Copyright 2017 Robbert Segeren
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#*****************************************************************************
+from jpype import java, JArray, JByte
+from . import common
+
+
+class UnicodeTestCase(common.JPypeTestCase):
+
+    def testToString(self):
+        UTF_8 = java.nio.charset.StandardCharsets.UTF_8
+        smiley = java.lang.String(b'\xF0\x9F\x98\x8A', UTF_8)
+        self.assertEqual(smiley.toString(), u'\U0001f60a')
+
+    def testFromUnicode(self):
+        smiley = java.lang.String(u'\U0001f60a')
+        self.assertEqual(smiley.toString(), u'\U0001f60a')
+
+    def testUTF8Encodable(self):
+        smiley = java.lang.String(b'\xF0\x9F\x98\x8A'.decode('utf8'))
+        self.assertEqual(smiley.toString().encode('utf8'), b'\xf0\x9f\x98\x8a')
+
+    def testBytes(self):
+        UTF_8 = java.nio.charset.StandardCharsets.UTF_8
+        smiley = java.lang.String(JArray(JByte)([0xF0, 0x9F, 0x98, 0x8A]), UTF_8)
+        self.assertEqual(list(smiley.getBytes(UTF_8)), [0xF0, 0x9F, 0x98, 0x8A])


### PR DESCRIPTION
Added support for interface `java.lang.Iterable` (JDK >= 1.5) to make them iterable in Python.
