### PR TITLE
Lambdas for java 8 now work.

### DIFF
--- a/native/common/jp_jniutil.cpp
+++ b/native/common/jp_jniutil.cpp
@@ -340,6 +340,9 @@ string JPJni::getCanonicalName(jclass clazz)
 	JP_TRACE_IN("getCanonicalName");
 	JPJavaFrame frame;
 	jstring str = (jstring) frame.CallObjectMethod(clazz, s_Class_GetCanonicalNameID);
+        // Anonomous classes don't have canonical names so they return null
+        if (str==NULL)
+	  str = (jstring) frame.CallObjectMethod(clazz, s_Class_GetNameID);
 	JP_TRACE("toString");
 	return JPJni::toStringUTF8(str);
 	JP_TRACE_OUT;

--- a/test/build.xml
+++ b/test/build.xml
@@ -2,22 +2,45 @@
 
 	<property name="src" location="harness"/>
 	<property name="build" location="classes"/>
+        <property name="version" value="${ant.java.version}"/>
 
 	<target name="test" depends="compile">
 	</target>
 
-	<target name="compile">
+	<condition property="build-8">
+		<equals arg1="${version}" arg2="1.8"/>
+	</condition>
+
+	<target name="compile-8" if="build-8">
+		<javac destdir="${build}"
+			source="${version}"
+			target="${version}"
+			>
+			<src>
+				<pathelement location="${src}/java8"/>
+			</src>
+			<include name="jpype/**/*"/>
+		</javac>
+	</target>
+
+	<target name="compile-main">
 		<mkdir dir="${build}"/>
 		<javac destdir="${build}"
-			srcdir="${src}"
-			source="1.7"
-			target="1.7"
-		/>
+			source="${version}"
+			target="${version}"
+			>
+			<src>
+				<pathelement location="${src}"/>
+			</src>
+			<include name="jpype/**/*"/>
+		</javac>
 	<!--		<rmic base="${build}"
 			classname="jpype.rmi.ServerImpl"
 		/>
   -->
 	</target>
+
+	<target name="compile" depends="compile-main,compile-8"/>
 
 	<target name="clean">
 		<delete dir="${build}"/>

--- a/test/harness/java8/jpype/lambda/Test1.java
+++ b/test/harness/java8/jpype/lambda/Test1.java
@@ -1,0 +1,23 @@
+
+package jpype.lambda;
+import java.util.function.Function;
+
+public class Test1
+{
+	public Function<Double, Double> getFunction()
+	{
+		return new Function<Double,Double>()
+		{
+			public Double apply(Double d)
+			{
+				return d+1;
+			}
+		};
+	}
+
+	public Function<Double, Double> getLambda()
+	{
+		return (Double d)->(d+1);
+	}
+}
+

--- a/test/jpypetest/lambdas.py
+++ b/test/jpypetest/lambdas.py
@@ -1,0 +1,42 @@
+# *****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+import jpype
+import sys
+import logging
+import time
+from . import common
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class LambdasTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        try:
+            self.lambdas = jpype.JClass("jpype.lambda.Test1")()
+            return
+        except:
+            pass
+        raise unittest.SkipTest
+
+    def testLambdasFunction(self):
+        self.assertEquals(self.lambdas.getFunction().apply(1.0), 2.0)
+
+    def testLambdasLambda(self):
+        self.assertEquals(self.lambdas.getLambda().apply(1.0), 2.0)


### PR DESCRIPTION
Support for Java8 lambdas in the development branch.  Includes necessary test cases.   

While the previous version was very difficult to support the use of lambdas because of the use of class names, it is now very simple to support.  I am not sure if I should make it so that anonymous classes and lambdas don't produce a python wrapper class on the other side of the wrapper, but that is a refinement.  

This has a minor modification to the build system to detect the JDK and build the test bench accordingly.  This is required to test the lambda functionality.  I do not yet have access to Java 9 or 10 installation, so the pattern for the testing only searched for Java 8.  There may need to be adjustments for other JVM.