### PR TITLE
Added synchronized

### DIFF
--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -36,7 +36,7 @@ from . import _jinit
 __all__ = [
     'isJVMStarted', 'startJVM', 'attachToJVM', 'shutdownJVM',
     'getDefaultJVMPath', 'getJVMVersion', 'isThreadAttachedToJVM', 'attachThreadToJVM',
-    'detachThreadFromJVM'
+    'detachThreadFromJVM', 'synchronized'
 ]
 
 # See http://scottlobdell.me/2015/04/decorators-arguments-python/
@@ -117,6 +117,8 @@ def attachThreadToJVM():
 def detachThreadFromJVM():
     _jpype.detachThreadFromJVM()
 
+def synchronized(obj):
+    return _jpype.PyJPMonitor(obj.__javavalue__)
 
 def getDefaultJVMPath():
     """

--- a/native/common/include/jp_monitor.h
+++ b/native/common/include/jp_monitor.h
@@ -20,13 +20,14 @@
 class JPMonitor
 {
 public:
-	JPMonitor(const JPValue& value);
+	JPMonitor(jobject obj);
 	virtual ~JPMonitor();
 
-	JPValue& getValue();
+	void enter();
+	void exit();
 
 private:
-	JPValue m_Value;
+	JPObjectRef m_Value;
 } ;
 
 #endif // _JPMONITOR_H_

--- a/native/common/jp_monitor.cpp
+++ b/native/common/jp_monitor.cpp
@@ -16,33 +16,26 @@
  *****************************************************************************/
 #include <jpype.h>
 
-JPMonitor::JPMonitor(const JPValue& value) : m_Value(value)
+JPMonitor::JPMonitor(jobject value) : m_Value(value)
 {
-	// This can hold off for a while so we need to release resource 
-        // so that we don't dead lock.
-	JPPyCallRelease call;
-	JPJavaFrame frame;
-	jvalue& val = m_Value;
-	frame.MonitorEnter(val.l);
-	val.l = frame.NewGlobalRef(val.l);
 }
 
 JPMonitor::~JPMonitor()
 {
-	try
-	{
-		JPJavaFrame frame;
-		jvalue& val = m_Value;
-		frame.MonitorExit(val.l);
-		frame.DeleteGlobalRef(val.l);
-	} catch (...)
-	{
-		// Don't be silent.  Force it to our tracer log.
-		JPypeTracer::trace("Exception in monitor destructor");
-	}
 }
 
-JPValue& JPMonitor::getValue()
+void JPMonitor::enter()
 {
-	return m_Value;
+	// This can hold off for a while so we need to release resource 
+  // so that we don't dead lock.
+	JPPyCallRelease call;
+	JPJavaFrame frame;
+	frame.MonitorEnter(m_Value.get());
 }
+
+void JPMonitor::exit()
+{
+	JPJavaFrame frame;
+	frame.MonitorExit(m_Value.get());
+}
+

--- a/native/python/include/pyjp_monitor.h
+++ b/native/python/include/pyjp_monitor.h
@@ -32,6 +32,8 @@ struct PyJPMonitor
 	static int        __init__(PyJPMonitor* self, PyObject* args);
 	static void       __dealloc__(PyJPMonitor* o);
 	static PyObject*  __str__(PyJPMonitor* o);
+	static PyObject*  __enter__(PyJPMonitor* self, PyObject* args);
+	static PyObject*  __exit__(PyJPMonitor* self, PyObject* args);
 
 	JPMonitor* m_Monitor;
 } ;

--- a/native/python/pyjp_monitor.cpp
+++ b/native/python/pyjp_monitor.cpp
@@ -17,6 +17,8 @@
 #include <pyjp.h>
 
 static PyMethodDef methods[] = {
+	{"__enter__", (PyCFunction) (&PyJPMonitor::__enter__), METH_NOARGS, ""},
+	{"__exit__", (PyCFunction) (&PyJPMonitor::__exit__), METH_VARARGS, ""},
 	{NULL},
 };
 
@@ -108,7 +110,7 @@ int PyJPMonitor::__init__(PyJPMonitor* self, PyObject* args)
 			return -1;
 		}
 
-		self->m_Monitor = new JPMonitor(v1);
+		self->m_Monitor = new JPMonitor(v1.getValue().l);
 		return 0;
 	}
 	PY_STANDARD_CATCH;
@@ -133,11 +135,36 @@ PyObject* PyJPMonitor::__str__(PyJPMonitor* self)
 	try
 	{
 		ASSERT_JVM_RUNNING("PyJPMonitor::__str__");
-		JPClass* cls = self->m_Monitor->getValue().getClass();
 		stringstream ss;
-		ss << "<java monitor for " << cls->toString() << ">";
+		ss << "<java monitor>";
 		return JPPyString::fromStringUTF8(ss.str()).keep();
 	}
 	PY_STANDARD_CATCH
 	return NULL;
 }
+
+PyObject* PyJPMonitor::__enter__(PyJPMonitor* self, PyObject* args)
+{
+	try
+	{
+		ASSERT_JVM_RUNNING("PyJPMonitor::__enter__");
+		self->m_Monitor->enter();
+                Py_RETURN_NONE;
+	}
+	PY_STANDARD_CATCH
+	return NULL;
+}
+
+PyObject* PyJPMonitor::__exit__(PyJPMonitor* self, PyObject* args)
+{
+	try
+	{
+		ASSERT_JVM_RUNNING("PyJPMonitor::__exit__");
+		self->m_Monitor->exit();
+                Py_RETURN_NONE;
+	}
+	PY_STANDARD_CATCH
+	return NULL;
+}
+
+

--- a/test/jpypetest/synchronized.py
+++ b/test/jpypetest/synchronized.py
@@ -1,0 +1,93 @@
+# *****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import sys
+import threading
+import time
+import jpype
+from jpype import synchronized
+from . import common
+
+fail = False
+if fail:
+    # Cause a fail
+    class _JMonitor(object):
+        def __init__(self, obj):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exception_type, exception_value, traceback):
+            pass
+
+    def synchronized(obj):
+        return _JMonitor(obj)
+
+success = True
+glob = 0
+obj = None
+
+
+class MyThread(threading.Thread):
+    def run(self):
+        global glob, success, obj
+        with synchronized(obj):
+            # Increment the global resource
+            glob += 1
+
+            # Wait for a while
+            time.sleep(0.1)
+
+            # If anything else accessed then it was a fail
+            if glob != 1:
+                success = False
+
+            # Decrement the global resoure
+            glob -= 1
+
+
+class SynchronizedTestCase(common.JPypeTestCase):
+
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        global glob, success, obj
+        obj = jpype.JClass("java.lang.Object")()
+
+    def testSynchronized(self):
+        global glob, success
+        glob = 0
+        success = True
+
+        tl = []
+        # Create 10 threads trying to access the same resource
+        for i in range(0, 10):
+            tl.append(MyThread())
+
+        # Release them at the same time
+        for i in tl:
+            i.start()
+
+        # Wait for all to finish
+        for i in tl:
+            i.join()
+
+        # Verify they did not trample each other
+        self.assertTrue(success)


### PR DESCRIPTION
This is a small pull request that completes the JPMonitor class.  In the current master, the monitor is a stub with no connection to the code base.  Monitors are used to implement the synchronized keyword when working with threads through JNI.  This pull request implements all the required machinery for using synchronized and adds a test case using threads to verify function.