### PR TITLE
Work on compiler.

### DIFF
--- a/jpype/compiler.py
+++ b/jpype/compiler.py
@@ -1,0 +1,98 @@
+# *****************************************************************************
+#   Copyright 2018 Karl Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+
+from . import _jclass
+from . import _jexception
+
+__all__ = ['JCompiler', 'JSyntaxError']
+
+class JSyntaxError(Exception):
+    def __init__(self, msg, code, diag):
+        self._code = code
+        self._diag = diag
+        Exception.__init__(self, msg)
+
+    diagnostics = property(lambda self: self._diag, None)
+    code = property(lambda self: self._code, None)
+
+
+class JCompiler(object):
+    """ Front end for java compiler.
+
+    Thic class is used to compiler short pieces of java code to create a
+    dynamic class.  Compiling classes is slow and thus this should only 
+    be used in cases in which the Java API requires extension of a class
+    to implement behavior.
+
+    Calling the compiler will produce a new class which is returned to 
+    the user.  This class can be used like any native class subject to
+    restrictions. As the java class does not belong to any jar it can
+    not be deserialized.
+
+    Restrictions:
+        * The java compiler must be installed on the system.
+        * Public classes must have a package name.  They may not be in 
+        the default package.
+        * Private classes must have a defined public constructor or they cannot
+        be instantiated.  Only public classes have default constructors.
+        * Classes are loaded using the JPype internal memory class loader
+        and thus may not be able to import access classes defined in other 
+        external classloaders.
+
+    Todo:
+        * Compiler options are not exposed.
+
+    """
+
+    def __init__(self, *args):
+        # Use the custom class loader
+        classLoader = _jclass.JClass("org.jpype.classloader.JPypeClassLoader")
+        Class = _jclass.JClass('java.lang.Class')
+
+        # Get a class from jpype class loader
+        cls = Class.forName("org.jpype.compiler.MemoryCompiler",
+                            False, classLoader.getInstance())
+
+        # Convert it to a python class
+        self._memoryCompiler = _jclass.JClass(cls)()
+
+    def available(self):
+        return self._memoryCompiler.isAvailable()
+
+    def compile(self, className, code):
+        """ Compile a class with current compiler options.
+
+        Args:
+            className(str): Class name to be compiled including the package name.  This should be 
+               dot seperated.
+            code(str): java code to be compiled typically represented with a multiline string using
+               regular expression encoding.
+
+        Returns:
+            A java class wrapper for the newly created class or throws an exception on failure.
+
+        """
+        if not self._memoryCompiler.isAvailable():
+            raise OSError("Compiler is not available")
+
+        cls = self._memoryCompiler.compile(className, code)
+
+        if cls == None:
+            dc = self._memoryCompiler.getDiagnostics().getDiagnostics()
+            raise JSyntaxError("Failed to compile.", code, dc)
+
+        return _jclass.JClass(cls)

--- a/native/java/org/jpype/compiler/MemoryCompiler.java
+++ b/native/java/org/jpype/compiler/MemoryCompiler.java
@@ -32,6 +32,12 @@ public class MemoryCompiler
 {
   public DiagnosticCollector<JavaFileObject> diagnostics;
 
+	public boolean isAvailable()
+	{
+    JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+		return javac!=null;
+	}
+
   /**
    * Compile code from memory into a class.
    * <p>
@@ -50,6 +56,9 @@ public class MemoryCompiler
               new MemorySourceObject(name, source));
 
       JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+			if (javac == null)
+				throw new NullPointerException("javac is null");
+
       this.diagnostics = new DiagnosticCollector<>();
 
       // We need a standard file manager to serve as our base.
@@ -59,7 +68,7 @@ public class MemoryCompiler
       MemoryFileManager memoryFileManager = new MemoryFileManager(stdFileManager);
 
       // Create a compiler
-      JavaCompiler.CompilationTask task = javac.getTask(null, memoryFileManager, null, null, null, sources);
+      JavaCompiler.CompilationTask task = javac.getTask(null, memoryFileManager, diagnostics, null, null, sources);
       boolean success = task.call();
       if (!success)
       {

--- a/test/jpypetest/compiler.py
+++ b/test/jpypetest/compiler.py
@@ -1,0 +1,67 @@
+# *****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+import jpype
+import sys
+import logging
+import time
+from . import common
+
+from jpype.compiler import JCompiler, JSyntaxError
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+class CompilerTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testCompileSuccess(self):
+        compiler = JCompiler()
+        if not compiler.available():
+            self.skipTest("compiler is not available")
+
+        Test = compiler.compile('my.Test',r'''
+            package my;
+            public class Test
+            {
+                public String get()
+                {
+                    return "word";
+                }
+            }
+        ''')
+        test = Test()
+        self.assertEquals(test.get(), "word")
+
+    def testCompileFail(self):
+        compiler = JCompiler()
+        if not compiler.available():
+            self.skipTest("compiler is not available")
+        with self.assertRaises(JSyntaxError):
+            Test = compiler.compile('my.Test',r'''
+                package my;
+                public class Test
+                {
+                    public Sting get()
+                    {
+                        return "word";
+                    }
+                }
+            ''')
+


### PR DESCRIPTION
This is the first hack at the compiler api.  It still has some rough edges though most of those have to do with the java language rather than anything we control.  Package names are required to create public classes.  Private classes do not produce a default constructor so one must be declared.   Performance is horrible in terms of time as the java compiler has a huge overhead to spin up.  But when you have no other choice but to compile a class to implement something due to how a class was designed in java then this has to be an option.

It also appears to be having a weird interaction with the leak checker on my system.  I don't believe that it causing leaks, but it appears the compiler causes a lot of garbage collection actions that foul up the leak checker.  I may need to put some tear down in the test cases to try to clean up its mess.

I updated the documentation a bit (more needed) and added test cases to make sure it actually works outside of my system.