### PR TITLE
And now for something completely different with lambdas

### DIFF
--- a/thunk2/README
+++ b/thunk2/README
@@ -1,0 +1,35 @@
+This is a set of experimental changes to fix the issues with Java 8 lambdas.
+
+The current jpype system is using names to distinguish classes, but lambdas
+don't have names that the class loader can find.  Thus any lambda chokes the 
+system badly.  We tried to switch this to jclass but these are handles that
+are not unique.  Comparing them with java doesn't work because it is both
+slow and won't work in a map.  We tried hashcodes but those aren't unique
+either.  Thus there is no good solution down the current path.  And the
+things are likely to just get worse by Java 9.
+
+The following proposal is to do the opposite. Rather than forcing C++
+to understand java types, we instead move all of the support for type
+management to Java.  Java will create C++ types through the JNI interface
+as it needs them and control the lifespan.  Further the typemanager will
+be synchronized with locks so that threading can never be cause an issue.
+
+This will remove the majority of the jp_jniutil.cpp functions as java
+will simply pass everything that is needed at the native layer.  There will
+be no need for C++ to talk to JNI except to convert types or communicate with
+the TypeManager.  The TypeManager can be communicated with directly through
+python using the org.jpype.TypeManager object.  Thus we can do much 
+easier probing of the state of the system without having to add more 
+stuff to the python module.  Thus we will slim both the python _jpype 
+module and the C++ support classes.  Further, as we can test aspects
+of the system in java natively we can increase the speed of development
+cycles.
+
+There are some downsides.  The thunks are likely to grow pretty large.  We
+may want to come up with a better way to encode the thunks in the _jpype
+binary.  Perhaps we can construct a jar and use a custom class loader to
+fetch the jar out to binary.  Also maintaining the JNI interface may be
+less than fun, but perhaps a utility function can use reflection to 
+write stubs for the process.
+
+

--- a/thunk2/build.xml
+++ b/thunk2/build.xml
@@ -1,0 +1,24 @@
+<project default="compile" name="JPype - Native">
+
+	<property name="JAVA_VERSION" value="${ant.java.version}"/>
+	<property name="src" location="src"/>
+	<property name="build" location="classes"/>
+
+	<target name="test" depends="compile">
+	</target>
+
+	<target name="compile">
+		<mkdir dir="${build}"/>
+		<javac destdir="${build}"
+			source="${JAVA_VERSION}"
+			target="${JAVA_VERSION}"
+			>
+			<src path="${src}"/>
+		</javac>
+	</target>
+
+	<target name="clean">
+		<delete dir="${build}"/>
+	</target>
+
+</project>

--- a/thunk2/src/org/jpype/ClassDescription.java
+++ b/thunk2/src/org/jpype/ClassDescription.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018, Karl Einar Nelson
+ * All rights reserved.
+ * 
+ */
+package org.jpype;
+
+import java.lang.reflect.Method;
+import java.util.TreeMap;
+
+/**
+ * A list of resources associated with this class.
+ * 
+ * These can be accessed within JPype using the org.jpype.TypeManager.
+ * 
+ */
+public class ClassDescription
+{
+  public Class cls;
+  /** The C++ jp_classtype pointer for this class. */
+  
+  public long classPtr;
+  
+  /** The jp_method wrapper for the constructor. */
+  public long constructorPtr;
+  
+  /** The list of all jp_method for this class. */
+  public long[] methodPtrs;
+  
+  /** The map of all method names to C++ method overload wrappers. */
+  public TreeMap<Method, Long> methodOverloadMap;
+  
+  /** The map of all method names to C++ method container wrappers. */
+  public TreeMap<String, Long> methodContainerMap;
+
+  ClassDescription(Class cls, long classPtr)
+  {
+    this.cls = cls;
+    this.classPtr = classPtr;
+  }
+}

