### PR TITLE
Work of jp_method bug

### DIFF
--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -90,6 +90,12 @@ class _JavaArrayClass(object):
         else:
             raise AttributeError("%s does not have field %s"%(self.__name__, attr), self)
 
+def _isIterable(obj):
+    if isinstance(obj, collections.Sequence):
+        return True
+    if hasattr(obj,'__len__') and hasattr(obj,'__iter__'):
+        return True
+    return False
 
 def _jarrayInit(self, *args):
     if len(args) == 2 and args[0] == _jclass._SPECIAL_CONSTRUCTOR_KEY:
@@ -100,7 +106,7 @@ def _jarrayInit(self, *args):
             .format(len(args) + 1))
     else:
         values = None
-        if isinstance(args[0], collections.Sequence):
+        if _isIterable(args[0]):
             sz = len(args[0])
             values = args[0]
         else:

--- a/native/common/include/jp_class.h
+++ b/native/common/include/jp_class.h
@@ -39,17 +39,8 @@ public :
 	
 	JPField*                getInstanceField(const string& name);
 	JPField*                getStaticField(const string& name);
-	JPMethod*				getMethod(const string& name);
-	vector<JPMethod*>		getMethods() const
-	{
-		vector<JPMethod*> res;
-		res.reserve(m_Methods.size());
-		for (map<string, JPMethod*>::const_iterator cur = m_Methods.begin(); cur != m_Methods.end(); cur++)
-		{
-			res.push_back(cur->second);
-		}
-		return res;
-	}
+	JPMethod*		getMethod(const string& name);
+	vector<JPMethod*>	getMethods();
 
 	jclass getClass()
 	{
@@ -96,12 +87,12 @@ private :
 
 private :
 	bool                    m_IsInterface;
-	JPClass*				m_SuperClass;
-	vector<JPClass*>		m_SuperInterfaces;
+	JPClass*		m_SuperClass;
+	vector<JPClass*>	m_SuperInterfaces;
 	map<string, JPField*>   m_StaticFields;
 	map<string, JPField*>   m_InstanceFields;
 	map<string, JPMethod*>	m_Methods;
-	JPMethod*				m_Constructors;
+	JPMethod*		m_Constructors;
 };
 
 

--- a/native/common/include/jp_hostenv.h
+++ b/native/common/include/jp_hostenv.h
@@ -148,6 +148,8 @@ public :
 	virtual void printReferenceInfo(HostRef* obj) = 0;
 	virtual bool isByteBuffer(HostRef*) = 0;
 	virtual void getByteBufferPtr(HostRef*, char**, long&) = 0;
+
+	virtual const char* getTypeName(HostRef*) = 0;
 };
 
 #endif // _JPHOSTENV_H_

--- a/native/common/include/jp_jniutil.h
+++ b/native/common/include/jp_jniutil.h
@@ -45,6 +45,7 @@ namespace JPJni
 	JPTypeName getClassName(jobject obj);
 	jclass getClass(jobject obj);
 	jstring toString(jobject obj);
+	string toStringC(jobject obj);
 
 	/**
 	* java.lang.Class.isInterface()

--- a/native/common/include/jp_method.h
+++ b/native/common/include/jp_method.h
@@ -17,25 +17,35 @@
 #ifndef _JPMETHOD_H_
 #define _JPMETHOD_H_
 
+#include <list>
 class JPObject;
 
 class JPMethod
 {
 public :
+	typedef std::list<JPMethodOverload*> OverloadList;
+
 	/**
 	 * Create a new method based on class and a name;
 	 */
 	JPMethod(jclass clazz, const string& name, bool isConstructor);
 	virtual ~JPMethod();
 
+private:
+	JPMethod(const JPMethod& method);
+	JPMethod& operator=(const JPMethod& method);
+
 public :
 	const string& getName() const;
 	string getClassName() const;
 	
 	void addOverload(JPClass* clazz, jobject mth);
-	void addOverloads(JPMethod* o);
 	
