### PR TITLE
Uses a cache to remove ant and jdk dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       env: NUMPY="--global-option=--disable-numpy"
   
 install:
-  - python setup.py sdist
+  - python setup.py --enable-build-jar sdist
   - pip install dist/* $NUMPY
   - pip install -r test-requirements.txt
   - ant -f test/build.xml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include native *.h *.xml *.java
+recursive-include native *.h *.xml *.java *.jar *.class
 recursive-include examples *
 include *.rst doc/* LICENSE
 # include everything under test/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,13 +63,14 @@ environment:
       CONDA_PY: "3-latest"
       ARCH: x86_64
 
-    - PYTHON: "C:\\Miniconda34-x64"
-      CONDA_PY: "3.4.3"
-      ARCH: x86_64
-
-    - PYTHON: "C:\\Miniconda34"
-      CONDA_PY: "3.4.3"
-      ARCH: x86
+      ### Dropping 3.4 build due to problem with setuptools
+      #- PYTHON: "C:\\Miniconda34-x64"
+      #CONDA_PY: "3.4.3"
+      #ARCH: x86_64
+      #
+      #- PYTHON: "C:\\Miniconda34"
+      #CONDA_PY: "3.4.3"
+      #ARCH: x86
 
     - PYTHON: "C:\\Miniconda35-x64"
       CONDA_PY: "3.5.2"

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -15,6 +15,6 @@ pip.exe install nose setuptools -r test-requirements.txt
 ant.exe -f test\\build.xml
 
 # Build the compiled extension and run the project tests
-python.exe setup.py bdist_wheel
+python.exe setup.py --enable-build-jar bdist_wheel
 dir .\dist
 Get-ChildItem -File -Path .\dist\*.whl | Foreach {pip install --upgrade $_.fullname}

--- a/appveyor/install.sh
+++ b/appveyor/install.sh
@@ -75,7 +75,7 @@ echo "==== Build test"
 
 # Install the package
 echo "==== Build module"
-$PYTHON ./setup.py bdist_wheel
+$PYTHON ./setup.py --enable-build-jar bdist_wheel
 $PYTHON -m pip install --upgrade ./dist/*.whl
 
 echo "==== Verify jvm.dll found"

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,36 +1,150 @@
 Installation
 ============
 
-Get JPype from the `github <https://github.com/jpype-project/jpype>`__ or
-from `PyPi <http://pypi.python.org/pypi/JPype1>`__. If you are using `Anaconda <https://anaconda.org>`_ Python stack,
-you can install pre-compiled binaries from conda-forge for Linux, OSX and Windows.
+JPype is available either as a pre-compiled binary for Anaconda, or 
+may be build from source though several methods.
+
 
 Binary Install
 --------------
-1. Ensure you have installed Anaconda/Miniconda. Instructions can be found `here <http://conda.pydata.org/docs/install/quick.html>`_.
-2. Install from the conda-forge software channel::
+
+JPype can be installed as pre-compiled binary if you are using the `Anaconda
+<https://anaconda.org>`_ Python stack. Binaries are available for Linux, OSX,
+ad windows are available on conda-forge.
+
+1. Ensure you have installed Anaconda/Miniconda. Instructions can be found
+   `here <http://conda.pydata.org/docs/install/quick.html>`__.  
+2. Install from
+   the conda-forge software channel::
 
     conda install -c conda-forge jpype1
 
-From source - Requirements
---------------------------
 
-Either the Sun/Oracle JDK/JRE Variant or OpenJDK. Python 2.6+ (including Python 3+).
+Source Install
+--------------
+
+Installing from source requires
+
+Python
+  JPype works with CPython 2.6 or later including the 3 series. Both the
+  runtime and the development package are required.
+
+Java
+  Either the Sun/Oracle JDK/JRE Variant or OpenJDK. Python 2.6+ (including
+  Python 3+).  JPype source distribution includes a copy of the Java JNI header
+  and precompiled Java code, so the development kit is not required from the
+  source distribution. JPype has been used with Java versions from 
+  Java 1.6 to Java 11.
+
+C++
+  A C++ compiler which matches the ABI used to build CPython.
+
+Ant and JDK
+  *(Optional)* JPype contains sections of Java code. These sections are
+  precompiled in the source distribution but must be build with installing from
+  git directly.
+
+Once these requirements have been met one can use pip to build either from the
+source distribution or directly from the repo.  Specific requirements from
+different achitectures are shown below_.   
+
+
+Build using pip
+~~~~~~~~~~~~~~~
+
+JPype may be build and installed with one easy step using pip.
+
+To install the latest JPype using the source distribute use: ::
+
+  pip install JPype1
+
+To install from the current github master use: ::
+
+  pip install git+https://github.com/jpype-project/jpype.git
+
+More details on installing from git can be found at `Pip install
+<https://pip.pypa.io/en/stable/reference/pip_install/#git>`__.  The git version
+does not include a prebuilt jar and thus both ant and JDK are required.
+
+
+Build and install manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+JPype can be built entirely from source. Just follow these three
+easy steps.
+
+**1. Get the JPype source**
+
+Either from 
+`github <https://github.com/jpype-project/jpype>`__ or
+from `PyPi <http://pypi.python.org/pypi/JPype1>`__. 
+
+**2. Build the source with desired options**
+
+Compile JPype using the included ``setup.py`` script with: ::
+
+  python setup.py build
+
+The setup script recognizes several arguments.
+
+--ant                Define the location of ant on your system using 
+                     ``--ant=path``.  This option is useful when building 
+                     when ant is not in the path.
+--enable-build-jar   Force setup to recreate the jar from scratch. 
+--enable-tracting    Build a verison of JPype with full logging to the 
+                     console. This can be used to diagnose trick JNI
+                     issues.
+--disable-numpy      Do not compile with numpy extenstions.
+
+After building, JPype can be tested using the test bench. The test
+bench requires ant and JDK to build.
+
+**3. Install JPype with:** ::
+
+    python setup.py install
+
+
+If it fails...
+~~~~~~~~~~~~~~
+
+This happens mostly due to the setup not being able to find your ``JAVA_HOME``.
+In case this happens, please do two things:
+
+1. You can continue the installation by finding the ``JAVA_HOME`` on your own (
+   the place where the headers etc. are) and explicitly setting it for the
+   installation: ::
+
+     JAVA_HOME=/usr/lib/java/jdk1.8.0/ python setup.py install
+
+2. Please create an Issue `on
+   github <https://github.com/jpype-project/jpype/issues?state=open>`__ and
+   post all the information you have.
+
+
+.. _below:
+
+Specific requirements
+~~~~~~~~~~~~~~~~~~~~~
+
+JPype is know to work on Linx, OSX, Windows, and Cygwin.  To make it easier to
+those who have not build CPython modules before here are some helpful tips for
+different machines.
 
 Debian/Ubuntu
-~~~~~~~~~~~~~
+:::::::::::::
 
-Debian/Ubuntu users will have to install ``g++``, ``python-dev``, and ``ant``
-first:
+Debian/Ubuntu users will have to install ``g++``, ``python-dev``, and ``ant`` (optional)
+Use:
 
 ::
 
     sudo apt-get install g++ python-dev python3-dev ant
 
 Windows
-~~~~~~~
+:::::::
 
-Windows users need a Python installation and C++ compilers:
+Windows users need a CPython installation and C++ compilers specificly for 
+CPython:
 
 1. Install some version of Python (2.7 or higher), e.g., `Anaconda
    <https://www.continuum.io/downloads>`_ is a good choice for users not yet
@@ -41,71 +155,30 @@ Windows users need a Python installation and C++ compilers:
    <https://www.microsoft.com/en-us/download/details.aspx?id=14632>`_ and
    `Microsoft Build Tools 2015 Update 3
    <https://visualstudio.microsoft.com/vs/older-downloads/>`_
-4. Install `Apache Ant (tested using 1.9.13)
+4. (optional) Install `Apache Ant (tested using 1.9.13)
    <https://ant.apache.org/bindownload.cgi>`_
 
 Netbeans ant can be used in place of Apache Ant.  Netbeans ant is located in
 ``${netbeans}/extide/ant/bin/ant.bat``.  
 
-The Build Tools 2015 is a pain to find. Microsoft really wants people to download the latest version. 
-To get to it from the above URL, click on "Redistributables and Build Tools", then select 
-Microsoft Build Tools 2015 Update 3.
+Due to differences in the C++ API, only the version specified will work to
+build CPython modules.  The Build Tools 2015 is a pain to find. Microsoft
+really wants people to download the latest version.  To get to it from the
+above URL, click on "Redistributables and Build Tools", then select Microsoft
+Build Tools 2015 Update 3.
 
-When building for windows you must use the Visual Studio developer command prompt.
+When building for windows you must use the Visual Studio developer command
+prompt.
 
-Install
--------
-
-Should be easy as
-
-::
-
-    python setup.py install
-
-
-For builds with a specific ant, use
-
-::
-
-    python setup.py --ant=C:\My\Ant\Path\ant.bat install
-
-
-
-If it fails...
-~~~~~~~~~~~~~~
-
-This happens mostly due to the setup not being able to find your
-``JAVA_HOME``. In case this happens, please do two things:
-
-1. You can continue the installation by finding the ``JAVA_HOME`` on
-   your own ( the place where the headers etc. are) and explicitly
-   setting it for the installation:
-
-   ``JAVA\_HOME=/usr/lib/java/jdk1.6.0/ python setup.py install``
-2. Please create an Issue `on
-   github <https://github.com/jpype-project/jpype/issues?state=open>`__ and
-   post all the information you have.
-
-Tested on
----------
-
--  OS X 10.7.4 with Sun/Oracle JDK 1.6.0
--  OSX 10.8.1-10.8.4 with Sun/Oracle JDK 1.6.0
--  OSX 10.9 DP5
--  Debian 6.0.4/6.0.5 with Sun/Oracle JDK 1.6.0
--  Debian 7.1 with OpenJDK 1.6.0
--  Ubuntu 12.04 with Sun/Oracle JDK 1.6.0
 
 Known Bugs/Limitations
 ----------------------
 
 -  Java classes outside of a package (in the ``<default>``) cannot be
    imported.
--  unable to access a field or method if it conflicts with a python
-   keyword.
 -  Because of lack of JVM support, you cannot shutdown the JVM and then
    restart it.
 -  Some methods rely on the "current" class/caller. Since calls coming
    directly from python code do not have a current class, these methods
-   do not work. The User Manual lists all the known methods like that.
+   do not work. The :doc:`userguide` lists all the known methods like that.
 -  Mixing 64 bit Python with 32 bit Java and vice versa crashes on import jpype.

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'build_thunk': setupext.build_thunk.BuildThunkCommand,
         'build_ext': setupext.build_ext.BuildExtCommand,
         'test_java': setupext.test_java.TestJavaCommand,
+        'sdist': setupext.sdist.BuildSourceDistribution,
     },
     zip_safe=False,
     ext_modules=[jpypeLib],

--- a/setupext/__init__.py
+++ b/setupext/__init__.py
@@ -5,3 +5,4 @@ from . import build_ext
 from . import build_java
 from . import build_thunk
 from . import test_java
+from . import sdist

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -4,6 +4,7 @@ import subprocess
 import distutils.cmd
 import distutils.log
 from distutils.errors import DistutilsPlatformError
+from distutils.dir_util import copy_tree, remove_tree
 
 
 class BuildJavaCommand(distutils.cmd.Command):
@@ -22,6 +23,17 @@ class BuildJavaCommand(distutils.cmd.Command):
 
     def run(self):
         """Run command."""
+        java = self.distribution.enable_build_jar
+        if not java:
+            src = os.path.join('native','jars')
+            dest = os.path.join('build','lib')
+            if not os.path.exists(src):
+                distutils.log.error("Jar cache missing, use --enable-build-jar make the jar")
+                raise DistutilsPlatformError("Fail to find org.jpype.jar")
+            copy_tree(src, dest)
+            return
+
+        # build the jar
         buildDir = os.path.join("..", "build")
         buildXmlFile = os.path.join("native", "build.xml")
         command = [self.distribution.ant, '-Dbuild=%s' %
@@ -33,3 +45,4 @@ class BuildJavaCommand(distutils.cmd.Command):
         except subprocess.CalledProcessError as exc:
             distutils.log.error(exc.output)
             raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
+

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -24,14 +24,17 @@ class BuildJavaCommand(distutils.cmd.Command):
     def run(self):
         """Run command."""
         java = self.distribution.enable_build_jar
+
+        # Try to use the cach if we are not requested build
         if not java:
             src = os.path.join('native','jars')
             dest = os.path.join('build','lib')
-            if not os.path.exists(src):
-                distutils.log.error("Jar cache missing, use --enable-build-jar make the jar")
-                raise DistutilsPlatformError("Fail to find org.jpype.jar")
-            copy_tree(src, dest)
-            return
+            if os.path.exists(src):
+                distutils.log.info("Using Jar cache")
+                copy_tree(src, dest)
+                return
+
+        distutils.log.info("Jar cache is missing, using --enable-build-jar to recreate it.")
 
         # build the jar
         buildDir = os.path.join("..", "build")
@@ -45,4 +48,5 @@ class BuildJavaCommand(distutils.cmd.Command):
         except subprocess.CalledProcessError as exc:
             distutils.log.error(exc.output)
             raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
+
 

--- a/setupext/dist.py
+++ b/setupext/dist.py
@@ -6,6 +6,7 @@ from setuptools.dist import Distribution as _Distribution
 
 class Distribution(_Distribution):
     global_options = [
+        ('enable-build-jar', None, 'Build the java jar portion'),
         ('enable-tracing', None, 'Set for tracing for debugging'),
         ('ant=', None, 'Set the ant executable (default ant)', 1),
         ('disable-numpy', None, 'Do not compile with numpy extenstions')
@@ -15,4 +16,5 @@ class Distribution(_Distribution):
         self.disable_numpy = False
         self.ant = "ant"
         self.enable_tracing = False
+        self.enable_build_jar = False
         return _Distribution.parse_command_line(self)

--- a/setupext/sdist.py
+++ b/setupext/sdist.py
@@ -15,12 +15,18 @@ class BuildSourceDistribution(sdist):
     Copy the build/lib to native/jars to remove ant/jdk dependency
     """
     def run(self):
+        # We need to build a jar cache for the source distribution
+        self.run_command("build_java")
         dest = os.path.join('native','jars')
         src = os.path.join('build','lib')
         if not os.path.exists(src):
             distutils.log.error("Jar source file is missing from build")
             raise distutils.errors.DistutilsPlatformError("Error copying jar file")
         copy_tree(src, dest)
+
+        # Collect the sources
         super(sdist, self).run()
+
+        # Clean up the jar cache after sdist
         remove_tree(dest)
 

--- a/setupext/sdist.py
+++ b/setupext/sdist.py
@@ -19,7 +19,7 @@ class BuildSourceDistribution(sdist):
         src = os.path.join('build','lib')
         if not os.path.exists(src):
             distutils.log.error("Jar source file is missing from build")
-            raise DistutilsPlatformError("Error copying jar file")
+            raise distutils.errors.DistutilsPlatformError("Error copying jar file")
         copy_tree(src, dest)
         super(sdist, self).run()
         remove_tree(dest)

--- a/setupext/sdist.py
+++ b/setupext/sdist.py
@@ -25,7 +25,7 @@ class BuildSourceDistribution(sdist):
         copy_tree(src, dest)
 
         # Collect the sources
-        super(sdist, self).run()
+        sdist.run(self)
 
         # Clean up the jar cache after sdist
         remove_tree(dest)

--- a/setupext/sdist.py
+++ b/setupext/sdist.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import warnings
+import distutils
 from distutils.dir_util import copy_tree, remove_tree
 from setuptools.command.sdist import sdist
 from setuptools import Extension

--- a/setupext/sdist.py
+++ b/setupext/sdist.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+import os
+import sys
+import warnings
+from distutils.dir_util import copy_tree, remove_tree
+from setuptools.command.sdist import sdist
+from setuptools import Extension
+
+# Customization of the sdist
+class BuildSourceDistribution(sdist):
+    """
+    Override some behavior on sdist
+
+    Copy the build/lib to native/jars to remove ant/jdk dependency
+    """
+    def run(self):
+        dest = os.path.join('native','jars')
+        src = os.path.join('build','lib')
+        if not os.path.exists(src):
+            distutils.log.error("Jar source file is missing from build")
+            raise DistutilsPlatformError("Error copying jar file")
+        copy_tree(src, dest)
+        super(sdist, self).run()
+        remove_tree(dest)
+


### PR DESCRIPTION
As requested this pull request adds a cache for the jars.  To build the jar when it changes use

```
python setup.py --enable-jar develop
```

The jar and class file must be copied back manually to the cache.  Not sure if the native source directory is a good place for the jar.   If you have a better spot feel free to move it.