### PR TITLE
Numpy array bug

### DIFF
--- a/native/common/include/jp_primitive_common.h
+++ b/native/common/include/jp_primitive_common.h
@@ -111,7 +111,12 @@ inline bool setRangeViaBuffer(JPJavaFrame& frame,
 		sequence = PyArray_Cast((PyArrayObject*) sequence, npy_type);
 		ref = JPPyObject(JPPyRef::_call, sequence);
 	}
+#else
+	// If we compile without numpy and then encounter numpy
+	// types we will incorrectly convert here.
+	return false;
 #endif
+
 	JPPyMemoryViewAccessor accessor(sequence);
 	if (!accessor.valid())
 		return false;
@@ -130,9 +135,9 @@ inline bool setRangeViaBuffer(JPJavaFrame& frame,
 	return true;
 }
 #else
-
+// Used only by Python 2.6
 template <typename a, typename b, typename c>
-bool setRangeViaBuffer(JPJavaFrame& frame, jarray, int, uint, PyObject*, c)
+bool setRangeViaBuffer(JPJavaFrame& frame, jarray, int, uint, PyObject*, int, c)
 {
 	return false;
 }

--- a/native/common/include/jp_primitive_common.h
+++ b/native/common/include/jp_primitive_common.h
@@ -114,7 +114,8 @@ inline bool setRangeViaBuffer(JPJavaFrame& frame,
 #else
 	// If we compile without numpy and then encounter numpy
 	// types we will incorrectly convert here.
-	return false;
+	if (strcmp(JPPyObject::getTypeName(sequence), "numpy.ndarray") == 0)
+		return false;
 #endif
 
 	JPPyMemoryViewAccessor accessor(sequence);
@@ -136,6 +137,7 @@ inline bool setRangeViaBuffer(JPJavaFrame& frame,
 }
 #else
 // Used only by Python 2.6
+
 template <typename a, typename b, typename c>
 bool setRangeViaBuffer(JPJavaFrame& frame, jarray, int, uint, PyObject*, int, c)
 {

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -167,7 +167,7 @@ JPPyObject JPBooleanType::getArrayRange(JPJavaFrame& frame, jarray a, jsize star
 void JPBooleanType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPBooleanType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_BOOL,
 			&JPJavaFrame::SetBooleanArrayRegion))
 		return;
 

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -188,7 +188,7 @@ JPPyObject JPByteType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, jsi
 void JPByteType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPByteType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_BYTE,
 			&JPJavaFrame::SetByteArrayRegion))
 		return;
 

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -182,7 +182,7 @@ JPPyObject JPCharType::getArrayRange(JPJavaFrame& frame, jarray a, jsize start, 
 void JPCharType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPCharType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_SHORT,
 			&JPJavaFrame::SetCharArrayRegion))
 		return;
 

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -176,7 +176,7 @@ JPPyObject JPDoubleType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, j
 void JPDoubleType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPDoubleType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_DOUBLE,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_FLOAT64,
 			&JPJavaFrame::SetDoubleArrayRegion))
 		return;
 

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -176,7 +176,7 @@ JPPyObject JPDoubleType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, j
 void JPDoubleType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPDoubleType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_DOUBLE,
 			&JPJavaFrame::SetDoubleArrayRegion))
 		return;
 

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -190,7 +190,7 @@ JPPyObject JPFloatType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, js
 void JPFloatType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPFloatType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_FLOAT32,
 			&JPJavaFrame::SetFloatArrayRegion))
 		return;
 

--- a/native/common/jp_inttype.cpp
+++ b/native/common/jp_inttype.cpp
@@ -177,7 +177,7 @@ JPPyObject JPIntType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, jsiz
 void JPIntType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPIntType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_INT,
 			&JPJavaFrame::SetIntArrayRegion))
 		return;
 

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -176,7 +176,7 @@ JPPyObject JPLongType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, jsi
 void JPLongType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPLongType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_INT64,
 			&JPJavaFrame::SetLongArrayRegion))
 		return;
 

