### PR TITLE
Clean up pass on exceptions.

### DIFF
--- a/native/common/jp_array.cpp
+++ b/native/common/jp_array.cpp
@@ -89,7 +89,7 @@ void JPArray::setRange(jsize start, jsize stop, PyObject* val)
 		// the length of the array.  But java arrays are immutable in length.
 		std::stringstream out;
 		out << "Slice assignment must be of equal lengths : " << len << " != " << plength;
-		JP_RAISE_RUNTIME_ERROR(out.str());
+		JP_RAISE_VALUE_ERROR(out.str());
 	}
 
 	JP_TRACE("Call component set range");
@@ -111,7 +111,7 @@ void JPArray::setItem(jsize ndx, PyObject* val)
 
 	if (compType->canConvertToJava(val) <= JPMatch::_explicit)
 	{
-		JP_RAISE_RUNTIME_ERROR("Unable to convert.");
+		JP_RAISE_TYPE_ERROR("Unable to convert.");
 	}
 
 	compType->setArrayItem(frame, m_Object.get(), ndx, val);

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -48,7 +48,7 @@ jobject JPByteType::convertToDirectBuffer(PyObject* src)
 		return frame.keep(frame.NewDirectByteBuffer(rawData, size));
 	}
 
-	JP_RAISE_RUNTIME_ERROR("Unable to convert to Direct Buffer");
+	JP_RAISE_TYPE_ERROR("Unable to convert to Direct Buffer");
 	JP_TRACE_OUT;
 }
 

--- a/native/common/jp_field.cpp
+++ b/native/common/jp_field.cpp
@@ -70,7 +70,7 @@ void JPField::setStaticField(PyObject* val)
 	{
 		stringstream err;
 		err << "Field " << m_Name << " is read-only";
-		JP_RAISE_RUNTIME_ERROR(err.str().c_str());
+		JP_RAISE_ATTRIBUTE_ERROR(err.str().c_str());
 	}
 
 	if (m_TypeCache->canConvertToJava(val) <= JPMatch::_explicit)
@@ -105,7 +105,7 @@ void JPField::setField(jobject inst, PyObject* val)
 	{
 		stringstream err;
 		err << "Field " << m_Name << " is read-only";
-		JP_RAISE_RUNTIME_ERROR(err.str().c_str());
+		JP_RAISE_ATTRIBUTE_ERROR(err.str().c_str());
 	}
 
 	if (m_TypeCache->canConvertToJava(val) <= JPMatch::_explicit)

--- a/native/common/jp_value.cpp
+++ b/native/common/jp_value.cpp
@@ -20,7 +20,11 @@ jobject JPValue::getJavaObject() const
 {
 	if (dynamic_cast<JPPrimitiveType*> (m_Class) != m_Class)
 		return m_Value.l;
-	JP_RAISE_RUNTIME_ERROR("access primitive value as object");
+
+	// This method is only used internally, thus it requires a logical code
+	// error to trigger. We will use type error in case there is some
+	// way a user can trigger it.
+	JP_RAISE_TYPE_ERROR("access Java primitive value as Java object");
 }
 
 jclass JPValue::getJavaClass() const

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -154,6 +154,17 @@ class ArrayTestCase(common.JPypeTestCase):
         # with self.assertRaises(jpype._):
         #    jpype.JArray(jpype.JShort)([2**16/2])
 
+    def testJArrayConversionFail(self):
+        jarr = jpype.JArray(jpype.JInt)(self.VALUES)
+        with self.assertRaises(TypeError):
+            jarr[1] = 'a'
+
+    def testJArraySliceLength(self):
+        jarr = jpype.JArray(jpype.JInt)(self.VALUES)
+        jarr[1:2] = [1]
+        with self.assertRaises(ValueError):
+            jarr[1:2] = [1,2,3]
+
     def testJArrayConversionInt(self):
         jarr = jpype.JArray(jpype.JInt)(self.VALUES)
         result = jarr[0: len(jarr)]


### PR DESCRIPTION
This one makes a last minute attempt to make the remaining runtime exceptions into the correct exception in python.  I added tests where I could.  Most of the changes are redundant as there is error checking for in the python layer for much of it which was already raising the appropriate type.  This pull just adds consistency between the C++ and Python layer.