### PR TITLE
Unicode support.

### DIFF
--- a/jpype/_jobject.py
+++ b/jpype/_jobject.py
@@ -96,6 +96,9 @@ class JObject(object):
     def __str__(self):
         return self.__javavalue__.toString()
 
+    def __unicode__(self):
+        return self.__javavalue__.toUnicode()
+
     def __hash__(self):
         return self.hashCode()
 

--- a/native/common/include/jp_javaframe.h
+++ b/native/common/include/jp_javaframe.h
@@ -355,6 +355,7 @@ public:
 	const jchar* GetStringChars(jstring a0, jboolean* a1);
 	void ReleaseStringChars(jstring a0, const jchar* a1);
 	jsize GetStringLength(jstring a0);
+	jsize GetStringUTFLength(jstring a0);
 } ;
 
 /** JPClass is a bit heavy when we just need to hold a 

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -60,7 +60,7 @@ JPPyObject JPByteType::convertToPythonObject(jvalue val)
 JPValue JPByteType::getValueFromObject(jobject obj)
 {
 	jvalue v;
-	field(v) = (type_t)JPJni::intValue(obj);
+	field(v) = (type_t) JPJni::intValue(obj);
 	return JPValue(this, v);
 }
 

--- a/native/common/jp_encoding.cpp
+++ b/native/common/jp_encoding.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
    Copyright 2018 Karl Einar Nelson
-  
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -12,14 +12,14 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-  
+
  *****************************************************************************/
 #include <jp_encoding.h>
 
 // FIXME These encoders handle all of the codes expected to be passed between
 // Java and Python assuming they both generate complient codings.  However,
 // this code does not handle miscodings very well.  The current behavior
-// is to simply terminate the string at the bad code without producing 
+// is to simply terminate the string at the bad code without producing
 // a warning.  I can add errors, but I am not sure how I would test it
 // as both java and python will produce an error if I tried to force a
 // bad encoding on them.  Thus I am going to leave this with the truncation
@@ -30,22 +30,22 @@
 //   - encoded forbidden utf passed from python
 //   - truncated surrogate codes passed from java
 //
-// The secondary problem is that string conversion is part of exception 
+// The secondary problem is that string conversion is part of exception
 // handling.  And the last thing we want to do is throw an exception
 // while trying to convert an exception string while reporting.  That
 // would completely redirect the user.  Thus truncation seems like
 // a sane policy unless we can verify all of the potential edge cases.
 //
-// Alternatively we could make them a bit more permissive and 
-// try to automatically correct bad encodings by recognizing 
-// extend ASCII, etc.  But this is potentially complex and 
+// Alternatively we could make them a bit more permissive and
+// try to automatically correct bad encodings by recognizing
+// extend ASCII, etc.  But this is potentially complex and
 // has the downside that we can't test it currently.
 
 JPEncoding::~JPEncoding()
 {
 }
 
