### PR TITLE
Proxy api rework

### DIFF
--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -18,7 +18,7 @@
 import collections
 import sys
 
-__all__ = ["JProxy"]
+__all__ = ["JProxy", "JImplements"]
 
 import _jpype
 from . import _jclass
@@ -26,43 +26,150 @@ from . import _jclass
 if sys.version > '3':
     unicode = str
 
+# FIXME the java.lang.method we are overriding should be passes to the lookup function
+# so we can properly handle name mangling on the override.
+
+def _createJProxy(cls, intf, **kwargs):
+    """ (internal) Create a proxy from a python class with
+    @JOverride notation on methods.
+    """
+    # Convert the interfaces list
+    actualIntf = _convertInterfaces(intf)
+
+    # Find all class defined overrides
+    overrides = {}
+    for k,v in cls.__dict__.items():
+        try:
+            attr = object.__getattribute__(v, "__joverride__")
+            overrides[k]=(v, attr)
+        except AttributeError:
+            pass
+
+    # Verify all methods are overriden
+    for interface in actualIntf:
+        for method in interface.class_.getMethods():
+            if method.getModifiers()&1024==0:
+                continue
+            if not str(method.getName()) in overrides:
+                raise NotImplementedError("Interface %s requires method %s to be implemented."%(interface.class_.getName(), method.getName()))
+
+    # Define a lookup interface
+    def lookup(self, name):
+        # Get the override from the override dictionary
+        over = overrides[name]
+
+        # We need convert the method to a bound method using descriptor interface
+        return over[0].__get__(self)
+
+    # Construct a new init method
+    init = cls.__dict__.get('__init__', None)
+    if init:
+        def init2(self, *args, **kwargs):
+            init(self, *args, **kwargs)
+            self.__javaproxy__ = _jpype.PyJPProxy(self, lookup, actualIntf)
+    else:
+        def init2(self, *args, **kwargs):
+            self.__javaproxy__ = _jpype.PyJPProxy(self, lookup, actualIntf)
+
+    # Replace the init with the proxy init
+    type.__setattr__(cls, '__init__', init2)
+
+    # Return the augmented class
+    return cls
+
+
+def JImplements(*args, **kwargs):
+    """ Annotation for creating a new proxy that implements a list of
+    java interfaces.
+
+    This annotation is placed on a python class.  The annotation
+    requires a list of interfaces.  It must implement all of the java
+    methods for each of the interfaces.  Each implemented method
+    should have a @JOverride annotation.
+
+    Example:
+      ... @JImplement("org.my.Interface")
+      ... class MyImpl(object):
+      ...    @JOverride
+      ...    def method(self, arg):
+      ...      pass
+
+    """
+    def f(cls):
+        return _createJProxy(cls, args, **kwargs)
+    return f
+
+def _convertInterfaces(intf):
+    """ (internal) Convert a list of interface names into
+    a list of interfaces suitable for a proxy.
+    """
+    # We operate on lists of interfaces, so a single element is promoted
+    # to a list
+    if not isinstance(intf, collections.Sequence):
+        intf = [intf]
+
+    # Verify that the list contains the required types
+    actualIntf = []
+    for i in intf:
+        if isinstance(i, str) or isinstance(i, unicode):
+            actualIntf.append(_jclass.JClass(i))
+        elif isinstance(i, _jclass.JClass):
+            actualIntf.append(i)
+        else:
+            raise TypeError("JProxy requires java interface classes "
+                            "or the names of java interfaces classes: {0}".format(i.__name))
+    # Check that all are interfaces
+    for i in actualIntf:
+        if not issubclass(i, _jclass.JInterface):
+            raise TypeError("JProxy requires java interface classes "
+                            "or the names of java interfaces classes: {0}"
+                            .format(i.__name__))
+
+    return actualIntf
+
 
 class JProxy(object):
