### PR TITLE
Pull changes from tcalmant

### DIFF
--- a/native/common/jp_array.cpp
+++ b/native/common/jp_array.cpp
@@ -71,14 +71,19 @@ JPPyObject JPArray::getRange(jsize start, jsize stop)
 void JPArray::setRange(jsize start, jsize stop, PyObject* val)
 {
 	JP_TRACE_IN("JPArray::setRange");
+
+	// Make sure it is an iterable before we start
+	if (!JPPySequence::check(val))
+		JP_RAISE_TYPE_ERROR("can only assign a sequence");
+
 	JPJavaFrame frame;
 	JPClass* compType = m_Class->getComponentType();
 	unsigned int len = stop - start;
 	JPPySequence seq(JPPyRef::_use, val);
-	size_t plength = seq.size();
+	long plength = seq.size();
 
 	JP_TRACE("Verify lengths", len, plength);
-	if (len != plength)
+	if ((long) len != plength)
 	{
 		// Python would allow mismatching size by growing or shrinking 
 		// the length of the array.  But java arrays are immutable in length.

--- a/native/python/jp_pythonenv.cpp
+++ b/native/python/jp_pythonenv.cpp
@@ -88,12 +88,12 @@ JPPyObject JPPythonEnv::newJavaClass(JPClass* javaClass)
 JPValue* JPPythonEnv::getJavaValue(PyObject* obj)
 {
 	JPPyObject vobj(JPPyRef::_use, obj);
-	if (obj->ob_type == &PyJPValue::Type)
+	if (Py_TYPE(obj) == &PyJPValue::Type)
 		return &((PyJPValue*) obj)->m_Value;
 	if (!JPPyObject::hasAttrString(obj, __javavalue__))
 		return 0;
 	JPPyObject self(JPPyObject::getAttrString(obj, __javavalue__));
-	if (self.get()->ob_type == &PyJPValue::Type)
+	if (Py_TYPE(self.get()) == &PyJPValue::Type)
 	{
 		return &(((PyJPValue*) self.get())->m_Value);
 	}
@@ -103,12 +103,12 @@ JPValue* JPPythonEnv::getJavaValue(PyObject* obj)
 JPClass* JPPythonEnv::getJavaClass(PyObject* obj)
 {
 	JPPyObject vobj(JPPyRef::_use, obj);
-	if (obj->ob_type == &PyJPClass::Type)
+	if (Py_TYPE(obj) == &PyJPClass::Type)
 		return ((PyJPClass*) obj)->m_Class;
 	if (!JPPyObject::hasAttrString(obj, __javaclass__))
 		return NULL;
 	JPPyObject self(JPPyObject::getAttrString(obj, __javaclass__));
-	if (self.get()->ob_type == &PyJPClass::Type)
+	if (Py_TYPE(self.get()) == &PyJPClass::Type)
 	{
 		return ((PyJPClass*) self.get())->m_Class;
 	}
@@ -117,12 +117,12 @@ JPClass* JPPythonEnv::getJavaClass(PyObject* obj)
 
 JPProxy* JPPythonEnv::getJavaProxy(PyObject* obj)
 {
-	if (obj->ob_type == &PyJPProxy::Type)
+	if (Py_TYPE(obj) == &PyJPProxy::Type)
 		return ((PyJPProxy*) obj)->m_Proxy;
 	if (!JPPyObject::hasAttrString(obj, __javaproxy__))
 		return 0;
 	JPPyObject self(JPPyObject::getAttrString(obj, __javaproxy__));
-	if (self.get()->ob_type == &PyJPProxy::Type)
+	if (Py_TYPE(self.get()) == &PyJPProxy::Type)
 	{
 		return (((PyJPProxy*) self.get())->m_Proxy);
 	}

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -81,7 +81,7 @@ void PyJPArray::initType(PyObject* module)
 
 bool PyJPArray::check(PyObject* o)
 {
-	return o->ob_type == &PyJPArray::Type;
+	return Py_TYPE(o) == &PyJPArray::Type;
 }
 
 JPPyObject PyJPArray::alloc(JPArray* obj)

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -94,7 +94,7 @@ void PyJPClass::initType(PyObject* module)
 
 bool PyJPClass::check(PyObject* o)
 {
-	return o->ob_type == &PyJPClass::Type;
+	return Py_TYPE(o) == &PyJPClass::Type;
 }
 
 JPPyObject PyJPClass::alloc(JPClass* cls)

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -163,5 +163,5 @@ void PyJPProxy::__dealloc__(PyJPProxy* self)
 
 bool PyJPProxy::check(PyObject* o)
 {
-	return o->ob_type == &PyJPProxy::Type;
+	return Py_TYPE(o) == &PyJPProxy::Type;
 }

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -78,7 +78,7 @@ void PyJPValue::initType(PyObject* module)
 
 bool PyJPValue::check(PyObject* o)
 {
-	return o->ob_type == &PyJPValue::Type;
+	return Py_TYPE(o) == &PyJPValue::Type;
 }
 
 // These are from the internal methods when we alreayd have the jvalue
@@ -154,7 +154,7 @@ int PyJPValue::__init__(PyJPValue* self, PyObject* args, PyObject* kwargs)
 		if (type->canConvertToJava(value) == JPMatch::_none)
 		{
 			stringstream ss;
-			ss << "Unable to convert " << value->ob_type->tp_name << " to java type " << type->toString();
+			ss << "Unable to convert " << Py_TYPE(value)->tp_name << " to java type " << type->toString();
 			PyErr_SetString(PyExc_TypeError, ss.str().c_str());
 			return -1;
 		}


### PR DESCRIPTION
These are a set of minor changes from the other major fork of JPype.  Although the master is not mergeable, I scanned the entire source to determine what if anything we have not yet overrun.  

Thus far there were very minor differences in the API.

 -  JProxy uses ``dictionary`` rather than ``dict`` as its kwarg
 -  cygwin contains an extra function for reprocessing the JVM arguments
 -  minor differences in the C++ layer from the branch point
 -  renames and such

I pulled the test bench from that fork into our own and ran it with only the one API difference being hit.
As the code is not mergeable I replicated the relevant changes in the C++ layer.  (removed direct access to Python structure rather than using macro, and error reporting for arrays.)

See Thrameos/jpype#41 and tcalmant/jpype-py3#28

I think that tcalmant fork can safely be repointed back to the org copy.  Now I just need to understand the  [ha_JPype1 ](https://libraries.io/pypi/ha_JPype1) fork.  I personally find it rather antisocial to fork an active project, change the maintainer pointer, add one to the version number and then push it out to the distributions.