-	bool hasStatic(); 
+	bool hasStatic() 
+	{
+		return m_hasStatic;
+	}
+
 	size_t getCount()
 	{
 		return m_Overloads.size();
@@ -52,23 +62,18 @@ public :
 	string describe(string prefix);
 
 	string matchReport(vector<HostRef*>&);
-	void ensureOverloadOrderCache();
 
 private :
-	JPMethodOverload* findOverload(vector<HostRef*>& arg, bool needStatic);
+	JPMethodOverload* findOverload(vector<HostRef*>& arg, bool searchStatic, bool searchInstance);
+	void ensureOverloadCache();
+	void dumpOverloads();
 
 	jclass                        m_Class;
 	string                        m_Name;
-	map<string, JPMethodOverload> m_Overloads;
-
-	struct OverloadData {
-		OverloadData(JPMethodOverload* o) : m_Overload(o) {}
-
-		JPMethodOverload*              m_Overload;
-		std::vector<JPMethodOverload*> m_MoreSpecificOverloads;
-	};
-	std::vector<OverloadData>     m_OverloadOrderCache;
+	OverloadList  m_Overloads;
 	bool                          m_IsConstructor;
+	bool          m_hasStatic;
+	bool          m_Cached;
 	
 };
 

--- a/native/common/include/jp_object.h
+++ b/native/common/include/jp_object.h
@@ -23,6 +23,11 @@ public :
 	JPObject(JPClass* clazz, jobject inst);
 	JPObject(JPTypeName& clazz, jobject inst);
 	virtual ~JPObject();
+private:
+	JPObject(const JPObject&);
+	JPObject& operator=(const JPObject&);
+
+public:
 	
 
 	JPClass* getClass()

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -201,8 +201,18 @@ JPMethod* JPClass::getMethod(const string& name)
 	{
 		return NULL;
 	}
-
 	return it->second;
+}
+
+vector<JPMethod*>  JPClass::getMethods()
+{
+	vector<JPMethod*> res;
+	res.reserve(m_Methods.size());
+	for (map<string, JPMethod*>::const_iterator cur = m_Methods.begin(); cur != m_Methods.end(); cur++)
+	{
+		res.push_back(cur->second);
+	}
+	return res;
 }
 
 HostRef* JPClass::getStaticAttribute(const string& name)

--- a/native/common/jp_jniutil.cpp
+++ b/native/common/jp_jniutil.cpp
@@ -209,7 +209,6 @@ string asciiFromJava(jstring str)
 	}
 
 	frame.ReleaseStringUTFChars(str, cstr);
-
 	return res;
 }
 
@@ -256,6 +255,13 @@ jstring toString(jobject o)
 	JPJavaFrame frame;
 	jstring str = (jstring)frame.CallObjectMethod(o, toStringID);
 	return str;
+}
+
+string toStringC(jobject o)
+{
+	JPJavaFrame frame;
+	jstring jname = (jstring)frame.CallObjectMethod(o, toStringID);
+	return asciiFromJava(jname);
 }
 
 static string convertToSimpleName(jclass c)

--- a/native/python/include/py_hostenv.h
+++ b/native/python/include/py_hostenv.h
@@ -240,6 +240,8 @@ public :
 	virtual void printReferenceInfo(HostRef* obj);
 	virtual bool isByteBuffer(HostRef*);
 	virtual void getByteBufferPtr(HostRef*, char**, long&);
+
+	virtual const char* getTypeName(HostRef*);
 };
 
 #endif // _PYHOSTENV_H_

--- a/native/python/py_hostenv.cpp
+++ b/native/python/py_hostenv.cpp
@@ -652,3 +652,10 @@ void PythonHostEnvironment::printReferenceInfo(HostRef* obj)
 	cout << "    Ref count " << (long)pobj->ob_refcnt << endl;
 }
 
+const char* PythonHostEnvironment::getTypeName(HostRef* ref)
+{
+	PyObject* obj = UNWRAP(ref);
+	return Py_TYPE(obj)->tp_name;
+}
+
+