--- a/native/common/jp_shorttype.cpp
+++ b/native/common/jp_shorttype.cpp
@@ -171,7 +171,7 @@ JPPyObject JPShortType::getArrayRange(JPJavaFrame& frame, jarray a, jsize lo, js
 void JPShortType::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* sequence)
 {
 	JP_TRACE_IN("JPShortType::setArrayRange");
-	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence,
+	if (setRangeViaBuffer<array_t, type_t>(frame, a, start, length, sequence, NPY_SHORT,
 			&JPJavaFrame::SetShortArrayRegion))
 		return;
 

--- a/test/jpypetest/array.py
+++ b/test/jpypetest/array.py
@@ -331,7 +331,7 @@ class ArrayTestCase(common.JPypeTestCase):
     @unittest.skipUnless(haveNumpy(), "numpy not available")
     def testInitFromNPFloatArrayInt(self):
         import numpy as np
-        a = np.array([1,2,3],dtype=np.int32)
+        a = np.array([1, 2, 3], dtype=np.int32)
         jarr = jpype.JArray(jpype.JFloat)(a)
         print(a)
         print(jarr)
@@ -340,7 +340,7 @@ class ArrayTestCase(common.JPypeTestCase):
     @unittest.skipUnless(haveNumpy(), "numpy not available")
     def testSetFromNPFloatArrayInt(self):
         import numpy as np
-        a = np.array([1,2,3],np.int32)
+        a = np.array([1, 2, 3], np.int32)
         jarr = jpype.JArray(jpype.JFloat)(len(a))
         jarr[:] = a
         self.assertCountEqual(a, jarr)
@@ -348,27 +348,27 @@ class ArrayTestCase(common.JPypeTestCase):
     def testArrayCtor1(self):
         jobject = jpype.JClass('java.lang.Object')
         jarray = jpype.JArray(jobject)
-        self.assertTrue( issubclass(jarray, jpype.JArray))
-        self.assertTrue( isinstance(jarray(10), jpype.JArray))
+        self.assertTrue(issubclass(jarray, jpype.JArray))
+        self.assertTrue(isinstance(jarray(10), jpype.JArray))
 
     def testArrayCtor2(self):
         jobject = jpype.JClass('java.util.List')
         jarray = jpype.JArray(jobject)
-        self.assertTrue( issubclass(jarray, jpype.JArray))
-        self.assertTrue( isinstance(jarray(10), jpype.JArray))
+        self.assertTrue(issubclass(jarray, jpype.JArray))
+        self.assertTrue(isinstance(jarray(10), jpype.JArray))
 
     def testArrayCtor3(self):
         jarray = jpype.JArray("java.lang.Object")
-        self.assertTrue( issubclass(jarray, jpype.JArray))
-        self.assertTrue( isinstance(jarray(10), jpype.JArray))
+        self.assertTrue(issubclass(jarray, jpype.JArray))
+        self.assertTrue(isinstance(jarray(10), jpype.JArray))
 
     def testArrayCtor4(self):
         jarray = jpype.JArray(jpype.JObject)
-        self.assertTrue( issubclass(jarray, jpype.JArray))
-        self.assertTrue( isinstance(jarray(10), jpype.JArray))
+        self.assertTrue(issubclass(jarray, jpype.JArray))
+        self.assertTrue(isinstance(jarray(10), jpype.JArray))
 
     def testArrayCtor5(self):
         jarray0 = jpype.JArray("java.lang.Object")
         jarray = jpype.JArray(jarray0)
-        self.assertTrue( issubclass(jarray, jpype.JArray))
-        self.assertTrue( isinstance(jarray(10), jpype.JArray))
+        self.assertTrue(issubclass(jarray, jpype.JArray))
+        self.assertTrue(isinstance(jarray(10), jpype.JArray))

--- a/test/jpypetest/array.py
+++ b/test/jpypetest/array.py
@@ -296,6 +296,55 @@ class ArrayTestCase(common.JPypeTestCase):
         jarr[:] = a
         self.assertCountEqual(a, jarr)
 
+    @unittest.skipUnless(haveNumpy(), "numpy not available")
+    def testInitFromNPIntArray(self):
+        import numpy as np
+        n = 100
+        a = np.random.random(n).astype(np.int)
+        jarr = jpype.JArray(jpype.JInt)(a)
+        self.assertCountEqual(a, jarr)
+
+    @unittest.skipUnless(haveNumpy(), "numpy not available")
+    def testInitFromNPDoubleArray(self):
+        import numpy as np
+        n = 100
+        a = np.random.random(n).astype(np.float)
+        jarr = jpype.JArray(jpype.JDouble)(a)
+        self.assertCountEqual(a, jarr)
+
+    @unittest.skipUnless(haveNumpy(), "numpy not available")
+    def testInitFromNPDoubleArrayFloat32(self):
+        import numpy as np
+        n = 100
+        a = np.random.random(n).astype(np.float32)
+        jarr = jpype.JArray(jpype.JDouble)(a)
+        self.assertCountEqual(a, jarr)
+
+    @unittest.skipUnless(haveNumpy(), "numpy not available")
+    def testInitFromNPDoubleArrayFloat64(self):
+        import numpy as np
+        n = 100
+        a = np.random.random(n).astype(np.float64)
+        jarr = jpype.JArray(jpype.JDouble)(a)
+        self.assertCountEqual(a, jarr)
+
+    @unittest.skipUnless(haveNumpy(), "numpy not available")
+    def testInitFromNPFloatArrayInt(self):
+        import numpy as np
+        a = np.array([1,2,3],dtype=np.int32)
+        jarr = jpype.JArray(jpype.JFloat)(a)
+        print(a)
+        print(jarr)
+        self.assertCountEqual(a, jarr)
+
+    @unittest.skipUnless(haveNumpy(), "numpy not available")
+    def testSetFromNPFloatArrayInt(self):
+        import numpy as np
+        a = np.array([1,2,3],np.int32)
+        jarr = jpype.JArray(jpype.JFloat)(len(a))
+        jarr[:] = a
+        self.assertCountEqual(a, jarr)
+
     def testArrayCtor1(self):
         jobject = jpype.JClass('java.lang.Object')
         jarray = jpype.JArray(jobject)

--- a/test/jpypetest/array.py
+++ b/test/jpypetest/array.py
@@ -333,8 +333,6 @@ class ArrayTestCase(common.JPypeTestCase):
         import numpy as np
         a = np.array([1, 2, 3], dtype=np.int32)
         jarr = jpype.JArray(jpype.JFloat)(a)
-        print(a)
-        print(jarr)
         self.assertCountEqual(a, jarr)
 
     @unittest.skipUnless(haveNumpy(), "numpy not available")


### PR DESCRIPTION
This pull request is for fixing a bug with handling of numpy arrays.  Currently the array conversion code when setting from a range assumes that any type that fits into a MemoryView can be directly copied into a java array without any type conversion.  This results in a number of incorrect conversions taking place when handling numpy types.  

This pull request is currently incomplete as it currently just includes the tests that demonstrate the bug.  Once complete this will be ported back to master if needed.