### PR TITLE
Add better error messages to jpype.imports

### DIFF
--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -95,6 +95,18 @@ def _hasClassPath(args):
             return True
     return False
 
+def _handleClassPath(clsList):
+    out = []
+    for s in clsList:
+        if not isinstance(s, (str, _jtypes._unicode)):
+            raise TypeError("Classpath elements must be strings")
+        if s.endswith('*'):
+            import glob
+            out.extend(glob.glob(s+'.jar'))
+        else:
+            out.append(s)
+    return _classpath._SEP.join(out)
+
 
 _JVM_started = False
 
@@ -165,10 +177,11 @@ def startJVM(*args, **kwargs):
     # Handle strings and list of strings.
     if classpath:
         if isinstance(classpath, (str, _jtypes._unicode)):
-            args.append('-Djava.class.path=%s' % classpath)
+            args.append('-Djava.class.path=%s' % _handleClassPath([classpath]))
+        elif hasattr(classpath, '__iter__'):
+            args.append('-Djava.class.path=%s' % _handleClassPath(classpath))
         else:
-            args.append('-Djava.class.path=%s' %
-                        (_classpath._SEP.join(classpath)))
+            raise TypeError("Unknown class path element")
 
     ignoreUnrecognized = kwargs.pop('ignoreUnrecognized', False)
 

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -244,16 +244,16 @@ class _JImport(object):
             return jtype
 
         # If the java class does not exist, throw a ClassNotFound exception
-        raise ImportError("Unable to find java class " + jname)
+        raise ImportError("Unable to find java class '%s'"%jname)
 
     def __setattr__(self, name, value):
         if name.startswith('__'):
-            raise AttributeError("Module does not allow setting of %s" % name)
+            raise AttributeError("Module does not allow setting of '%s'" % name)
         if hasattr(value, '__javaclass__'):
             return object.__setattr__(self, name, getattr(value, '__javaclass__'))
         if isinstance(value, (_JImport, _ModuleType)):
             return object.__setattr__(self, name, value)
-        raise AttributeError("JImport may not set attribute %s" % name)
+        raise AttributeError("JImport may not set attribute '%s'" % name)
 
 
 # In order to get properties to be attached to the _JImport class,

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -94,11 +94,44 @@ def _keywordWrap(name):
     return name
 
 
+_java_lang_Class = None
+_java_lang_NoClassDefFoundError = None
+_java_lang_ClassNotFoundException = None
+_java_lang_UnsupportedClassVersionError = None
 def _getJavaClass(javaname):
+    global _java_lang_Class
+    global _java_lang_NoClassDefFoundError
+    global _java_lang_ClassNotFoundException
+    global _java_lang_UnsupportedClassVersionError
+    if not _java_lang_Class:
+      _java_lang_Class = _jclass.JClass("java.lang.Class")
+      _java_lang_ClassNotFoundException = _jclass.JClass("java.lang.ClassNotFoundException")
+      _java_lang_NoClassDefFoundError = _jclass.JClass("java.lang.NoClassDefFoundError")
+      _java_lang_UnsupportedClassVersionError = _jclass.JClass("java.lang.UnsupportedClassVersionError")
+
+    err = None
     try:
-        return _jclass.JClass(javaname)
-    except Exception:
+        # Use forname because it give better diagnostics
+        cls = _java_lang_Class.forName(javaname)
+        return _jclass.JClass(cls)
+
+    # Not found is acceptable
+    except _java_lang_ClassNotFoundException:
         return None
+
+    # Missing dependency
+    except _java_lang_NoClassDefFoundError as ex:
+        missing = str(ex).replace('/','.')
+        err = "Unable to import '%s' due to missing dependency '%s'"%(javaname, missing)
+
+    # Wrong Java version
+    except _java_lang_UnsupportedClassVersionError as ex:
+        err = "Unable to import '%s' due to incorrect Java version"%(javaname)
+
+    # Otherwise!?
+    except Exception as ex:
+        err = "Unable to import '%s' due to unexpected exception"
+    raise ImportError(err)
 
 # FIXME imports of static fields not working for now.
 


### PR DESCRIPTION
This has burned me for the last time.  Die! Die! Die!

This pull request improves the error reporting for jpype.imports to try to report wrong version and missing dependencies.   The JClass method we were using gave back the same exception every time thus making it hard to distinguish the source of the problem.  To debug this, the user would then need to call forName to find the actual source of the problem.  This pull request cuts out the middle man and just directly calls forName to get class in the first place.  The performance is slightly worse, but this is a very low frequency operation.