--- a/thunk2/src/org/jpype/MethodOverloadResolution.java
+++ b/thunk2/src/org/jpype/MethodOverloadResolution.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018, Karl Einar Nelson
+ * All rights reserved.
+ * 
+ */
+package org.jpype;
+
+import java.lang.reflect.Executable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Sort out which methods hide other methods.
+ * 
+ * When resolving method overloads there may be times in which
+ * more than one overload applies.  JPype requires that the 
+ * methods appear in order from most to least specific.  And
+ * each method overload requires a list of methods that are
+ * more general. If two or more methods match and one is not
+ * more specific than the other 
+ * @author nelson85
+ */
+public class MethodOverloadResolution
+{
+  long ptr=0;
+  boolean covered = false;
+  Executable executable;
+  List<MethodOverloadResolution> children = new ArrayList<>();
+
+  MethodOverloadResolution(Executable method)
+  {
+    this.executable = method;
+  }
+
+  private boolean isCovered()
+  {
+    for (MethodOverloadResolution ov : this.children)
+    {
+      if (!ov.covered)
+        return false;
+    }
+    covered = true;
+    return true;
+  }
+
+  /**
+   * Order methods from least to most specific.
+   *
+   * @param methods
+   * @return
+   */
+  public static <T extends Executable> List<MethodOverloadResolution> sortMethods(List<T> methods)
+  {
+    LinkedList<MethodOverloadResolution> unsorted = new LinkedList<>();
+    for (T m1 : methods)
+    {
+      unsorted.add(new MethodOverloadResolution(m1));
+    }
+
+    for (MethodOverloadResolution m1 : unsorted)
+    {
+      for (MethodOverloadResolution m2 : unsorted)
+      {
+        if (m1 == m2)
+          continue;
+
+        if (isMoreSpecificThan(m1.executable, m2.executable) && !isMoreSpecificThan(m2.executable, m1.executable))
+        {
+          m1.children.add(m2);
+        }
+      }
+    }
+
+    // Execute a graph sort problem so that the most specific are always on the front
+    LinkedList<MethodOverloadResolution> out = new LinkedList<>();
+    while (!unsorted.isEmpty())
+    {
+      // Remove the first unsorted element
+      MethodOverloadResolution front = unsorted.pop();
+      // Check to see if all dependencies are already ordered
+      boolean good = front.isCovered();
+
+      // If all dependencies are included
+      if (good)
+      {
+        front.covered = true;
+        out.add(front);
+      } else
+      {
+        unsorted.add(front);
+      }
+
+    }
+    return out;
+  }
+
+  /**
+   * Determine is a executable is more specific than another.
+   * <p>
+   * This is public so that we can debug from within jpype.
+   *
+   * @param method1
+   * @param method2
+   * @return
+   */
+  public static boolean isMoreSpecificThan(Executable method1, Executable method2)
+  {
+    Class<?>[] param1 = method1.getParameterTypes();
+    Class<?>[] param2 = method2.getParameterTypes();
+
+    if (param1.length != param2.length)
+      return false;
+    
+    for (int i = 0; i < param1.length; ++i)
+    {
+      if (!param1[i].isAssignableFrom(param2[i]))
+        return false;
+    }
+    return true;
+  }
+}

--- a/thunk2/src/org/jpype/TypeFactory.java
+++ b/thunk2/src/org/jpype/TypeFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018, Karl Einar Nelson
+ * All rights reserved.
+ * 
+ */
+package org.jpype;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+/**
+ * This is the interface for creating C++ object in JPype.
+ * <p>
+ * These methods are all native.
+ *
+ */
+public class TypeFactory
+{
+  public native long definePrimitive(int code, Class cls, long boxedPtr);
+
+  public native long defineObjectClass(
+          int code,
+          Class cls,
+          String name,
+          long superClassPtr,
+          long[] superInterfaceClassPtrs,
+          boolean isInterface
+  );
+
+  public native long defineArrayClass(
+          Class cls,
+          String name,
+          long componentPtr);
+
+  /**
+   *
+   * @param cls
+   * @param name
+   * @param overloads
+   * @return
+   */
+  public native long defineConstructorContainer(
+          long classPtr,
+          String name,
+          long[] overloads);
+
+  /**
+   * Creates a C++ wrapper for a method overload.
+   *
+   * @param classPtr is the C++ type wrapper for the defining class.
+   * @param method is the method to be called.
+   * @param name is the toString description of the method.
+   * @param paramPtrs is a list of C++ type wrappers for arguments.
+   * @param precedenceMethodOverloadPtr is a list of method overloads that have
+   * precedence over this overload.
+   * @param isVarArgs is true if the method takes variable arguments.
+   * @return a pointer to the C++ wrapper.
+   */
+  public native long defineConstructorOverload(
+          long classPtr,
+          Constructor method,
+          String name,
+          long[] paramPtrs,
+          long[] precedenceMethodOverloadPtr,
+          boolean isVarArgs
+  );
+
+  public native long defineMethodContainer(
+          long classPtr,
+          String name,
+          long[] overloads,
+          boolean hasStatic);
+
+  /**
+   * Creates a C++ wrapper for a method overload.
+   *
+   * @param classPtr is the C++ type wrapper for the defining class.
+   * @param method is the method to be called.
+   * @param name is the toString description of the method.
+   * @param retTypePtr is a C++ type wrapper for the return.
+   * @param paramPtrs is a list of C++ type wrappers for arguments.
+   * @param precedenceMethodOverloadPtr is a list of method overloads that have
+   * precedence over this overload.
+   * @param isStatic is true for a static method.
+   * @param isVarArgs is true if the method takes variable arguments.
+   * @return a pointer to the C++ wrapper.
+   */
+  public native long defineMethodOverload(
+          long classPtr,
+          Method method,
+          String name,
+          long retTypePtr,
+          long[] paramPtrs,
+          long[] precedenceMethodOverloadPtr,
+          boolean isStatic,
+          boolean isVarArgs
+  );
+
+  public native void destroy(long[] resources, int sz);
+}