+    """ Define a proxy for a java interface.
+
+    This is an older style jpype proxy interface that uses either a
+    dictionary or an object instance to implement methods defined
+    in java.  The python object can be held by java and its lifespan
+    will continue as long as java holds a reference to the object
+    instance.  New code should use @JImplements annotation as
+    it will support improved type safety and error handling.
+
+    Name lookups can either made using a dictionary or an object
+    instance.  One of these two options must be specified.
+
+    Args:
+        intf: either a single interface or a list of java interfaces.
+            The interfaces can either be defined by strings or
+            JClass instance.  Only interfaces may be used in a
+            proxy,
+        dict (dict[string, callable], optional): specifies a dictionary
+            containing the methods to be called when executing the
+            java interface methods.
+        inst (object, optional): specifies an object with methods
+            whose names matches the java interfaces methods.
+    """
     def __init__(self, intf, dict=None, inst=None):
-        actualIntf = None
+        # Convert the interfaces
+        actualIntf = _convertInterfaces(intf)
 
-        # We operate on lists of interfaces, so a single element is promoted
-        # to a list
-        if not isinstance(intf, collections.Sequence):
-            intf = [intf]
-
-        # Verify that the list contains the required types
-        actualIntf = []
-        for i in intf:
-            if isinstance(i, str) or isinstance(i, unicode):
-                actualIntf.append(_jclass.JClass(i))
-            elif isinstance(i, _jclass.JClass):
-                actualIntf.append(i)
-            else:
-                raise TypeError("JProxy requires java interface classes "
-                                "or the names of java interfaces classes: {0}".format(i.__name))
-
-        # Check that all are interfaces
-        for i in actualIntf:
-            if not issubclass(i, _jclass.JInterface):
-                raise TypeError("JProxy requires java interface classes "
-                                "or the names of java interfaces classes: {0}"
-                                .format(i.__name__))
-
+        # Verify that one of the options has been selected
         if dict is not None and inst is not None:
             raise RuntimeError("Specify only one of dict and inst")
 
         if dict is not None:
+            # Define the lookup function based for a dict
             def lookup(d, name):
                 return d[name]
+            # create a proxy
             self.__javaproxy__ = _jpype.PyJPProxy(dict, lookup, actualIntf)
 
         if inst is not None:
+            # Define the lookup function based for a object instance
             def lookup(d, name):
                 return getattr(d, name)
+            # create a proxy
             self.__javaproxy__ = _jpype.PyJPProxy(inst, lookup, actualIntf)

--- a/native/common/jp_baseclasses.cpp
+++ b/native/common/jp_baseclasses.cpp
@@ -74,6 +74,13 @@ JPMatch::Type JPObjectBaseClass::canConvertToJava(PyObject* pyobj)
 		return JPMatch::_implicit;
 	}
 
+	JPProxy* proxy = JPPythonEnv::getJavaProxy(pyobj);
+	if (proxy != NULL)
+	{
+		JP_TRACE("implicit python proxy");
+		return JPMatch::_implicit;
+	}
+
 	return JPMatch::_none;
 	JP_TRACE_OUT;
 }

--- a/test/harness/jpype/proxy/ProxyTriggers.java
+++ b/test/harness/jpype/proxy/ProxyTriggers.java
@@ -21,14 +21,17 @@ import java.util.List;
 
 public class ProxyTriggers
 {
-    public static String[] testProxy(TestInterface2 itf)
+    public static String[] testProxy(Object itf)
     {
         List<String> methods = new LinkedList<>();
         if (itf instanceof TestInterface1)
         {
             methods.add("Test Method1 = "+((TestInterface1)itf).testMethod1());
         }
-        methods.add("Test Method2 = "+itf.testMethod2());
+        if (itf instanceof TestInterface2)
+        {
+          methods.add("Test Method2 = "+((TestInterface2)itf).testMethod2());
+        }
         if (itf instanceof TestInterface3)
         {
             methods.add("Test Method3 = "+((TestInterface3)itf).testMethod3());


### PR DESCRIPTION
Applying duck typing to our proxy implementation allows for annotations to be used to create proxy class.  This adds `@JImplements` and reuses `@JOverride`.  It does not yet do runtime checking to make sure all methods are implemented and does not yet have support of name mangling.  

This patch also fixes a bug in which java.lang.Object did not accept proxies for conversion.  More testing is required before this is complete.  But I want to put it through the CI to make sure it works on multiple python versions and to discuss how the api looks.