### PR TITLE
Enable option to support legacy conversion of strings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 *.cpp text eol=lf
 *.c text eol=lf
 *.h text eol=lf
+*.java text eol=lf
 
 *.xml text eol=lf
 *.md text

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -123,8 +123,14 @@ def startJVM(*args, **kwargs):
         cast to Python strings. This option is to support legacy code
         for which conversion of Python strings was the default. This
         will globally change the behavior of all calls using
-        strings, and is not recommended for newly developed
-        code.
+        strings, and a value of True is NOT recommended for newly 
+        developed code.
+
+        The default value for this option during 0.7 series is 
+        True.  The option will be False starting in 0.8. A
+        warning will be issued if this option is not specified
+        during the transition period.
+
 
     Raises:
       OSError: if the JVM cannot be started or is already running.
@@ -177,7 +183,21 @@ def startJVM(*args, **kwargs):
                         (_classpath._SEP.join(classpath)))
 
     ignoreUnrecognized = kwargs.pop('ignoreUnrecognized', False)
-    convertStrings = kwargs.pop('convertStrings', False)
+
+    if not "convertStrings" in kwargs:
+        import warnings
+        warnings.warn("""
+-------------------------------------------------------------------------------
+Deprecated: convertStrings was not specified when starting the JVM. The default
+behavior in JPype will be False starting in JPype 0.8. The recommended setting
+for new code is convertStrings=False.  The legacy value of True was assumed for
+this session. If you are a user of an application that reported this warning,
+please file a ticket with the developer.
+-------------------------------------------------------------------------------
+""")
+
+    convertStrings = kwargs.pop('convertStrings', True)
+
 
     if kwargs:
         raise TypeError("startJVM() got an unexpected keyword argument '%s'"

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -101,7 +101,7 @@ _JVM_started = False
 def startJVM(*args, **kwargs):
     """
     Starts a Java Virtual Machine.  Without options it will start
-    the JVM with the default classpath and jvmpath.  
+    the JVM with the default classpath and jvmpath.
 
     The default classpath is determined by ``jpype.getClassPath()``.
     The default jvmpath is determined by ``jpype.getDefaultJVMPath()``.
@@ -112,17 +112,23 @@ def startJVM(*args, **kwargs):
 
     Keyword Arguments:
       jvmpath (str):  Path to the jvm library file,
-        Typically one of (``libjvm.so``, ``jvm.dll``, ...) 
+        Typically one of (``libjvm.so``, ``jvm.dll``, ...)
         Using None will apply the default jvmpath.
       classpath (str,[str]): Set the classpath for the jvm.
         This will override any classpath supplied in the arguments
         list. A value of None will give no classpath to JVM.
       ignoreUnrecognized (bool): Option to JVM to ignore
         invalid JVM arguments. Default is False.
+      convertStrings (bool): Option to JPype to force Java strings to
+        cast to Python strings. This option is to support legacy code
+        for which conversion of Python strings was the default. This
+        will globally change the behavior of all calls using
+        strings, and is not recommended for newly developed
+        code.
 
     Raises:
       OSError: if the JVM cannot be started or is already running.
-      TypeError: if an invalid keyword argument is supplied 
+      TypeError: if an invalid keyword argument is supplied
         or a keyword argument conflicts with the arguments.
 
      """
@@ -171,12 +177,13 @@ def startJVM(*args, **kwargs):
                         (_classpath._SEP.join(classpath)))
 
     ignoreUnrecognized = kwargs.pop('ignoreUnrecognized', False)
+    convertStrings = kwargs.pop('convertStrings', False)
 
     if kwargs:
         raise TypeError("startJVM() got an unexpected keyword argument '%s'"
                         % (','.join([str(i) for i in kwargs])))
 
-    _jpype.startup(jvmpath, tuple(args), ignoreUnrecognized)
+    _jpype.startup(jvmpath, tuple(args), ignoreUnrecognized, convertStrings)
     _initialize()
 
 
@@ -188,8 +195,8 @@ def attachToJVM(jvm):
 def shutdownJVM():
     """ Shuts down the JVM.
 
-    This method shuts down the JVM and thus disables access to existing 
-    Java objects. Due to limitations in the JPype, it is not possible to 
+    This method shuts down the JVM and thus disables access to existing
+    Java objects. Due to limitations in the JPype, it is not possible to
     restart the JVM after being terminated.
     """
     _jpype.shutdown()