-// char* to stream from 
+// char* to stream from
 // https://stackoverflow.com/questions/7781898/get-an-istream-from-a-char
 struct membuf : std::streambuf
 {
@@ -58,7 +58,7 @@ struct membuf : std::streambuf
 
 // Convert a string from one encoding to another.
 // Currently we use this to transcribe from utf-8 to java-utf-8 and back.
-// It could do other encodings, but would need to be generalized to 
+// It could do other encodings, but would need to be generalized to
 // a template to handle wider character sets.
 std::string transcribe(const char* in, size_t len,
 		const JPEncoding& sourceEncoding,
@@ -106,6 +106,34 @@ std::string transcribe(const char* in, size_t len,
 
 //**************************************************************
 
+// Encode a 21 bit code point as UTF-8
+//
+// There are 4 encodings used
+//
+// Range                     Encoding
+// 0x000000-0x00007F
+//                           0xxxxxxx
+//                    bits    6543210
+//
+// 0x000080-0x0007FF
+//                           110xxxxx  10xxxxxx
+//                              1
+//                    bits      09876    543210
+//
+// 0x000800-0x000FFFF (excluding 0xD800-0xDFFF)
+//                           1110xxxx  10xxxxxx  10xxxxxx
+//                               1111    11
+//                    bits       5432    109876    543210
+//
+// 0x100000-0x10FFFF
+//                           11110xxx  10xxxxxx  10xxxxxx  10xxxxxx
+//                                211    111111    11
+//                    bits        098    765432    109876    543210
+//
+// The encoding process is simply to add the constant portion encoding
+// the byte position, then shifting to get the lowest bits, the masking
+// off the required bits.
+//
 void JPEncodingUTF8::encode(std::ostream& out, unsigned int c) const
 {
 	if (c < 0x80)
@@ -136,6 +164,13 @@ void JPEncodingUTF8::encode(std::ostream& out, unsigned int c) const
 	}
 }
 
+// Retrieve a 21 unicode code point from a stream of bytes.
+//
+// This is the reverse of the process of encoding.
+// We must first locate the position encoding bits from the
+// top of the byte, then pull off the encoded bits.  The
+// final code point is the sum of each set of encoded bits.
+//
 unsigned int JPEncodingUTF8::fetch(std::istream& in) const
 {
 	unsigned int c0 = in.get();
@@ -182,34 +217,81 @@ unsigned int JPEncodingUTF8::fetch(std::istream& in) const
 }
 
 //*****************************************************************
-//
+// <rant>
 // To the Sun programmer who wrote GetStringUTFchars() that thought it was a
 // good idea to return UTF-16 embedded in UTF-8, you sir are an embarrassment.
-// 
-// You had one job here, to take an internal representation in UTF16 and produce
-// a stream of chars that could be read by the outside world.  It had to be 
-// translated as those encodings are incompatible and rather that writing
-// to a defined format, you simply lazily packed each UTF-16 into UTF-8 resulting 
-// in surrogate codes in UTF-8.  It would have taken you all of 20 extra minutes
-// to do it right and you failed. 
 //
-// Any time saving that you got by doing this in a lazy fashion was lost when 
+// You had one job here, to take an internal representation in UTF16 and produce
+// a stream of chars that could be read by the outside world.  It had to be
+// translated as those encodings are incompatible and rather that writing
+// to a defined format, you simply lazily packed each UTF-16 into UTF-8 resulting
+// in surrogate codes in UTF-8.  It would have taken you all of 20 extra minutes
+// to do it right and you failed.
+//
+// Any time saving that you got by doing this in a lazy fashion was lost when
 // the second programmer besides yourself had to write a translation code.  And
-// all efficiency gains that you thought were made have been lost in the 
+// all efficiency gains that you thought were made have been lost in the
 // memory management and retranslation that anyone would need to make use of your
-// U+1F4A9.  You are solely responsible for wasting thousands of hours of other 
+// U+1F4A9.  You are solely responsible for wasting thousands of hours of other
 // programmer's lives and promoting the heat death of the universe.
 //
 // And in case you feel that documentation makes it all okay, to top everything off
-// your documentation is incorrect.  You list encodings between U+0800 and U+FFFF 
+// your documentation is incorrect.  You list encodings between U+0800 and U+FFFF
 // as being the 3 byte encoding, but the document fails to mention that U+D800 to U+DFFF
-// are not a valid encoding.  Thus leaving any coder to struggle to 
+// are not a valid encoding.  Thus leaving any coder to struggle to
 // figure out how there would not be a conflict between coding 3 and coding 4 without
 // consulting an additional source.
 //
 // You are an embarrassment to the craft.  Shame on you, shame on your family,
 // and shame on the goat that hauled your sorry butt into work each day.
+// </rant>
+//*****************************************************************
 
+
+// Encode a 21 code point into a Java UTF char stream.
+//
+// Java uses 16 bit characters to represent a string, but this is not
+// sufficient to hold all 21 bits of valid unicode chars.  Thus to
+// encode the upper bits java uses UTF-16 encoding internally.  Unfortunately,
+// when java converts the 16 bit string into 8 bit encoding, it does not
+// decode the string first.  As a result we receive not UTF-8 but rather
+// doublely encoded UTF-16/UTF-8.  Further UTF-16 encoding requires
+// not just simple byte packing but also an offset of the bits.  Thus this
+// process becomes a real mess.  Also a special code point is required for
+// embedded nulls.
+//
+// There are 4 encodings used
+//
+// Range                     Encoding
+// 0x000001-0x00007F
+//                           0xxxxxxx
+//                    bits    6543210
+//
+// 0x000080-0x0007FF, special code 0
+//                           110xxxxx  10xxxxxx
+//                              1
+//                    bits      09876    543210
+//
+// 0x000800-0x000D7FF or 0x00DFFF-0x000FFFF
+//                           1110xxxx  10xxxxxx  10xxxxxx
+//                               1111    11
+//                    bits       5432    109876    543210
+//
+// 0x100000-0x10FFFF (called surgate codes in UTF-16)
+// (doublely encoded 6 byte code point)
+// first subtract 0x10000 which reduces the range by 2 bits
+//                           11101101  1010xxxx  10xxxxxx  11101101  1011xxxx  10xxxxxx
+//                                         1111    111111
+//                    bits                 9876    543210                9876    543210
+//
+// The encoding process is simply to add the constant portion encoding
+// the byte position, then shifting to get the lowest bits, the masking
+// off the required bits. The exception being the surgate codes which
+// require an offset then a bit pack.
+//
+// 4 byte unicode or coding a 3 point in the invalid range followed by anything other
+// than 3 byte encoding (in the invalid range) is a coding error.
+//
 void JPEncodingJavaUTF8::encode(std::ostream& out, unsigned int c) const
 {
 	if (c == 0)
@@ -250,6 +332,23 @@ void JPEncodingJavaUTF8::encode(std::ostream& out, unsigned int c) const
 	}
 }
 
+// Decoding is the reverse of encoding, but there
+// is a special gotcha because the position encoding bits
+// are not unique.  Both the 3 and 6 points codes share
+// the position encoding 0xED for the first byte.
+//
+// The unicde packing solves this by removing a portion of
+// the encoding such that 0xD800-0xDFFF are not valid unicode code
+// points.  Thus these invalid code points are used to represent
+// the upper and lower encoding for the extended unicode
+// code points.
+//
+// Thus the procedure is decode the top 3 and check to see if
+// it is in a valid range.  If it isn't then decode the
+// second set of 3.  So long as the bytes are coded through the
+// java encoder it will be valid.  However, a user could
+// manually encode a string with an invalid coding.
+//
 unsigned int JPEncodingJavaUTF8::fetch(std::istream& in) const
 {
 	unsigned int out = 0;
@@ -295,6 +394,19 @@ unsigned int JPEncodingJavaUTF8::fetch(std::istream& in) const
 
 	// Grab the low word for surrogate code
 	c0 = in.get();
+
+	// Note: we should technically check to see what the first byte is here.
+	// for a valid code point it must be 0xED.  But if the user has
+	// manually encoded an invalid string there is not much we can
+	// do as we already are pulling bytes for the next character assuming
+	// it was a valid coding. We don't really want to throw an exception
+	// because this routine can happen at any point that string is being
+	// passed, including reporting of an exception.
+	//
+	// Manually encoding invalid code points and asking them to be
+	// converted is undefined behavior, but I don't know the path
+	// to nethack.
+
 	c1 = in.get();
 	c2 = in.get();
 	next = ((c0 & 0xf) << 12) + ((c1 & 0x3f) << 6) + (c2 & 0x3f);

--- a/native/common/jp_env.cpp
+++ b/native/common/jp_env.cpp
@@ -1407,6 +1407,12 @@ jsize JPJavaFrame::GetStringLength(jstring a0)
 	return env->functions->GetStringLength(env, a0);
 }
 
+jsize JPJavaFrame::GetStringUTFLength(jstring a0)
+{
+	JPCall call(*this, "GetStringUTFLength");
+	return env->functions->GetStringUTFLength(env, a0);
+}
+
 jclass JPJavaFrame::DefineClass(const char* a0, jobject a1, const jbyte* a2, jsize a3)
 {
 	JPCall call(*this, "DefineClass");

--- a/native/common/jp_jniutil.cpp
+++ b/native/common/jp_jniutil.cpp
@@ -728,7 +728,7 @@ public:
 	: frame_(frame), jstr_(jstr)
 	{
 		cstr = frame_.GetStringUTFChars(jstr, &isCopy);
-		length = frame_.GetStringLength(jstr);
+		length = frame_.GetStringUTFLength(jstr);
 	}
 
 	~JPStringAccessor()

--- a/native/common/jp_monitor.cpp
+++ b/native/common/jp_monitor.cpp
@@ -19,7 +19,7 @@
 JPMonitor::JPMonitor(const JPValue& value) : m_Value(value)
 {
 	// This can hold off for a while so we need to release resource 
-        // so that we don't dead lock.
+	// so that we don't dead lock.
 	JPPyCallRelease call;
 	JPJavaFrame frame;
 	jvalue& val = m_Value;

--- a/native/common/jp_stringclass.cpp
+++ b/native/common/jp_stringclass.cpp
@@ -32,7 +32,7 @@ JPPyObject JPStringClass::convertToPythonObject(jvalue val)
 	{
 		return JPPyObject::getNone();
 	}
-	
+
 	return JPPythonEnv::newJavaObject(JPValue(this, val));
 	JP_TRACE_OUT;
 }

--- a/native/python/include/jp_pythontypes.h
+++ b/native/python/include/jp_pythontypes.h
@@ -292,14 +292,14 @@ public:
 
 	/** Create a new string from utf8 encoded string.
 	 * Note: java utf8 is not utf8.
-         *
-         * Python2 produced str unless unicode is set to 
-         * true.  Python3 will always produce a unicode string.
-         *
-         * @param str is the string to convert
-         * @param unicode is true if unicode is allowed.
+	 *
+	 * Python2 produced str unless unicode is set to 
+	 * true.  Python3 will always produce a unicode string.
+	 *
+	 * @param str is the string to convert
+	 * @param unicode is true if unicode is allowed.
 	 */
-	static JPPyObject fromStringUTF8(const string& str, bool unicode=false);
+	static JPPyObject fromStringUTF8(const string& str, bool unicode = false);
 
 	/** Get a UTF-8 encoded string from Python
 	 */

--- a/native/python/include/pyjp_value.h
+++ b/native/python/include/pyjp_value.h
@@ -34,9 +34,10 @@ struct PyJPValue
 	static void        __dealloc__(PyJPValue* self);
 	static PyObject*   __str__(PyJPValue* self);
 	static PyObject*   toString(PyJPValue* self);
+	static PyObject*   toUnicode(PyJPValue* self);
 
 	JPValue m_Value;
-	PyObject* m_StrCache;
+	PyObject* m_Cache;
 } ;
 
 #endif // _PYJP_VALUE_H_2

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -211,7 +211,7 @@ JPPyObject JPPyInt::fromLong(jlong l)
 #if PY_MAJOR_VERSION >= 3 
 	return JPPyObject(JPPyRef::_call, PyLong_FromLongLong(l));
 #else
-	return JPPyObject(JPPyRef::_call, PyInt_FromLong((int)l));
+	return JPPyObject(JPPyRef::_call, PyInt_FromLong((int) l));
 #endif
 }
 