--- a/thunk2/src/org/jpype/TypeManager.java
+++ b/thunk2/src/org/jpype/TypeManager.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright 2018, Karl Einar Nelson
+ * All rights reserved
+ * 
+ */
+package org.jpype;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ *
+ */
+public class TypeManager
+{
+  private static TypeManager INSTANCE = new TypeManager();
+  public boolean isShutdown = false;
+  public HashMap<Class, ClassDescription> classMap = new HashMap<>();
+  LinkedList<Long> destroy = new LinkedList<>();
+  public TypeFactory typeFactory = new TypeFactory();
+
+//<editor-fold desc="interface">
+  public static TypeManager getInstance()
+  {
+    return TypeManager.INSTANCE;
+  }
+
+  public synchronized void init()
+  {
+    if (!this.destroy.isEmpty())
+      throw new RuntimeException("Initialize must only be called once");
+    isShutdown = false;
+
+    // Create the required minimum classes
+    createClass(-1, Object.class);
+    createClass(-1, Class.class);
+
+    // Create the boxed types
+    // These require special rules in the C++ layer so we will tag them 
+    // as being different.
+    createClass(0, Void.class);
+    createClass(1, Boolean.class);
+    createClass(2, Byte.class);
+    createClass(3, Character.class);
+    createClass(4, Short.class);
+    createClass(5, Integer.class);
+    createClass(6, Long.class);
+    createClass(7, Float.class);
+    createClass(8, Double.class);
+    createClass(9, String.class);
+
+    // Create the primitive types
+    // Link boxed and primitive types so that the wrappers can find them.
+    createPrimitive(0, Void.TYPE, Void.class);
+    createPrimitive(1, Boolean.TYPE, Boolean.class);
+    createPrimitive(2, Byte.TYPE, Byte.class);
+    createPrimitive(3, Character.TYPE, Character.class);
+    createPrimitive(4, Short.TYPE, Short.class);
+    createPrimitive(5, Integer.TYPE, Integer.class);
+    createPrimitive(6, Long.TYPE, Long.class);
+    createPrimitive(7, Float.TYPE, Float.class);
+    createPrimitive(8, Double.TYPE, Double.class);
+  }
+
+  /**
+   * Find a wrapper for a class.
+   * <p>
+   * Creates one if needed.
+   *
+   * @param cls
+   * @return the class wrapper, or null it one cannot be created.
+   */
+  public synchronized long findClass(Class cls)
+  {
+    if (this.isShutdown)
+      return 0;
+
+    ClassDescription ptr = this.classMap.get(cls);
+    if (ptr != null)
+      return ptr.classPtr;
+
+    return createClass(-1, cls);
+  }
+
+  public synchronized void shutdown()
+  {
+    final int BLOCK_SIZE = 64;
+    this.isShutdown = true;
+    long[] set = new long[BLOCK_SIZE];
+    int i = 0;
+
+    // Destroy all wrapper class/methods/overloads
+    Iterator<Long> iter = this.destroy.iterator();
+    while (iter.hasNext())
+    {
+      set[i++] = iter.next();
+      if (i == BLOCK_SIZE)
+      {
+        typeFactory.destroy(set,i);
+        i = 0;
+      }
+    }
+
+    for (; i < BLOCK_SIZE; ++i)
+      set[i] = 0;
+    typeFactory.destroy(set,i);
+
+    // Clear the maps
+    destroy.clear();
+    this.classMap.clear();
+  }
+
+  /**
+   * Load the constructors for a class.
+   *
+   * @param cls
+   */
+  public synchronized long getConstructor(Class cls)
+  {
+    LinkedList<Constructor> constructors = new LinkedList<>(Arrays.asList(cls.getDeclaredConstructors()));
+    ClassDescription desc = this.classMap.get(cls);
+    if (desc.constructorPtr != 0)
+      return desc.constructorPtr;
+
+    // Finded all public constructors
+    filterPublic(constructors);
+
+    // Sort them by precedence order
+    List<MethodOverloadResolution> overloads = MethodOverloadResolution.sortMethods(constructors);
+
+    // Convert overload list to a list of overloads pointers
+    long[] overloadPtrs = this.createConstructorOverloads(desc, overloads);
+    desc.constructorPtr = typeFactory.defineConstructorContainer(desc.classPtr, "[init", overloadPtrs);
+    return desc.constructorPtr;
+  }
+
+  /**
+   * Load the methods for a class.
+   *
+   * @param cls
+   * @return a list of method wrappers.
+   */
+  public synchronized long[] getMethods(Class cls)
+  {
+    ClassDescription desc = this.classMap.get(cls);
+    if (desc == null)
+      throw new RuntimeException("Class not defined");
+
+    // We may already be loaded
+    if (desc.methodPtrs != null)
+      return desc.methodPtrs;
+
+    desc.methodContainerMap = new TreeMap<>();
+    desc.methodOverloadMap = new TreeMap<>();
+
+    // Collect a list of parents
+    LinkedList<ClassDescription> parents = new LinkedList<>();
+    ClassDescription superDesc = this.classMap.get(cls.getSuperclass());
+    if (superDesc != null)
+    {
+      getMethods(cls.getSuperclass());
+      parents.add(superDesc);
+    }
+    for (Class intr : cls.getInterfaces())
+    {
+      getMethods(intr);
+      parents.add(this.classMap.get(intr));
+    }
+
+    // Figure out what we have to resolve by comparing the declared list 
+    TreeMap<String, Long> resolve = new TreeMap<>();
+
+    for (Method method : cls.getDeclaredMethods())
+    {
+      if (Modifier.isPublic(method.getModifiers()))
+        resolve.put(method.getName(), 0l);
+    }
+
+    // Anything that is not overriden can be inherited.
+    for (ClassDescription p : parents)
+    {
+      for (Map.Entry<String, Long> e : p.methodContainerMap.entrySet())
+      {
+        if (resolve.containsKey(e.getKey()))
+        {
+          resolve.put(e.getKey(), 0l);
+        } else
+        {
+          resolve.put(e.getKey(), e.getValue());
+        }
+      }
+    }
+
+    // Get the list of all methods we will process
+    LinkedList<Method> methods = new LinkedList<>(Arrays.asList(cls.getMethods()));
+
+    // Remove overridden and non-public methods so we don't have to deal with them.
+    filterOverridden(cls, methods);
+
+    // Everything with a 0 needs to be resolved with a new method container
+    // wrapper.  Everything with a non-zero number can be inherited.
+    for (Map.Entry<String, Long> e : resolve.entrySet())
+    {
+      if (e.getValue() != 0)
+      {
+        // inherit the executable container
+        desc.methodContainerMap.put(e.getKey(), e.getValue());
+      } else
+      {
+        desc.methodContainerMap.put(e.getKey(), this.createMethodContainer(desc, e.getKey(), methods));
+      }
+    }
+
+    // Collect a list from the map
+    long[] methodPtrs = new long[desc.methodContainerMap.size()];
+    int i = 0;
+    for (long v : desc.methodContainerMap.values())
+    {
+      methodPtrs[i++] = v;
+    }
+
+    // Cache for later
+    desc.methodPtrs = methodPtrs;
+    return methodPtrs;
+  }
+
+//</editor-fold>
+//<editor-fold desc="ctors" defaultstate="classes">
+  /**
+   * Allocate a new wrapper for a java class.
+   * <p>
+   * Boxed types require special handlers, as does java.lang.String
+   *
+   * @param code is >=0 for boxed types and -1 otherwise.
+   * @param cls
+   * @return a C++ wrapper handle for a jp_classtype
+   */
+  private long createClass(int code, Class cls)
+  {
+    if (cls.isArray())
+    {
+      // Array classes are simple, we just need the component type
+      Class componentType = cls.getComponentType();
+      long componentTypePtr = this.findClass(componentType);
+
+      long classPtr = typeFactory.defineArrayClass(cls, cls.getSimpleName(), componentTypePtr);
+      this.classMap.put(cls, new ClassDescription(cls, classPtr));
+      this.destroy.add(classPtr);
+      return classPtr;
+    }
+
+    // Object classes are more work as we need the super information as well.
+    // Make sure all base classes are loaded
+    Class superClass = cls.getSuperclass();
+    long superClassPtr = 0;
+    if (superClass != null)
+    {
+      superClassPtr = this.findClass(superClass);
+    }
+
+    // Make sure all interfaces are loaded.
+    Class[] interfaces = cls.getInterfaces();
+    long[] interfacesPtr = new long[interfaces.length];
+    for (int i = 0; i < interfaces.length; ++i)
+    {
+      interfacesPtr[i] = this.findClass(interfaces[i]);
+    }
+
+    long classPtr = typeFactory.defineObjectClass(
+            code,
+            cls,
+            cls.getSimpleName(),
+            superClassPtr,
+            interfacesPtr,
+            cls.isInterface());
+    this.classMap.put(cls, new ClassDescription(cls, classPtr));
+    this.destroy.add(classPtr);
+    return classPtr;
+  }
+
+  private void createPrimitive(int code, Class cls, Class boxed)
+  {
+    long classPtr = typeFactory.definePrimitive(code, cls, this.findClass(boxed));
+    this.classMap.put(cls, new ClassDescription(cls, classPtr));
+    this.destroy.add(classPtr);
+  }
+
+//</editor-fold>
+//<editor-fold desc="containers" defaultstate="collapsed">
+  private long createMethodContainer(
+          ClassDescription desc,
+          String key,
+          LinkedList<Method> candidates)
+  {
+    // Find all the methods that match the key 
+    LinkedList<Method> methods = new LinkedList<>();
+    Iterator<Method> iter = candidates.iterator();
+    boolean hasStatic = false;
+    while (iter.hasNext())
+    {
+      Method next = iter.next();
+      if (next.getName().equals(key))
+      {
+        iter.remove();
+        methods.add(next);
+      } else if (Modifier.isStatic(next.getModifiers()))
+        hasStatic = true;
+    }
+
+    List<MethodOverloadResolution> overloads = MethodOverloadResolution.sortMethods(methods);
+
+    // Convert overload list to a list of overloads pointers
+    long[] overloadPtrs = this.createMethodOverloads(desc, overloads);
+    long methodContainer = typeFactory.defineMethodContainer(desc.classPtr, key, overloadPtrs, hasStatic);
+
+    // Place in the list for shutdown
+    this.destroy.add(methodContainer);
+    return methodContainer;
+  }
+
+//</editor-fold>
+//<editor-fold desc="overloads" defaultstate="collapsed">
+  /**
+   * Construct a set of constructor overloads for an OverloadResolution.
+   * <p>
+   * These will be added to the shutdown destruction list.
+   *
+   * @param desc
+   * @param overloads
+   * @return
+   */
+  private long[] createConstructorOverloads(ClassDescription desc,
+          List<MethodOverloadResolution> overloads)
+  {
+    int n = overloads.size();
+    long[] overloadPtrs = new long[overloads.size()];
+    for (MethodOverloadResolution ov : overloads)
+    {
+      Constructor constructor = (Constructor) ov.executable;
+      Class<?>[] params = constructor.getParameterTypes();
+      long[] paramPtrs = new long[params.length];
+      int i = 0;
+      for (Class<?> p : params)
+      {
+        paramPtrs[i++] = this.findClass(p);
+      }
+      i = 0;
+      long[] precedencePtrs = new long[ov.children.size()];
+      for (MethodOverloadResolution ch : ov.children)
+      {
+        precedencePtrs[i++] = ch.ptr;
+      }
+      ov.ptr = typeFactory.defineConstructorOverload(
+              desc.classPtr,
+              constructor,
+              constructor.toString(),
+              paramPtrs,
+              precedencePtrs,
+              constructor.isVarArgs());
+      overloadPtrs[--n] = ov.ptr;
+
+      // Place this on the clean up list
+      this.destroy.add(ov.ptr);
+    }
+    return overloadPtrs;
+  }
+
+  /**
+   * Convert a list of executable overload resolutions into a executable
+   * overload list.
+   * <p>
+   * These will be added to the shutdown destruction list.
+   *
+   * @param desc
+   * @param overloads
+   * @return a list of method overload wrappers.
+   */
+  private long[] createMethodOverloads(
+          ClassDescription desc,
+          List<MethodOverloadResolution> overloads)
+  {
+    int n = overloads.size();
+    long[] overloadPtrs = new long[overloads.size()];
+    for (MethodOverloadResolution ov : overloads)
+    {
+      Method method = (Method) ov.executable;
+
+      // We may already have built a methodoverload for this
+      Class<?> decl = method.getDeclaringClass();
+      if (method.getDeclaringClass() != desc.cls)
+      {
+        ov.ptr = this.classMap.get(decl).methodOverloadMap.get(method);
+        overloadPtrs[--n] = ov.ptr;
+        continue;
+      }
+
+      long returnPtr = findClass(method.getReturnType());
+
+      // Convert the executable parameters
+      Class<?>[] params = method.getParameterTypes();
+      long[] paramPtrs = new long[params.length];
+      int i = 0;
+      for (Class<?> p : params)
+      {
+        paramPtrs[i++] = this.findClass(p);
+      }
+
+      // Determine what takes precedence
+      i = 0;
+      long[] precedencePtrs = new long[ov.children.size()];
+      for (MethodOverloadResolution ch : ov.children)
+      {
+        precedencePtrs[i++] = ch.ptr;
+      }
+
+      ov.ptr = typeFactory.defineMethodOverload(
+              desc.classPtr,
+              method,
+              method.toString(),
+              returnPtr,
+              paramPtrs,
+              precedencePtrs,
+              Modifier.isStatic(method.getModifiers()),
+              method.isVarArgs());
+      overloadPtrs[--n] = ov.ptr;
+
+      // Place this on the clean up list
+      this.destroy.add(ov.ptr);
+    }
+    return overloadPtrs;
+  }
+//</editor-fold>
+//<editor-fold desc="filters" defaultstate="collapsed">
+
+  /**
+   * Remove any methods that are not public from a list.
+   *
+   * @param <T>
+   * @param methods
+   */
+  public static <T extends Executable> void filterPublic(LinkedList<T> methods)
+  {
+    Iterator<T> iter = methods.iterator();
+    while (iter.hasNext())
+    {
+      Executable next = iter.next();
+      if (!Modifier.isPublic(next.getModifiers()))
+      {
+        iter.remove();
+      }
+    }
+  }
+
+  /**
+   * Remove any methods that are not public and have been overridden from a
+   * list.
+   *
+   * @param cls
+   * @param methods
+   */
+  public static void filterOverridden(Class cls, LinkedList<Method> methods)
+  {
+    Iterator<Method> iter = methods.iterator();
+    while (iter.hasNext())
+    {
+      Method next = iter.next();
+      if (Modifier.isPublic(next.getModifiers()) && !isOverridden(cls, next))
+        continue;
+      iter.remove();
+    }
+  }
+
+//</editor-fold>
+//<editor-fold desc="utilities" defaultstate="collapsed">
+  /**
+   * Determines if a method is masked by another in a class.
+   *
+   * @param cls is the class to investigate.
+   * @param method is a method that applies to the class.
+   * @return true if the method is not overridden in the true, or false if this
+   * method is overridden.
+   */
+  public static boolean isOverridden(Class cls, Method method)
+  {
+    try
+    {
+      return !method.equals(cls.getMethod(method.getName(), method.getParameterTypes()));
+    } catch (NoSuchMethodException | SecurityException ex)
+    {
+      return false;
+    }
+  }
+//</editor-fold>
+}


### PR DESCRIPTION
@marscher Okay I hate to bother after that last horrible pull request but I have a different idea on how to fix the lambda issue.  (Please don't merge this, it is just for review)

Unfortunately, the lambda problem continues to impact my library support, so I need to take another shot at fixing it.  The direction I tried last time was a struggle as jumping from the system that used TypeName and HostRef to using jclass and PyObject* required too big of leap for me to put my feet down.  Though I tested regularly with small codes running the full nose test during transition was too much as it could never complete during the transition and I paid for it with a deep core bug that I could never resolve.  

Thus I am going to propose work on a different solution entirely pulling from what I learned last time.  Rather than struggle with C++/CPython Module/Python with a turn around time of about 15 minutes per test.  I propose moving as much of the jpype core into java as possible. This would leave just the type conversions in the C++ layer.

I did a prototype (not connected to anything) so you can review.  Is this a viable direction?