@@ -198,10 +205,10 @@ def shutdownJVM():
 def isThreadAttachedToJVM():
     """ Checks if a thread is attached to the JVM.
 
-    Python automatically attaches threads when a Java method is called. 
-    This creates a resource in Java for the Python thread. This method 
-    can be used to check if a Python thread is currently attached so that 
-    it can be disconnected prior to thread termination to prevent leaks.  
+    Python automatically attaches threads when a Java method is called.
+    This creates a resource in Java for the Python thread. This method
+    can be used to check if a Python thread is currently attached so that
+    it can be disconnected prior to thread termination to prevent leaks.
 
     Returns:
       True if the thread is attached to the JVM, False if the thread is
@@ -213,8 +220,8 @@ def isThreadAttachedToJVM():
 def attachThreadToJVM():
     """ Attaches a thread to the JVM.
 
-    The function manually connects a thread to the JVM to allow access to 
-    Java objects and methods. JPype automaticatlly attaches when a Java 
+    The function manually connects a thread to the JVM to allow access to
+    Java objects and methods. JPype automaticatlly attaches when a Java
     resource is used, so a call to this is usually not needed.
 
     Raises:
@@ -228,7 +235,7 @@ def detachThreadFromJVM():
 
     This function detaches the thread and frees the associated resource in
     the JVM. For codes making heavy use of threading this should be used
-    to prevent resource leaks. The thread can be reattached, so there 
+    to prevent resource leaks. The thread can be reattached, so there
     is no harm in detaching early or more than once. This method cannot fail
     and there is no harm in calling it when the JVM is not running.
     """
@@ -239,7 +246,7 @@ def synchronized(obj):
     """ Creates a resource lock for a Java object.
 
     Produces a monitor object. During the lifespan of the monitor the Java
-    will not be able to acquire a thread lock on the object. This will 
+    will not be able to acquire a thread lock on the object. This will
     prevent multiple threads from modifying a shared resource.
 
     This should always be used as part of a Python ``with`` startment.
