### PR TITLE
Fixed attach/detach/isAttached

### DIFF
--- a/native/common/jp_env.cpp
+++ b/native/common/jp_env.cpp
@@ -274,7 +274,7 @@ void JPEnv::attachCurrentThreadAsDaemon()
 bool JPEnv::isThreadAttached()
 {
 	JNIEnv* env;
-	return JNI_OK != s_JavaVM->functions->GetEnv(s_JavaVM, (void**) &env, USE_JNI_VERSION);
+	return JNI_OK == s_JavaVM->functions->GetEnv(s_JavaVM, (void**) &env, USE_JNI_VERSION);
 }
 
 void JPEnv::detachCurrentThread()

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -259,8 +259,8 @@ PyObject* PyJPModule::detachThread(PyObject* obj)
 	JP_TRACE_IN("PyJPModule::detachThread");
 	try
 	{
-		ASSERT_JVM_RUNNING("JPypeModule::detachThread");
-		JPEnv::detachCurrentThread();
+		if (JPEnv::isInitialized())
+			JPEnv::detachCurrentThread();
 		Py_RETURN_NONE;
 	}
 	PY_STANDARD_CATCH;
@@ -273,7 +273,8 @@ PyObject* PyJPModule::isThreadAttached(PyObject* obj)
 {
 	try
 	{
-		ASSERT_JVM_RUNNING("JPypeModule::isThreadAttached");
+		if (!JPEnv::isInitialized())
+			return PyBool_FromLong(0);
 		return PyBool_FromLong(JPEnv::isThreadAttached());
 	}
 	PY_STANDARD_CATCH;

--- a/test/jpypetest/thread.py
+++ b/test/jpypetest/thread.py
@@ -1,0 +1,46 @@
+# *****************************************************************************
+#   Copyright 2019 Karl Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+import jpype
+import sys
+import time
+from . import common
+
+
+class ThreadTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testAttach(self):
+        # Make sure we are attached to start the test
+        jpype.attachThreadToJVM()
+        self.assertTrue(jpype.isThreadAttachedToJVM())
+
+        # Detach from the thread
+        jpype.detachThreadFromJVM()
+        self.assertFalse(jpype.isThreadAttachedToJVM())
+
+        # Reattach to the thread
+        jpype.attachThreadToJVM()
+        self.assertTrue(jpype.isThreadAttachedToJVM())
+
+        # Detach again
+        jpype.detachThreadFromJVM()
+        self.assertFalse(jpype.isThreadAttachedToJVM())
+
+        # Call a Java method which will cause it to attach automatically
+        s = jpype.JString("foo")
+        self.assertTrue(jpype.isThreadAttachedToJVM())


### PR DESCRIPTION
Fix for #413.  Fixed the broken logic and made it so that detach and isAttached both succeed even if the JVM is not started.  Added appropriate test case.

@marscher Quick check, are you still around to review or should I commit as needed to get the head back to production state?