### PR TITLE
Fixed missed setupext from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ recursive-include examples *
 include *.rst doc/* LICENSE
 # include everything under test/
 graft test
+graft setupext
 global-exclude *.pyc
 prune test/classes 


### PR DESCRIPTION
The modules from setup.py that I broke out where not being included properly when building an sdist, resulting in an uninstallable tarball.  I believe it is just a missing line in the Manifest file. 