@@ -306,8 +313,8 @@ def get_default_jvm_path(*args, **kwargs):
 def getJVMVersion():
     """ Get the JVM version if the JVM is started.
 
-    This function can be used to determine the version of the JVM. It is 
-    useful to help determine why a Jar has failed to load.  
+    This function can be used to determine the version of the JVM. It is
+    useful to help determine why a Jar has failed to load.
 
     Returns:
       A typle with the (major, minor, revison) of the JVM if running.

--- a/native/common/include/jp_env.h
+++ b/native/common/include/jp_env.h
@@ -44,7 +44,7 @@ namespace JPEnv
 	 * Load the JVM
 	 * TODO : add the non-string parameters, for possible callbacks
 	 */
-	void loadJVM(const string& vmPath, char ignoreUnrecognized, const StringVector& args);
+	void loadJVM(const string& vmPath, const StringVector& args, bool ignoreUnrecognized, bool convertStrings);
 
 	void attachJVM(const string& vmPath);
 
@@ -62,6 +62,8 @@ namespace JPEnv
 
 	void CreateJavaVM(void* arg);
 	void GetCreatedJavaVM();
+
+        bool getConvertStrings();
 }
 
 #endif // _JPENV_H_

--- a/native/common/jp_env.cpp
+++ b/native/common/jp_env.cpp
@@ -26,6 +26,7 @@
 namespace
 { // impl details
 	JavaVM* s_JavaVM = NULL;
+	bool s_ConvertStrings = false;
 
 	jint(JNICALL *CreateJVM_Method)(JavaVM **pvm, void **penv, void *args);
 	jint(JNICALL *GetCreatedJVMs_Method)(JavaVM **pvm, jsize size, jsize* nVms);
@@ -137,9 +138,10 @@ void loadEntryPoints(const string& path)
 	GetCreatedJVMs_Method = (jint(JNICALL *)(JavaVM **, jsize, jsize*))GetAdapter()->getSymbol("JNI_GetCreatedJavaVMs");
 }
 
-void JPEnv::loadJVM(const string& vmPath, char ignoreUnrecognized, const StringVector& args)
+void JPEnv::loadJVM(const string& vmPath, const StringVector& args, bool ignoreUnrecognized, bool convertStrings)
 {
 	JP_TRACE_IN("JPEnv::loadJVM");
+        s_ConvertStrings = convertStrings;
 
 	// Get the entry points in the shared library
 	loadEntryPoints(vmPath);
@@ -175,6 +177,11 @@ void JPEnv::loadJVM(const string& vmPath, char ignoreUnrecognized, const StringV
 	JPProxy::init();
 	JPReferenceQueue::startJPypeReferenceQueue(true);
 	JP_TRACE_OUT;
+}
+
+bool JPEnv::getConvertStrings()
+{
+  return s_ConvertStrings;
 }
 
 void JPEnv::shutdown()

--- a/native/common/jp_stringclass.cpp
+++ b/native/common/jp_stringclass.cpp
@@ -33,6 +33,12 @@ JPPyObject JPStringClass::convertToPythonObject(jvalue val)
 		return JPPyObject::getNone();
 	}
 
+        if (JPEnv::getConvertStrings())
+        {
+		string str = JPJni::toStringUTF8((jstring)(val.l));
+		return JPPyString::fromStringUTF8(str);
+        }
+
 	return JPPythonEnv::newJavaObject(JPValue(this, val));
 	JP_TRACE_OUT;
 }

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 
 #include <pyjp.h>
@@ -62,7 +62,7 @@ PyMODINIT_FUNC PyInit__jpype()
 PyMODINIT_FUNC init_jpype()
 #endif
 {
-	// This is required for python versions prior to 3.7.  
+	// This is required for python versions prior to 3.7.
 	// It is called by the python initialization starting from 3.7,
 	// but is safe to call afterwards.
 	PyEval_InitThreads();
@@ -117,8 +117,10 @@ PyObject* PyJPModule::startup(PyObject* obj, PyObject* args)
 		PyObject* vmOpt;
 		PyObject* vmPath;
 		char ignoreUnrecognized = true;
+		char convertStrings = false;
 
-		if (!PyArg_ParseTuple(args, "OO!b|", &vmPath, &PyTuple_Type, &vmOpt, &ignoreUnrecognized))
+		if (!PyArg_ParseTuple(args, "OO!bb", &vmPath, &PyTuple_Type, &vmOpt,
+                      &ignoreUnrecognized, &convertStrings))
 		{
 			return NULL;
 		}
@@ -151,7 +153,7 @@ PyObject* PyJPModule::startup(PyObject* obj, PyObject* args)
 			}
 		}
 
-		JPEnv::loadJVM(cVmPath, ignoreUnrecognized, args);
+		JPEnv::loadJVM(cVmPath, args, ignoreUnrecognized, convertStrings);
 		Py_RETURN_NONE;
 	}
 	PY_STANDARD_CATCH;
@@ -324,7 +326,7 @@ PyObject* PyJPModule::convertToDirectByteBuffer(PyObject* self, PyObject* args)
 			// Bind lifespan of the python to the java object.
 			JPReferenceQueue::registerRef(ref, src);
 
-			// Convert to python object 
+			// Convert to python object
 
 			jvalue v;
 			v.l = ref;

--- a/test/harness/jpype/array/TestArray.java
+++ b/test/harness/jpype/array/TestArray.java
@@ -27,7 +27,7 @@ public class TestArray
     
     public Object[] getSubClassArray()
     {
-      return new String[] { "aaa", "bbb" };
+      return new Integer[] { 1, 2 };
     }
 
     public Object getArrayAsObject()

--- a/test/harness/jpype/str/StringFunction.java
+++ b/test/harness/jpype/str/StringFunction.java
@@ -1,0 +1,6 @@
+package jpype.str;
+
+public interface StringFunction
+{
+	public String call(String s);
+}

--- a/test/harness/jpype/str/Test.java
+++ b/test/harness/jpype/str/Test.java
@@ -1,0 +1,28 @@
+package jpype.str;
+
+public class Test
+{
+
+	public static String staticField = "staticField";
+	public String memberField = "memberField";
+
+	public static String staticCall()
+	{
+		return "staticCall";
+	}
+
+	public String memberCall()
+	{
+		return "memberCall";
+	}
+
+	public static final String array[] =
+	{"apples","banana","cherries","dates","elderberry"};
+
+	public static String callProxy(StringFunction f, String s)
+	{
+		return f.call(s);
+	}
+}
+
+

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -91,7 +91,7 @@ class ArrayTestCase(common.JPypeTestCase):
     def testGetSubclass(self):
         t = JClass("jpype.array.TestArray")()
         v = t.getSubClassArray()
-        self.assertTrue(isinstance(v[0], jpype.JString))
+        self.assertTrue(isinstance(v[0], jpype.java.lang.Integer))
 
     def testGetArrayAsObject(self):
         t = JClass("jpype.array.TestArray")()

--- a/test/jpypetest/test_exc.py
+++ b/test/jpypetest/test_exc.py
@@ -40,7 +40,7 @@ class ExceptionTestCase(common.JPypeTestCase):
             self.assertIs(type(ex), java.lang.RuntimeException)
             self.assertEqual('Foo', ex.message())
             trace = ex.stacktrace()
-            self.assertTrue(trace.startsWith(
+            self.assertTrue(str(trace).startswith(
                 'java.lang.RuntimeException: Foo'))
 
     def testExceptionByJavaClass(self):
@@ -51,7 +51,7 @@ class ExceptionTestCase(common.JPypeTestCase):
             self.assertIs(type(ex), java.lang.RuntimeException)
             self.assertEqual('Foo', ex.message())
             trace = ex.stacktrace()
-            self.assertTrue(trace.startsWith(
+            self.assertTrue(str(trace).startswith(
                 'java.lang.RuntimeException: Foo'))
 
     def testThrowException(self):

--- a/test/jpypetest/test_legacy.py
+++ b/test/jpypetest/test_legacy.py
@@ -1,0 +1,75 @@
+# *****************************************************************************
+#   Copyright 2019 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+import jpype
+import common
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+def proxy(s):
+    if not isinstance(s, str):
+        raise TypeError("Fail")
+    return s
+
+# This is a test case to exercise all of the paths that pass through 
+# the string conversion to make sure all are exercised.
+class LegacyTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self._test = jpype.JClass("jpype.str.Test")
+        self._intf = jpype.JClass("jpype.str.StringFunction")
+
+    def testStaticField(self):
+        s = self._test.staticField
+        self.assertEqual(s, "staticField")
+        self.assertIsInstance(s, str)
+
+    def testMemberField(self):
+        s = self._test().memberField
+        self.assertEqual(s, "memberField")
+        self.assertIsInstance(s, str)
+
+    def testStaticMethod(self):
+        s = self._test.staticCall()
+        self.assertEqual(s, "staticCall")
+        self.assertIsInstance(s, str)
+
+    def testMemberMethod(self):
+        s = self._test().memberCall()
+        self.assertEqual(s, "memberCall")
+        self.assertIsInstance(s, str)
+
+    def testArrayItem(self):
+        tc = ('apples','banana','cherries','dates','elderberry')
+        for i in range(0,5):
+            s = self._test.array[i]
+            self.assertEqual(s, tc[i])
+            self.assertIsInstance(s, str)
+
+    def testArrayRange(self):
+        tc = ('apples','banana','cherries','dates','elderberry')
+        slc = self._test.array[1:-1]
+        self.assertEqual(slc, tc[1:-1])
+        self.assertIsInstance(slc[1], str)
+
+    def testProxy(self):
+        p = jpype.JProxy([self._intf],dict={'call':proxy})
+        r = self._test().callProxy(p, "roundtrip")
+        self.assertEqual(r, "roundtrip")
+        self.assertIsInstance(r, str)
+

--- a/test/jpypetest/test_utf8.py
+++ b/test/jpypetest/test_utf8.py
@@ -193,7 +193,7 @@ class Utf8TestCase(common.JPypeTestCase):
         """
         for lbl, val in self.TDICT:
             utf8_test = self.Utf8Test(val)
-            res = utf8_test.get().__unicode__()
-          #  res = unicode(utf8_test.get())
+          #  res = utf8_test.get().__unicode__()
+            res = unicode(utf8_test.get())
             self.assertEqual(
                 val, res, "Utf8Test.java string upload for: " + lbl)


### PR DESCRIPTION
Attempt to support the legacy behavior of string conversion on return.  I am not sure how well this matches with the original.  We had no test bench to check before and after with the switch thrown.  For now everything is converting on return regardless of the source requesting conversion (BFFI approach).  This should match the old behavior for methods and likely fields.  But may not be a good match for other paths.  The most problematic are likely the ArrayItem, ArrayRange, and Proxy args, where conversion does not make as much sense.  I can add source tracking flags on the call if we need finer grain controls.

To use the legacy behavior start the JVM with ``convertStrings=True``.  The behavior is currently set once, because I really don't want to try to deal with the issues of having this change during operation in the future especially if multithreading were used.

A reformatter removed some dangling spaces which resulted in some extra lines in the PR.  Sorry.