### PR TITLE
JArray fails on Classes and strings in 0.6.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
-    ANT_HOME: "C:\\ProgramData\\chocolatey\\lib\\ant\\apache-ant-1.10.1"
+    ANT_HOME: "C:\\ProgramData\\chocolatey\\lib\\ant\\apache-ant-1.10.5"
     NUMPY_: "numpy x.x"
     JAVA_HOME: "C:\\jdk8"
     CINST_OPTS:

--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -156,16 +156,19 @@ def _getClassFor(name):
 
 
 def JArray(t, ndims=1):
-    if issubclass(t, _jwrapper._JWrapper):
+    if isinstance(t, (str,unicode)):
+        pass
+
+    elif issubclass(t, _jwrapper._JWrapper):
         t = t.typeName
 
     elif isinstance(t, _JavaArray):
         t = t.typeName
 
-    elif issubclass(t, _jclass._JAVAOBJECT):
+    elif isinstance(t, _jclass._JavaClass):
         t = t.__name__
 
-    elif not isinstance(t, str) and not isinstance(t, unicode):
+    else:
         raise TypeError("Argument must be a java class, java array class, "
                         "java wrapper or string representing a java class")
 

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import distutils.cmd
 import distutils.log
+from distutils.errors import DistutilsPlatformError
 
 class BuildJavaCommand(distutils.cmd.Command):
   """A custom command to create jar file during build."""
@@ -25,5 +26,9 @@ class BuildJavaCommand(distutils.cmd.Command):
     command = [self.distribution.ant, '-Dbuild=%s'%buildDir, '-f', buildXmlFile]
     cmdStr= ' '.join(command)
     self.announce("  %s"%cmdStr, level=distutils.log.INFO)
-    subprocess.check_call(command)
+    try:
+        subprocess.check_call(command)
+    except subprocess.CalledProcessError as exc:
+        distutils.log.error(exc.output)
+        raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
 

--- a/test/jpypetest/array.py
+++ b/test/jpypetest/array.py
@@ -285,3 +285,22 @@ class ArrayTestCase(common.JPypeTestCase):
         jarr = jpype.JArray(jpype.JDouble)(n)
         jarr[:] = a
         self.assertCountEqual(a, jarr)
+
+    def testArrayCtor1(self):
+        jobject = jpype.JClass('java.lang.Object')
+        jarray = jpype.JArray(jobject)
+        self.assertTrue( isinstance(jarray, jpype._jarray._JavaArray))
+
+    def testArrayCtor2(self):
+        jobject = jpype.JClass('java.util.List')
+        jarray = jpype.JArray(jobject)
+        self.assertTrue( isinstance(jarray, jpype._jarray._JavaArray))
+
+    def testArrayCtor3(self):
+        jarray = jpype.JArray("java.lang.Object")
+        self.assertTrue( isinstance(jarray, jpype._jarray._JavaArray))
+
+    def testArrayCtor4(self):
+        jarray = jpype.JArray(jpype.JObject)
+        self.assertTrue( isinstance(jarray, jpype._jarray._JavaArray))
+


### PR DESCRIPTION
Somehow during some work on the JArray a bug was introduced that removed two required paths for the JArray constructor.  issubclass does not work on strings and thus the first path failed.  The test for a class instance was also incorrect.  It appears that we had some holes in our test coverage that was not checking this pattern.

I corrected the logic and added appropriate tests for each of the patterns.  