@@ -317,7 +317,7 @@ JPPyObject JPPyString::fromCharUTF16(jchar c)
 	Py_UCS4 c2 = c;
 	PyUnicode_WriteChar(buf.get(), 0, c2);
 	JP_PY_CHECK();
-        PyUnicode_READY(buf.get());
+	PyUnicode_READY(buf.get());
 	return buf;
 #endif
 }
@@ -452,7 +452,7 @@ JPPyObject JPPyString::fromStringUTF8(const string& str, bool unicode)
 	size_t len = str.size();
 
 #if PY_MAJOR_VERSION < 3
-        // Python 2 is unicode only on request
+	// Python 2 is unicode only on request
 	if (unicode)
 	{
 		return JPPyObject(JPPyRef::_call, PyUnicode_FromStringAndSize(str.c_str(), len));
@@ -462,7 +462,7 @@ JPPyObject JPPyString::fromStringUTF8(const string& str, bool unicode)
 		return JPPyObject(JPPyRef::_call, PyString_FromStringAndSize(str.c_str(), len));
 	}
 #else
-        // Python 3 is always unicode
+	// Python 3 is always unicode
 	JPPyObject bytes(JPPyRef::_call, PyBytes_FromStringAndSize(str.c_str(), len));
 	return JPPyObject(JPPyRef::_call, PyUnicode_FromEncodedObject(bytes.get(), "UTF-8", "strict"));
 #endif