--- a/native/python/py_method.cpp
+++ b/native/python/py_method.cpp
@@ -320,9 +320,12 @@ PyObject* PyJPBoundMethod::__call__(PyObject* o, PyObject* args, PyObject* kwarg
 	
 			vector<HostRef*> vargs;
 			Py_ssize_t len = JPyObject::length(args);
+
+			// Push the self onto the list
 			HostRef* ref = new HostRef((void*)self->m_Instance);
 			cleaner.add(ref);
 			vargs.push_back(ref);
+
 			for (Py_ssize_t i = 0; i < len; i++)
 			{
 				PyObject* obj = JPySequence::getItem(args, i); // returns a new ref
@@ -332,7 +335,7 @@ PyObject* PyJPBoundMethod::__call__(PyObject* o, PyObject* args, PyObject* kwarg
 				Py_DECREF(obj); // remove ref returned by getItem
 			}
 	
-			HostRef* res = self->m_Method->m_Method->invoke(vargs);
+			HostRef* res = self->m_Method->m_Method->invokeInstance(vargs);
 			TRACE2("Call finished, result = ", res);	
 			
 			result = detachRef(res);

--- a/native/python/pythonenv.cpp
+++ b/native/python/pythonenv.cpp
@@ -293,7 +293,6 @@ void JPyErr::rethrow(const char* file, int line)
 	catch(PythonException& ex)
 	{
 		TRACE1("Python exception");
-//		cout << "Python error occured" << endl;
 	}
 	catch(...)
 	{


### PR DESCRIPTION
This  patch corrects a bug in which assignment was being used to copy a resource leaving the object operating on a non-existent global reference. It would then free the global reference freeing other resources resulting in errors.  However, at this was mostly at destruction time, it was rarely exercised.

The patch has the side effect of allowing construction of a JArray from an np.array when initializing.  np.array was not registering as a sequence and thus not hitting the correct code path.

The patch has the side effect of improving error reporting for methods.  (which is what I was trying to do when I found the bug).

```
import jpype
import jpype.imports
jpype.startJVM(jpype.getDefaultJVMPath())

import java.lang.String
import java.lang.Double
import numpy as np

try:
    java.lang.String(5.0)
except Exception as ex:
    print(ex)

try:
    f=java.lang.String("foo")
    f.substring(6.0)
except Exception as ex:
    print(ex)

try:
    java.lang.String.copyValueOf(6.0)
except Exception as ex:
    print(ex)

try:
    x=np.array([0],dtype=np.int)
    f=java.lang.String("foo")
    f.substring(x[0])
except Exception as ex:
    print(ex)
```

now gives
```
No matching overloads found for constructor class java.lang.String(float), options are:
        public java.lang.String(byte[],int,int)
        public java.lang.String(byte[],java.nio.charset.Charset)
        public java.lang.String(byte[],java.lang.String) throws java.io.UnsupportedEncodingException
        public java.lang.String(byte[],int,int,java.nio.charset.Charset)
        public java.lang.String(byte[],int,int,java.lang.String) throws java.io.UnsupportedEncodingException
        public java.lang.String(java.lang.StringBuilder)
        public java.lang.String(java.lang.StringBuffer)
        public java.lang.String(byte[])
        public java.lang.String(int[],int,int)
        public java.lang.String()
        public java.lang.String(char[])
        public java.lang.String(java.lang.String)
        public java.lang.String(char[],int,int)
        public java.lang.String(byte[],int)
        public java.lang.String(byte[],int,int,int)
 at native\common\jp_method.cpp:130
No matching overloads found for class java.lang.String.substring(float), options are:
        public java.lang.String java.lang.String.substring(int)
        public java.lang.String java.lang.String.substring(int,int)
 at native\common\jp_method.cpp:130
No matching overloads found for class java.lang.String.copyValueOf(float), options are:
        public static java.lang.String java.lang.String.copyValueOf(char[])
        public static java.lang.String java.lang.String.copyValueOf(char[],int,int)
 at native\common\jp_method.cpp:130
No matching overloads found for class java.lang.String.substring(numpy.int32), options are:
        public java.lang.String java.lang.String.substring(int)
        public java.lang.String java.lang.String.substring(int,int)
 at native\common\jp_method.cpp:130
```

Implementation notes
- it was necessary to rework the caching mechanism on the jp_method, but this needs to be tested to make sure that it still properly handles ambiguous overloads.
- it was necessary to cause methods to be lazy loaded by the class as there is a race condition between loading methods from java.lang.Object during initialization.  I suspect that nothing was actually using this function as methods may be pulled later when the python class is created.  But I have not sorted that out.
- it was challenging to properly suppress the this pointer when printing the error message.  I changed the copy of the Bound version to help sort that out.