@@ -543,7 +543,7 @@ void JPPyMemoryView::getByteBufferSize(PyObject* obj, char** outBuffer, long& ou
 
 JPPyTuple JPPyTuple::newTuple(jlong sz)
 {
-	return JPPyTuple(JPPyRef::_call, PyTuple_New((Py_ssize_t)sz));
+	return JPPyTuple(JPPyRef::_call, PyTuple_New((Py_ssize_t) sz));
 }
 
 bool JPPyTuple::check(PyObject* obj)
@@ -554,7 +554,7 @@ bool JPPyTuple::check(PyObject* obj)
 void JPPyTuple::setItem(jlong ndx, PyObject* val)
 {
 	ASSERT_NOT_NULL(val);
-	PyTuple_SetItem(pyobj, (Py_ssize_t)ndx, val); // steals reference
+	PyTuple_SetItem(pyobj, (Py_ssize_t) ndx, val); // steals reference
 	JP_PY_CHECK();
 
 	// Return the stolen reference, but only after transfer has been completed.
@@ -563,7 +563,7 @@ void JPPyTuple::setItem(jlong ndx, PyObject* val)
 
 PyObject* JPPyTuple::getItem(jlong ndx)
 {
-	PyObject* res = PyTuple_GetItem(pyobj, (Py_ssize_t)ndx);
+	PyObject* res = PyTuple_GetItem(pyobj, (Py_ssize_t) ndx);
 	JP_PY_CHECK();
 	return res;
 }
@@ -580,7 +580,7 @@ jlong JPPyTuple::size()
 
 JPPyList JPPyList::newList(jlong sz)
 {
-	return JPPyList(JPPyRef::_call, PyList_New((Py_ssize_t)sz));
+	return JPPyList(JPPyRef::_call, PyList_New((Py_ssize_t) sz));
 }
 
 bool JPPyList::check(PyObject* obj)
@@ -591,13 +591,13 @@ bool JPPyList::check(PyObject* obj)
 void JPPyList::setItem(jlong ndx, PyObject* val)
 {
 	ASSERT_NOT_NULL(val);
-	PySequence_SetItem(pyobj, (Py_ssize_t)ndx, val); // Does not steal
+	PySequence_SetItem(pyobj, (Py_ssize_t) ndx, val); // Does not steal
 	JP_PY_CHECK();
 }
 
 PyObject* JPPyList::getItem(jlong ndx)
 {
-	PyObject* res = PyList_GetItem(pyobj, (Py_ssize_t)ndx);
+	PyObject* res = PyList_GetItem(pyobj, (Py_ssize_t) ndx);
 	JP_PY_CHECK();
 	return res;
 }
@@ -711,7 +711,7 @@ void JPPyErr::clear()
 
 bool JPPyErr::occurred()
 {
-	return PyErr_Occurred()!=0;
+	return PyErr_Occurred() != 0;
 }
 
 bool JPPyErr::fetch(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JPPyObject& exceptionTrace)

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -74,7 +74,7 @@ PyMODINIT_FUNC init_jpype()
 	PyObject* module = Py_InitModule("_jpype", jpype_methods);
 #endif
 	Py_INCREF(module);
-        PyModule_AddStringConstant(module,"__version__","0.7.0");
+	PyModule_AddStringConstant(module, "__version__", "0.7.0");
 
 	// Initialize the Java static resources
 	JPEnv::init();

--- a/test/harness/jpype/utf8/Utf8Test.java
+++ b/test/harness/jpype/utf8/Utf8Test.java
@@ -1,0 +1,91 @@
+package jpype.utf8;
+
+public class Utf8Test {
+
+    private final static String[] DEFAULT_STRINGS = {
+			      "I can eat glass and it doesn't hurt me.",
+            "Je peux manger du verre, \u00E7a ne me fait pas mal.",
+            "\u16D6\u16B4 \u16B7\u16D6\u16CF \u16D6\u16CF\u16C1 \u16A7 \u16B7\u16DA\u16D6\u16B1 \u16D8\u16BE \u16A6\u16D6\u16CB\u16CB \u16A8\u16A7 \u16A1\u16D6 \u16B1\u16A7\u16A8 \u16CB\u16A8\u16B1",
+            "\u4EBA\u4EBA\u751F\u800C\u81EA\u7531,\u5728\u5C0A\u4E25\u548C\u6743\u5229\u4E0A\u4E00\u5F8B\u5E73\u7B49\u3002\u4ED6\u4EEC\u8D4B\u6709\u7406\u6027\u548C\u826F\u5FC3,\u5E76\u5E94\u4EE5\u5144\u5F1F\u5173\u7CFB\u7684\u7CBE\u795E\u4E92\u76F8\u5BF9\u5F85\u3002",
+            "\u4EBA\u4EBA\u751F\u800C\u81EA\u7531\uFE50\u5728\u5C0A\u56B4\u548C\u6B0A\u5229\u4E0A\u4E00\u5F8B\u5E73\u7B49\u3002\u4ED6\u5011\u8CE6\u6709\u7406\u6027\u548C\u826F\u5FC3\uFE50\u4E26\u61C9\u4EE5\u5144\u5F1F\u95DC\u4FC2\u7684\u7CBE\u795E\u4E92\u76F8\u5C0D\u5F85\u3002",
+            "\u0623\u0646\u0627 \u0642\u0627\u062F\u0631 \u0639\u0644\u0649 \u0623\u0643\u0644 \u0627\u0644\u0632\u062C\u0627\u062C \u0648 \u0647\u0630\u0627 \u0644\u0627 \u064A\u0624\u0644\u0645\u0646\u064A.",
+            "\uD83D\uDE01\uD83D\uDE02\uD83D\uDE03\uD83D\uDE04\uD83D\uDE05\uD83D\uDE06\uD83D\uDE20\uD83D\uDE21\uD83D\uDE22\uD83D\uDE23\uD83D\uDE24\uD83D\uDE25\uD83D\uDE28\uD83D\uDE29\uD83D\uDE2A\uD83D\uDE89\uD83D\uDE8C\uD83D\uDE8F\uD83D\uDE91\uD83D\uDE92\uD83D\uDE93\uD83D\uDE95\uD83D\uDE97\uD83D\uDE99\uD83D\uDE9A\uD83D\uDEA2\uD83D\uDEA4\uD83D\uDEA5\uD83D\uDEA7\uD83D\uDEA8\uD83D\uDEBB\uD83D\uDEBC\uD83D\uDEBD\uD83D\uDEBE\uD83D\uDEC0\uD83C\uDD95\uD83C\uDD96\uD83C\uDD97\uD83C\uDD98\uD83C\uDD99\uD83C\uDD9A\uD83C\uDE01\uD83C\uDE02\uD83C\uDE1A\uD83C\uDE2F\uD83C\uDE39\uD83C\uDE3A\uD83C\uDE50\uD83C\uDE518\u20E39\u20E37\u20E36\u20E31\u20E30"
+    };
+
+    private String data;
+
+    /**
+     * Dummy: just set a pure ascii string
+     */
+    public Utf8Test() {
+        this.data = "Utf8Test pure ASCII";
+    }
+
+    /**
+     * Instantiate the class with one of the DEFAULT strings. Use the index as reference.
+     * @param indx reference to the DEFAULT_STRING
+     */
+    public Utf8Test(int indx) {
+        this.data = DEFAULT_STRINGS[Math.abs(indx) % DEFAULT_STRINGS.length];
+    }
+
+    /**
+     * Instantiate with a user-defined string
+     * @param myinput
+     */
+    public Utf8Test(String myinput) {
+        if (null == myinput) {
+            this.data = "NULL INPUT";
+        } else {
+            try {
+                int indx = Integer.parseInt(myinput);
+                this.data = DEFAULT_STRINGS[Math.abs(indx) % DEFAULT_STRINGS.length];
+            } catch (NumberFormatException nfe) {
+                this.data = myinput;
+            }
+        }
+    }
+
+    public void print_system_info() {
+        System.out.println("----------------------------------------------------------------------------------------");
+        System.out.println("JVM: " + System.getProperty("java.vm.name") + ", version: " +
+                System.getProperty("java.version") + " (" + System.getProperty("java.vm.version") + ")");
+        System.out.println("OS:  " + System.getProperty("os.name") + "-" + System.getProperty("os.arch") +
+                ", version: " + System.getProperty("os.version"));
+        System.out.println("----------------------------------------------------------------------------------------");
+    }
+
+    public void print_to_stdout() {
+        int nc = (int) this.data.codePoints().count();
+        int nb = this.data.getBytes().length;
+        System.out.println(String.format("nc = %3d, nb = %3d: (%s)",nc,nb,this.data));
+    }
+
+    /*
+     * get the string defined by the instantiator
+     */
+    public String get() {
+        return this.data;
+    }
+
+    /*
+     * return true if the string defined by the instantiator equals the default string with given index
+     */
+    public boolean equalsTo(int indx) {
+        return DEFAULT_STRINGS[Math.abs(indx) % DEFAULT_STRINGS.length].equals(this.data);
+    }
+
+    public static void main(String[] argv) {
+        Utf8Test jp;
+
+        new Utf8Test().print_system_info();
+        if (0 == argv.length) {
+            new Utf8Test().print_to_stdout();
+            for (int i=0; i < DEFAULT_STRINGS.length; i++) {
+                new Utf8Test(i).print_to_stdout();
+            }
+        } else {
+            new Utf8Test(argv[0]).print_to_stdout();
+        }
+    }
+}

--- a/test/jpypetest/utf8.py
+++ b/test/jpypetest/utf8.py
@@ -62,7 +62,6 @@ except ImportError:
     import unittest
 import sys
 
-from collections import OrderedDict
 from jpype import JPackage
 from . import common
 
@@ -85,21 +84,21 @@ class Utf8TestCase(common.JPypeTestCase):
         # Test strings
         # IMPORTANT: they should be identical, and in the same order, as the test strings difned in the
         #            java class Utf8Test
-        self.TDICT = OrderedDict()
-        self.TDICT['english'] = tounicode(
-            "I can eat glass and it doesn't hurt me.")
-        self.TDICT['french'] = tounicode(
-            "Je peux manger du verre, ça ne me fait pas mal.")
-        self.TDICT['rune'] = tounicode(
-            "ᛖᚴ ᚷᛖᛏ ᛖᛏᛁ ᚧ ᚷᛚᛖᚱ ᛘᚾ ᚦᛖᛋᛋ ᚨᚧ ᚡᛖ ᚱᚧᚨ ᛋᚨᚱ")
-        self.TDICT['cn_simp'] = tounicode(
-            "人人生而自由,在尊严和权利上一律平等。他们赋有理性和良心,并应以兄弟关系的精神互相对待。")
-        self.TDICT['cn_trad'] = tounicode(
-            "人人生而自由﹐在尊嚴和權利上一律平等。他們賦有理性和良心﹐並應以兄弟關係的精神互相對待。")
-        self.TDICT['arab'] = tounicode(
-            "أنا قادر على أكل الزجاج و هذا لا يؤلمني.")
-        self.TDICT[
-            'emoji'] = tounicode("😁😂😃😄😅😆😠😡😢😣😤😥😨😩😪🚉🚌🚏🚑🚒🚓🚕🚗🚙🚚🚢🚤🚥🚧🚨🚻🚼🚽🚾🛀🆕🆖🆗🆘🆙🆚🈁🈂🈚🈯🈹🈺🉐🉑8⃣9⃣7⃣6⃣1⃣0")
+        self.TDICT = []
+        self.TDICT.append(['english', 
+            tounicode("I can eat glass and it doesn't hurt me.")])
+        self.TDICT.append(['french', 
+            tounicode("Je peux manger du verre, ça ne me fait pas mal.")])
+        self.TDICT.append(['rune', 
+            tounicode("ᛖᚴ ᚷᛖᛏ ᛖᛏᛁ ᚧ ᚷᛚᛖᚱ ᛘᚾ ᚦᛖᛋᛋ ᚨᚧ ᚡᛖ ᚱᚧᚨ ᛋᚨᚱ")])
+        self.TDICT.append(['cn_simp', 
+            tounicode("人人生而自由,在尊严和权利上一律平等。他们赋有理性和良心,并应以兄弟关系的精神互相对待。")])
+        self.TDICT.append(['cn_trad', 
+            tounicode("人人生而自由﹐在尊嚴和權利上一律平等。他們賦有理性和良心﹐並應以兄弟關係的精神互相對待。")])
+        self.TDICT.append(['arab', 
+            tounicode("أنا قادر على أكل الزجاج و هذا لا يؤلمني.")])
+        self.TDICT.append(['emoji', 
+            tounicode("😁😂😃😄😅😆😠😡😢😣😤😥😨😩😪🚉🚌🚏🚑🚒🚓🚕🚗🚙🚚🚢🚤🚥🚧🚨🚻🚼🚽🚾🛀🆕🆖🆗🆘🆙🆚🈁🈂🈚🈯🈹🈺🉐🉑8⃣9⃣7⃣6⃣1⃣0")])
 
     def test_get_ascii(self):
         """
@@ -125,7 +124,7 @@ class Utf8TestCase(common.JPypeTestCase):
         """
         String = JPackage('java').lang.String
         indx = 0
-        for lbl, val in self.TDICT.items():
+        for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(String(val.encode('utf-8'), 'UTF8'))
             self.assertTrue(utf8_test.equalsTo(indx), "Utf8Test.java binary upload %d (%s) = %s" %
                             (indx, lbl, val))
@@ -137,7 +136,7 @@ class Utf8TestCase(common.JPypeTestCase):
         Allow for surrogate unicode substitution of the return value.
         """
         String = JPackage('java').lang.String
-        for lbl, val in self.TDICT.items():
+        for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(String(val.encode('utf-8'), 'UTF8'))
             try:
                 rval = unicode(utf8_test.get()).encode(
@@ -154,7 +153,7 @@ class Utf8TestCase(common.JPypeTestCase):
         Test pure binary upload and download of utf strings.
         """
         String = JPackage('java').lang.String
-        for lbl, val in self.TDICT.items():
+        for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(String(val.encode('utf-8'), 'UTF8'))
             self.assertEqual(val, unicode(utf8_test.get()),
                              "Utf8Test.java binary upload for: " + lbl)
@@ -165,7 +164,7 @@ class Utf8TestCase(common.JPypeTestCase):
         Assumes synchronized test strings in the java class and in this test class.
         """
         indx = 0
-        for lbl, val in self.TDICT.items():
+        for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(val)
             self.assertTrue(utf8_test.equalsTo(
                 indx), "Utf8Test.java binary upload: indx %d = %s" % (indx, lbl))
@@ -176,7 +175,7 @@ class Utf8TestCase(common.JPypeTestCase):
         Test python string upload and download of utf strings.
         Allow for surrogate unicode substitution of the return value.
         """
-        for lbl, val in self.TDICT.items():
+        for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(val)
             try:
                 rval = unicode(utf8_test.get()).encode(
@@ -192,7 +191,7 @@ class Utf8TestCase(common.JPypeTestCase):
         """
         Test pure python string upload and download of utf strings.
         """
-        for lbl, val in self.TDICT.items():
+        for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(val)
             res = utf8_test.get().__unicode__()
           #  res = unicode(utf8_test.get())

--- a/test/jpypetest/utf8.py
+++ b/test/jpypetest/utf8.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+# *****************************************************************************
+#   Copyright 2018 Rene Bakker
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+
+'''
+    Test communication with jpype using 4-byte utf-8 characters (emoji)
+
+    IMPORTANT:
+    The routines have only be tested in Python3. Given the difference in string handling between
+    Python2 and Python3, it is not likely this routines have any significance for Python2.
+
+    The following tests are defined:
+    General:
+    1. Test if the java class (jpype.utf8.Utf8Test) can return the default ASCII string.
+    2. Pass an ASCII string to the java test class and check if it remained unchanged when returned from java.
+
+    Binary: python strings are injected into java.lang.String in binary format with str.encode()
+    3. Pass a series of reference UTF-8 strings and compare them with the reference strings
+       in the java class.
+    4. Pass a series of reference UTF-8 strings and check if they remained unchanged when returned from Java.
+       Allow for surrogate substitution in the utf-16 strings returned from Java.
+    5. Pass a series of reference UTF-8 strings and check if they remained unchanged when returned from Java.
+       Use the python default strict encoding rules for the returned string.
+
+    Navive strings: python strings are passed as-is into a java method, wich accepts String as argument
+    6. Pass a series of reference UTF-8 strings and compare them with the reference strings
+       in the java class.
+    7. Pass a series of reference UTF-8 strings and check if they remained unchanged when returned from Java.
+       Allow for surrogate substitution in the utf-16 strings returned from Java.
+    8. Pass a series of reference UTF-8 strings and check if they remained unchanged when returned from Java.
+       Use the python default strict encoding rules for the returned string.
+
+    At the time if writing:
+    Passed tests: 1, 2, 3, and 4
+    Failed tests:
+     5. encoding error returned string
+     6. uploaded string mutilated for emoji
+     7. follow-up of 6: mutilated string returned to python (emoji only=
+     8. idem 7.
+
+    Note on encoding errors:
+    UnicodeEncodeError: 'utf-8' codec can't encode characters in position xxx-xxx: surrogates not allowed
+'''
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+
+from collections import OrderedDict
+from jpype import JPackage
+from . import common
+
+if sys.version_info[0] >= 3:
+    unicode = str
+
+    def tounicode(x): return x
+else:
+    def tounicode(x): return unicode(x, 'utf-8')
+
+
+class Utf8TestCase(common.JPypeTestCase):
+
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+        # Java IO test class
+        self.Utf8Test = JPackage('jpype').utf8.Utf8Test
+
+        # Test strings
+        # IMPORTANT: they should be identical, and in the same order, as the test strings difned in the
+        #            java class Utf8Test
+        self.TDICT = OrderedDict()
+        self.TDICT['english'] = tounicode(
+            "I can eat glass and it doesn't hurt me.")
+        self.TDICT['french'] = tounicode(
+            "Je peux manger du verre, ça ne me fait pas mal.")
+        self.TDICT['rune'] = tounicode(
+            "ᛖᚴ ᚷᛖᛏ ᛖᛏᛁ ᚧ ᚷᛚᛖᚱ ᛘᚾ ᚦᛖᛋᛋ ᚨᚧ ᚡᛖ ᚱᚧᚨ ᛋᚨᚱ")
+        self.TDICT['cn_simp'] = tounicode(
+            "人人生而自由,在尊严和权利上一律平等。他们赋有理性和良心,并应以兄弟关系的精神互相对待。")
+        self.TDICT['cn_trad'] = tounicode(
+            "人人生而自由﹐在尊嚴和權利上一律平等。他們賦有理性和良心﹐並應以兄弟關係的精神互相對待。")
+        self.TDICT['arab'] = tounicode(
+            "أنا قادر على أكل الزجاج و هذا لا يؤلمني.")
+        self.TDICT[
+            'emoji'] = tounicode("😁😂😃😄😅😆😠😡😢😣😤😥😨😩😪🚉🚌🚏🚑🚒🚓🚕🚗🚙🚚🚢🚤🚥🚧🚨🚻🚼🚽🚾🛀🆕🆖🆗🆘🆙🆚🈁🈂🈚🈯🈹🈺🉐🉑8⃣9⃣7⃣6⃣1⃣0")
+
+    def test_get_ascii(self):
+        """
+        Test if the default string returns from the java test class.
+        """
+        utf8_test = self.Utf8Test()
+        self.assertEqual("Utf8Test pure ASCII", utf8_test.get(),
+                         "Utf8Test.java default string")
+
+    def test_ascii_upload(self):
+        """
+        Test uploading and downloading of a simple ASCII string.
+        """
+        test_string = 'Python Utf8Test ascii test string'
+        utf8_test = self.Utf8Test(test_string)
+        self.assertEqual(test_string, utf8_test.get(),
+                         "Utf8Test.java uploaded ASCII string")
+
+    def test_binary_upload(self):
+        """
+        Test binary upload and check in Java if the strings are correct.
+        Assumes synchronized test strings in the java class and in this test class.
+        """
+        String = JPackage('java').lang.String
+        indx = 0
+        for lbl, val in self.TDICT.items():
+            utf8_test = self.Utf8Test(String(val.encode('utf-8'), 'UTF8'))
+            self.assertTrue(utf8_test.equalsTo(indx), "Utf8Test.java binary upload %d (%s) = %s" %
+                            (indx, lbl, val))
+            indx += 1
+
+    def test_binary_upload_with_surrogates(self):
+        """
+        Test binary upload and download of utf strings.
+        Allow for surrogate unicode substitution of the return value.
+        """
+        String = JPackage('java').lang.String
+        for lbl, val in self.TDICT.items():
+            utf8_test = self.Utf8Test(String(val.encode('utf-8'), 'UTF8'))
+            try:
+                rval = unicode(utf8_test.get()).encode(
+                    'utf-16').decode('utf-16')
+            except UnicodeEncodeError as uue:
+                rval = unicode(utf8_test.get()).encode(
+                    'utf-16', errors='surrogatepass').decode('utf-16')
+                lbl += (' ' + str(uue))
+            self.assertEqual(
+                val, rval, "Utf8Test.java binary upload with surrogate substitution for: " + lbl)
+
+    def test_binary_upload_no_surrogates(self):
+        """
+        Test pure binary upload and download of utf strings.
+        """
+        String = JPackage('java').lang.String
+        for lbl, val in self.TDICT.items():
+            utf8_test = self.Utf8Test(String(val.encode('utf-8'), 'UTF8'))
+            self.assertEqual(val, unicode(utf8_test.get()),
+                             "Utf8Test.java binary upload for: " + lbl)
+
+    def test_string_upload(self):
+        """
+        Test binary upload and check in Java if the strings are correct.
+        Assumes synchronized test strings in the java class and in this test class.
+        """
+        indx = 0
+        for lbl, val in self.TDICT.items():
+            utf8_test = self.Utf8Test(val)
+            self.assertTrue(utf8_test.equalsTo(
+                indx), "Utf8Test.java binary upload: indx %d = %s" % (indx, lbl))
+            indx += 1
+
+    def test_string_upload_with_surrogates(self):
+        """
+        Test python string upload and download of utf strings.
+        Allow for surrogate unicode substitution of the return value.
+        """
+        for lbl, val in self.TDICT.items():
+            utf8_test = self.Utf8Test(val)
+            try:
+                rval = unicode(utf8_test.get()).encode(
+                    'utf-16').decode('utf-16')
+            except UnicodeEncodeError as uue:
+                rval = unicode(utf8_test.get()).encode(
+                    'utf-16', errors='surrogatepass').decode('utf-16')
+                lbl += (' ' + str(uue))
+            self.assertEqual(
+                val, rval, "Utf8Test.java string upload with surrogate substitution for: " + lbl)
+
+    def test_string_upload_no_surrogates(self):
+        """
+        Test pure python string upload and download of utf strings.
+        """
+        for lbl, val in self.TDICT.items():
+            utf8_test = self.Utf8Test(val)
+            res = utf8_test.get().__unicode__()
+          #  res = unicode(utf8_test.get())
+            self.assertEqual(
+                val, res, "Utf8Test.java string upload for: " + lbl)

--- a/test/jpypetest/varargs.py
+++ b/test/jpypetest/varargs.py
@@ -29,13 +29,15 @@ if sys.version > '3':
 
 # Test code
 
+
 def compareList(l1, l2):
-    if len(l1)!=len(l2):
+    if len(l1) != len(l2):
         return False
     for i in range(0, len(l1)):
-        if l1[i]!=l2[i]:
+        if l1[i] != l2[i]:
             return False
     return True
+
 
 class VarArgsTestCase(common.JPypeTestCase):
     def setUp(self):
@@ -98,20 +100,21 @@ class VarArgsTestCase(common.JPypeTestCase):
 
     def testVarArgsStringTest(self):
         strArray = jpype.JArray(jpype.JString)
-        self.assertTrue(compareList(self.VarArgs.callString('a','b'),['a','b']))
-        self.assertTrue(compareList(self.VarArgs.callString('a'),['a']))
-        self.assertTrue(compareList(self.VarArgs.callString(),[]))
+        self.assertTrue(compareList(
+            self.VarArgs.callString('a', 'b'), ['a', 'b']))
+        self.assertTrue(compareList(self.VarArgs.callString('a'), ['a']))
+        self.assertTrue(compareList(self.VarArgs.callString(), []))
 
     def testVarArgsPlus0(self):
-        self.assertEquals(self.VarArgs.callString0("a"),0)
-        self.assertEquals(self.VarArgs.callString0("a","b"),1)
-        self.assertEquals(self.VarArgs.callString0("a","b","c"),2)
+        self.assertEquals(self.VarArgs.callString0("a"), 0)
+        self.assertEquals(self.VarArgs.callString0("a", "b"), 1)
+        self.assertEquals(self.VarArgs.callString0("a", "b", "c"), 2)
 
     def testVarArgsPlus1(self):
         var = self.VarArgs()
-        self.assertEquals(var.callString1("a"),0)
-        self.assertEquals(var.callString1("a","b"),1)
-        self.assertEquals(var.callString1("a","b","c"),2)
+        self.assertEquals(var.callString1("a"), 0)
+        self.assertEquals(var.callString1("a", "b"), 1)
+        self.assertEquals(var.callString1("a", "b", "c"), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch completes the work on the UTF8 support and incorporates Rene Bakker's UTF8 testing code.  All problems in the encoder should now be fixed.  (though I still object to the fact that Java decided to call UTF-16 surrogate codes encoded as UTF-8 as anything standard).  

Most of the patch is pretty clean but there were some white space errors cropping up from the autopep8 that slipped in that were cleaned up by this patch hence a few random whitespace changes.   There is one FIXME tag which has some addition clean up which is not worth doing at the current time regarding pulling Python.h into the common source.  I was not able to give Rene credit because the patch history was a major mess between the master and devel branch.  The fraction between Python2 and Python3 over str vs unicode was replicated.  

There are still 3 more pulls before I get to my development head, but those are having problems with the conflict resolution that broke something when merging.   Assuming I can get those back up to working we should be getting closer to a release candidate.   Sorry for the heavy review assignments.  