### PR TITLE
Improvements to JProxy

### DIFF
--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -14,8 +14,12 @@
 #   limitations under the License.
 #
 # *****************************************************************************
-import collections
 import sys as _sys
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
+
 
 import _jpype
 from . import _jclass
@@ -245,7 +249,7 @@ def _JArrayNewClass(cls, ndims=1):
 # Cannot be Mutable because java arrays are fixed in length
 
 def _isIterable(obj):
-    if isinstance(obj, collections.Sequence):
+    if isinstance(obj, Sequence):
         return True
     if hasattr(obj, '__len__') and hasattr(obj, '__iter__'):
         return True

--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -14,7 +14,10 @@
 #   limitations under the License.
 #
 # *****************************************************************************
-import collections
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from . import _jclass
 from . import _jcustomizer
@@ -24,7 +27,7 @@ JOverride = _jclass.JOverride
 
 
 def isPythonSequence(v):
-    if isinstance(v, collections.Sequence):
+    if isinstance(v, Sequence):
         if not hasattr(v.__class__, '__metaclass__') \
            or v.__class__.__metaclass__ is _jclass._JavaClass:
             return True

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -30,7 +30,7 @@ if sys.version > '3':
 # so we can properly handle name mangling on the override.
 
 
-def _createJProxy(cls, intf, **kwargs):
+def _createJProxy(cls, *intf, **kwargs):
     """ (internal) Create a proxy from a python class with
     @JOverride notation on methods.
     """
@@ -52,7 +52,7 @@ def _createJProxy(cls, intf, **kwargs):
             if method.getModifiers() & 1024 == 0:
                 continue
             if not str(method.getName()) in overrides:
-                raise NotImplementedError("Interface %s requires method %s to be implemented." % (
+                raise NotImplementedError("Interface '%s' requires method '%s' to be implemented." % (
                     interface.class_.getName(), method.getName()))
 
     # Define a lookup interface
@@ -90,53 +90,64 @@ def JImplements(*args, **kwargs):
     should have a @JOverride annotation.
 
     Args:
-      interfaces (str): Strings for each Java interface this proxy is to
-        implement.
+      interfaces (str*,JClass*): Strings or JClasses for each Java interface
+        this proxy is to implement.
 
     Example:
 
       .. code-block:: python
 
-          @JImplement("org.my.Interface")
+          @JImplement("java.lang.Runnable")
+          class MyImpl(object):
+             @JOverride
+             def run(self, arg):
+               pass
+
+          @JImplement("org.my.Interface1", "org.my.Interface2")
           class MyImpl(object):
              @JOverride
              def method(self, arg):
                pass
 
     """
-    def f(cls):
-        return _createJProxy(cls, args, **kwargs)
-    return f
+    def JProxyCreator(cls):
+        return _createJProxy(cls, *args, **kwargs)
+    return JProxyCreator
 
 
 def _convertInterfaces(intf):
     """ (internal) Convert a list of interface names into
     a list of interfaces suitable for a proxy.
     """
-    # We operate on lists of interfaces, so a single element is promoted
-    # to a list. Python considers strings to be sequences, so need
-    # special handling for that case.
-    if isinstance(intf, (str, unicode)) or not isinstance(intf, collections.Sequence):
-        intf = [intf]
-
-    # Verify that the list contains the required types
-    actualIntf = []
-    for i in intf:
-        if isinstance(i, str) or isinstance(i, unicode):
-            actualIntf.append(_jclass.JClass(i))
-        elif isinstance(i, _jclass.JClass):
-            actualIntf.append(i)
+    # Flatten the list
+    intflist = []
+    for item in intf:
+        if isinstance(item, (str, unicode)) or not hasattr(item, '__iter__'):
+            intflist.append(item)
         else:
-            raise TypeError("JProxy requires java interface classes "
-                            "or the names of java interfaces classes: {0}".format(i.__name))
-    # Check that all are interfaces
-    for i in actualIntf:
-        if not issubclass(i, _jclass.JInterface):
-            raise TypeError("JProxy requires java interface classes "
-                            "or the names of java interfaces classes: {0}"
-                            .format(i.__name__))
+            intflist.extend(item)
 
-    return actualIntf
+    # Look up the classes if given as a string
+    actualIntf = set()
+    for item in intflist:
+        if isinstance(item, (str, unicode)):
+            actualIntf.add(_jclass.JClass(item))
+        else:
+            actualIntf.add(item)
+
+    # Check that all are interfaces
+    if not actualIntf:
+        raise TypeError("At least one Java interface must be specified")
+
+    for cls in actualIntf:
+        # If it isn't a JClass, then it cannot be a Java interface
+        if not isinstance(cls, _jclass.JClass):
+            raise TypeError("'%s' is not a Java interface"%type(cls).__name__)
+        # Java concrete and abstract classes cannot be proxied
+        if not issubclass(cls, _jclass.JInterface):
+            raise TypeError("'%s' is not a Java interface"%cls.__name__)
+
+    return tuple(actualIntf)
 
 
 class JProxy(object):
@@ -164,7 +175,7 @@ class JProxy(object):
             whose names matches the java interfaces methods.
     """
 
-    def __init__(self, intf, dict=None, inst=None):
+    def __init__(self, *intf, dict=None, inst=None):
         # Convert the interfaces
         actualIntf = _convertInterfaces(intf)
 
@@ -187,4 +198,4 @@ class JProxy(object):
             # create a proxy
             self.__javaproxy__ = _jpype.PyJPProxy(inst, lookup, actualIntf)
             return
-        raise TypeError("a dict or instance must be supplied")
+        raise TypeError("a dict or inst must be specified")

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -175,9 +175,9 @@ class JProxy(object):
             whose names matches the java interfaces methods.
     """
 
-    def __init__(self, *intf, dict=None, inst=None):
+    def __init__(self, intf, dict=None, inst=None):
         # Convert the interfaces
-        actualIntf = _convertInterfaces(intf)
+        actualIntf = _convertInterfaces([intf])
 
         # Verify that one of the options has been selected
         if dict is not None and inst is not None:

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -114,8 +114,9 @@ def _convertInterfaces(intf):
     a list of interfaces suitable for a proxy.
     """
     # We operate on lists of interfaces, so a single element is promoted
-    # to a list
-    if not isinstance(intf, collections.Sequence):
+    # to a list. Python considers strings to be sequences, so need
+    # special handling for that case.
+    if isinstance(intf, (str, unicode)) or not isinstance(intf, collections.Sequence):
         intf = [intf]
 
     # Verify that the list contains the required types
@@ -177,6 +178,7 @@ class JProxy(object):
                 return d[name]
             # create a proxy
             self.__javaproxy__ = _jpype.PyJPProxy(dict, lookup, actualIntf)
+            return
 
         if inst is not None:
             # Define the lookup function based for a object instance
@@ -184,3 +186,5 @@ class JProxy(object):
                 return getattr(d, name)
             # create a proxy
             self.__javaproxy__ = _jpype.PyJPProxy(inst, lookup, actualIntf)
+            return
+        raise TypeError("a dict or instance must be supplied")

--- a/native/common/include/jp_methodoverload.h
+++ b/native/common/include/jp_methodoverload.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _JPMETHODOVERLOAD_H_
 #define _JPMETHODOVERLOAD_H_
@@ -62,10 +62,10 @@ public:
 	 *
 	 * @param isInstance is true if the first argument is an instance object.
 	 * @param args is a list of arguments including the instance.
-	 * 
+	 *
 	 */
 	JPMatch matches(bool isInstance, JPPyObjectVector& args) ;
-	JPPyObject invoke(JPMatch& match, JPPyObjectVector&  arg);
+	JPPyObject invoke(JPMatch& match, JPPyObjectVector&  arg, bool instance);
 	JPValue  invokeConstructor(JPMatch& match, JPPyObjectVector& arg);
 
 	bool isStatic() const
@@ -111,14 +111,14 @@ public:
 	bool checkMoreSpecificThan(JPMethodOverload* other) const;
 
 	/** Used to determine if a bean get property should be added to the class.
-	 * 
-	 * FIXME This does not check for begins with "get" 
+	 *
+	 * FIXME This does not check for begins with "get"
 	 */
 	bool isBeanAccessor();
 
 	/** Used to determine if a bean set property should be added to the class.
-	 * 
-	 * FIXME This does not check for begins with "set" or "is" 
+	 *
+	 * FIXME This does not check for begins with "set" or "is"
 	 */
 	bool isBeanMutator();
 

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -254,7 +254,7 @@ JPPyObject JPMethod::invoke(JPPyObjectVector& args, bool instance)
 {
 	JP_TRACE_IN("JPMethod::invoke");
 	JPMatch match = findOverload(args, instance);
-	return match.overload->invoke(match, args);
+	return match.overload->invoke(match, args, instance);
 	JP_TRACE_OUT;
 }
 

--- a/native/common/jp_methodoverload.cpp
+++ b/native/common/jp_methodoverload.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #include <jpype.h>
 
@@ -244,7 +244,7 @@ void JPMethodOverload::packArgs(JPMatch& match, vector<jvalue>& v, JPPyObjectVec
 	JP_TRACE_OUT;
 }
 
-JPPyObject JPMethodOverload::invoke(JPMatch& match, JPPyObjectVector& arg)
+JPPyObject JPMethodOverload::invoke(JPMatch& match, JPPyObjectVector& arg, bool instance)
 {
 	JP_TRACE_IN("JPMethodOverload::invoke");
 	ensureTypeCache();
@@ -268,7 +268,7 @@ JPPyObject JPMethodOverload::invoke(JPMatch& match, JPPyObjectVector& arg)
 		JPValue* selfObj = JPPythonEnv::getJavaValue(arg[0]);
 		jobject c = selfObj->getJavaObject();
 		jclass clazz = NULL;
-		if (!m_IsAbstract)
+		if (!m_IsAbstract && !instance)
 			clazz = m_Class->getJavaClass();
 		return retType->invoke(frame, c, clazz, m_MethodID, &v[0]);
 	}

--- a/native/python/include/pyjp_method.h
+++ b/native/python/include/pyjp_method.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _PYMETHOD_H_
 #define _PYMETHOD_H_
@@ -30,6 +30,9 @@ struct PyJPMethod
 
 	static PyObject*  __new__(PyTypeObject* self, PyObject* args, PyObject* kwargs);
 	static void       __dealloc__(PyJPMethod* o);
+	static int        traverse(PyJPMethod *self, visitproc visit, void *arg);
+	static int        clear(PyJPMethod *self);
+
 	static PyObject*  __get__(PyJPMethod* self, PyObject* obj, PyObject* type);
 	static PyObject*  __str__(PyJPMethod* o);
 	static PyObject*  __call__(PyJPMethod* self, PyObject* args, PyObject* kwargs);

--- a/native/python/include/pyjp_proxy.h
+++ b/native/python/include/pyjp_proxy.h
@@ -13,7 +13,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _PYJPPROXY_H_
 #define _PYJPPROXY_H_
@@ -29,6 +29,8 @@ struct PyJPProxy
 	static PyObject*   __new__(PyTypeObject* self, PyObject* args, PyObject* kwargs);
 	static int __init__(PyJPProxy* self, PyObject* args, PyObject* kwargs);
 	static void __dealloc__(PyJPProxy* self);
+	static int traverse(PyJPProxy *self, visitproc visit, void *arg);
+	static int clear(PyJPProxy *self);
 	static PyObject* __str__(PyJPProxy* self);
 
 	JPProxy* m_Proxy;

--- a/native/python/include/pyjp_value.h
+++ b/native/python/include/pyjp_value.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _PYJP_VALUE_H_
 #define _PYJP_VALUE_H_
@@ -32,6 +32,9 @@ struct PyJPValue
 	static PyObject*   __new__(PyTypeObject* self, PyObject* args, PyObject* kwargs);
 	static int         __init__(PyJPValue* self, PyObject* args, PyObject* kwargs);
 	static void        __dealloc__(PyJPValue* self);
+	static int         traverse(PyJPValue *self, visitproc visit, void *arg);
+	static int         clear(PyJPValue *self);
+
 	static PyObject*   __str__(PyJPValue* self);
 	static PyObject*   toString(PyJPValue* self);
 	static PyObject*   toUnicode(PyJPValue* self);

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -98,7 +98,7 @@ JPPyObject PyJPArray::alloc(JPArray* obj)
 PyObject* PyJPArray::__new__(PyTypeObject* type, PyObject* args, PyObject* kwargs)
 {
 	PyJPArray* self = (PyJPArray*) type->tp_alloc(type, 0);
-	self->m_Array = 0;
+	self->m_Array = NULL;
 	return (PyObject*) self;
 }
 

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -12,10 +12,10 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 
-// FIXME PyJPArray should inherit from PyJPValue so that arrays are 
+// FIXME PyJPArray should inherit from PyJPValue so that arrays are
 // properly specializations of value types.
 
 #include <pyjp.h>
@@ -88,7 +88,7 @@ JPPyObject PyJPArray::alloc(JPArray* obj)
 {
 	JPJavaFrame fame;
 	JP_TRACE_IN("PyJPArray::alloc");
-	PyJPArray* res = PyObject_New(PyJPArray, &PyJPArray::Type);
+	PyJPArray* res = (PyJPArray*) PyJPArray::Type.tp_alloc(&PyJPArray::Type, 0);
 	JP_PY_CHECK();
 	res->m_Array = obj;
 	return JPPyObject(JPPyRef::_claim, (PyObject*) res);

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -108,7 +108,7 @@ JPPyObject PyJPClass::alloc(JPClass* cls)
 PyObject* PyJPClass::__new__(PyTypeObject* type, PyObject* args, PyObject* kwargs)
 {
 	PyJPClass* self = (PyJPClass*) type->tp_alloc(type, 0);
-	self->m_Class = 0;
+	self->m_Class = NULL;
 	return (PyObject*) self;
 }
 

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 
 #include <pyjp.h>
@@ -99,7 +99,7 @@ bool PyJPClass::check(PyObject* o)
 
 JPPyObject PyJPClass::alloc(JPClass* cls)
 {
-	PyJPClass* res = PyObject_New(PyJPClass, &PyJPClass::Type);
+	PyJPClass* res = (PyJPClass*) PyJPClass::Type.tp_alloc(&PyJPClass::Type, 0);
 	JP_PY_CHECK();
 	res->m_Class = cls;
 	return JPPyObject(JPPyRef::_claim, (PyObject*) res);
@@ -310,7 +310,7 @@ PyObject* PyJPClass::isAssignableFrom(PyJPClass* self, PyObject* arg)
 		ASSERT_JVM_RUNNING("PyJPClass::isSubClass");
 		JPJavaFrame frame;
 
-		// We have to lookup the name by string here because the 
+		// We have to lookup the name by string here because the
 		// class wrapper may not exist.  This is used by the
 		// customizers.
 		PyObject* other;

--- a/native/python/pyjp_field.cpp
+++ b/native/python/pyjp_field.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #include <pyjp.h>
 
@@ -76,7 +76,7 @@ void PyJPField::initType(PyObject* module)
 
 JPPyObject PyJPField::alloc(JPField* m)
 {
-	PyJPField* res = PyObject_New(PyJPField, &PyJPField::Type);
+	PyJPField* res = (PyJPField*) PyJPField::Type.tp_alloc(&PyJPField::Type, 0);;
 	JP_PY_CHECK();
 	res->m_Field = m;
 	return JPPyObject(JPPyRef::_claim, (PyObject*) res);

--- a/native/python/pyjp_field.cpp
+++ b/native/python/pyjp_field.cpp
@@ -76,14 +76,15 @@ void PyJPField::initType(PyObject* module)
 
 JPPyObject PyJPField::alloc(JPField* m)
 {
-	PyJPField* res = (PyJPField*) PyJPField::Type.tp_alloc(&PyJPField::Type, 0);;
+	PyJPField* self = (PyJPField*) PyJPField::Type.tp_alloc(&PyJPField::Type, 0);;
 	JP_PY_CHECK();
-	res->m_Field = m;
-	return JPPyObject(JPPyRef::_claim, (PyObject*) res);
+	self->m_Field = m;
+	return JPPyObject(JPPyRef::_claim, (PyObject*) self);
 }
 
 void PyJPField::__dealloc__(PyJPField* self)
 {
+	self->m_Field = NULL;
 	Py_TYPE(self)->tp_free(self);
 }
 

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -47,8 +47,8 @@ PyTypeObject PyJPMethod::Type = {
 	/* tp_as_buffer      */ 0,
 	/* tp_flags          */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
 	/* tp_doc            */ "Java Method",
-	/* tp_traverse       */ (traverseproc) PyJPProxy::traverse,
-	/* tp_clear          */ (inquiry) PyJPProxy::clear,
+	/* tp_traverse       */ (traverseproc) PyJPMethod::traverse,
+	/* tp_clear          */ (inquiry) PyJPMethod::clear,
 	/* tp_richcompare    */ 0,
 	/* tp_weaklistoffset */ 0,
 	/* tp_iter           */ 0,
@@ -78,24 +78,20 @@ void PyJPMethod::initType(PyObject* module)
 JPPyObject PyJPMethod::alloc(JPMethod* m, PyObject* instance)
 {
 	JP_TRACE_IN("PyJPMethod::alloc");
-	PyJPMethod* res = (PyJPMethod*) PyJPMethod::Type.tp_alloc(&PyJPMethod::Type, 0);;
+	PyJPMethod* self = (PyJPMethod*) PyJPMethod::Type.tp_alloc(&PyJPMethod::Type, 0);;
 	JP_PY_CHECK();
-	res->m_Method = m;
-	res->m_Instance = instance;
-	if (instance != NULL)
-	{
-		JP_TRACE_PY("method alloc (inc)", instance);
-		Py_INCREF(instance);
-	}
-	return JPPyObject(JPPyRef::_claim, (PyObject*) res);
+	self->m_Method = m;
+	self->m_Instance = instance;
+	Py_XINCREF(self->m_Instance);
+	return JPPyObject(JPPyRef::_claim, (PyObject*) self);
 	JP_TRACE_OUT;
 }
 
 PyObject* PyJPMethod::__new__(PyTypeObject* type, PyObject* args, PyObject* kwargs)
 {
 	PyJPMethod* self = (PyJPMethod*) type->tp_alloc(type, 0);
-	self->m_Method = 0;
-	self->m_Instance = 0;
+	self->m_Method = NULL;
+	self->m_Instance = NULL;
 	return (PyObject*) self;
 }
 

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -72,11 +72,13 @@ void PyJPProxy::initType(PyObject* module)
 
 PyObject* PyJPProxy::__new__(PyTypeObject* type, PyObject* args, PyObject* kwargs)
 {
+	JP_TRACE_IN("PyJPProxy::new");
 	PyJPProxy* self = (PyJPProxy*) type->tp_alloc(type, 0);
 	self->m_Proxy = NULL;
 	self->m_Target = NULL;
 	self->m_Callable = NULL;
 	return (PyObject*) self;
+	JP_TRACE_OUT;
 }
 
 int PyJPProxy::__init__(PyJPProxy* self, PyObject* args, PyObject* kwargs)
@@ -153,7 +155,6 @@ void PyJPProxy::__dealloc__(PyJPProxy* self)
 	delete self->m_Proxy;
 	PyObject_GC_UnTrack(self);
 	clear(self);
-	// Free self
 	Py_TYPE(self)->tp_free(self);
 	JP_TRACE_OUT;
 }

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     package_dir={
         'jpype': 'jpype',
     },
-    tests_require=['pytest'],
+    tests_require=['pytest', 'mock'],
     extras_require={'numpy': ['numpy>=1.6']},
     cmdclass={
         'build_java': setupext.build_java.BuildJavaCommand,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
     package_dir={
         'jpype': 'jpype',
     },
-    tests_require=['pytest', 'mock'],
+    setup_requires=['setuptools_scm'],
+    tests_require=['pytest', 'mock', 'unittest2'],
     extras_require={'numpy': ['numpy>=1.6']},
     cmdclass={
         'build_java': setupext.build_java.BuildJavaCommand,

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -90,7 +90,7 @@ class ProxyTestCase(common.JPypeTestCase):
         with self.assertRaisesRegex(TypeError, "is not a Java interface"):
             proxy = JProxy(int(1), dict={})
 
-    def testProxyImplements(self):
+    def testProxyImplementsForm1(self):
         itf1 = self.package.TestInterface1
         itf2 = self.package.TestInterface2
 
@@ -100,18 +100,9 @@ class ProxyTestCase(common.JPypeTestCase):
             def testMethod1(self):
               pass
 
-        @JImplements([itf1,itf2])
-        class MyImpl(object):
-            @JOverride
-            def testMethod1(self):
-              pass
-            @JOverride
-            def testMethod2(self):
-              pass
-            @JOverride
-            def write(self):
-              pass
-
+    def testProxyImplementsForm2(self):
+        itf1 = self.package.TestInterface1
+        itf2 = self.package.TestInterface2
         @JImplements(itf1,itf2)
         class MyImpl(object):
             @JOverride
@@ -124,24 +115,14 @@ class ProxyTestCase(common.JPypeTestCase):
             def write(self):
               pass
 
+    def testProxyImplementsForm3(self):
         @JImplements("jpype.proxy.TestInterface1")
         class MyImpl(object):
             @JOverride
             def testMethod1(self):
               pass
 
-        @JImplements(["jpype.proxy.TestInterface1","jpype.proxy.TestInterface2"])
-        class MyImpl(object):
-            @JOverride
-            def testMethod1(self):
-              pass
-            @JOverride
-            def testMethod2(self):
-              pass
-            @JOverride
-            def write(self):
-              pass
-
+    def testProxyImplementsForm4(self):
         @JImplements("jpype.proxy.TestInterface1","jpype.proxy.TestInterface2")
         class MyImpl(object):
             @JOverride

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -64,6 +64,22 @@ class ProxyTestCase(common.JPypeTestCase):
         self.package = JPackage("jpype.proxy")
         self._triggers = self.package.ProxyTriggers
 
+    def testProxyDecl(self):
+        d = {
+            'testMethod1': _testMethod1,
+            'testMethod2': _testMethod2,
+        }
+        itf1 = self.package.TestInterface1
+        proxy = JProxy(itf1, dict=d)
+        proxy = JProxy([itf1], dict=d)
+        proxy = JProxy("jpype.proxy.TestInterface1", dict=d)
+        proxy = JProxy(["jpype.proxy.TestInterface1"], dict=d)
+
+    def testProxyDeclFail(self):
+        itf1 = self.package.TestInterface1
+        with self.assertRaises(TypeError):
+            proxy = JProxy(itf1)
+
     def testProxyWithDict(self):
         d = {
             'testMethod1': _testMethod1,

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -73,7 +73,6 @@ class ProxyTestCase(common.JPypeTestCase):
         itf2 = self.package.TestInterface2
         proxy = JProxy(itf1, dict=d)
         proxy = JProxy([itf1], dict=d)
-        proxy = JProxy(itf1, itf2, dict=d)
         proxy = JProxy([itf1, itf2], dict=d)
         proxy = JProxy("jpype.proxy.TestInterface1", dict=d)
         proxy = JProxy(["jpype.proxy.TestInterface1"], dict=d)

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -70,15 +70,123 @@ class ProxyTestCase(common.JPypeTestCase):
             'testMethod2': _testMethod2,
         }
         itf1 = self.package.TestInterface1
+        itf2 = self.package.TestInterface2
         proxy = JProxy(itf1, dict=d)
         proxy = JProxy([itf1], dict=d)
+        proxy = JProxy(itf1, itf2, dict=d)
+        proxy = JProxy([itf1, itf2], dict=d)
         proxy = JProxy("jpype.proxy.TestInterface1", dict=d)
         proxy = JProxy(["jpype.proxy.TestInterface1"], dict=d)
 
-    def testProxyDeclFail(self):
+    def testProxyDeclFail1(self):
         itf1 = self.package.TestInterface1
-        with self.assertRaises(TypeError):
+        # Missing required arguments
+        with self.assertRaisesRegex(TypeError, "must be specified"):
             proxy = JProxy(itf1)
+
+    def testProxyDeclFail2(self):
+        itf1 = self.package.TestInterface1
+        # Not a str, JClass, or str
+        with self.assertRaisesRegex(TypeError, "is not a Java interface"):
+            proxy = JProxy(int(1), dict={})
+
+    def testProxyImplements(self):
+        itf1 = self.package.TestInterface1
+        itf2 = self.package.TestInterface2
+
+        @JImplements(itf1)
+        class MyImpl(object):
+            @JOverride
+            def testMethod1(self):
+              pass
+
+        @JImplements([itf1,itf2])
+        class MyImpl(object):
+            @JOverride
+            def testMethod1(self):
+              pass
+            @JOverride
+            def testMethod2(self):
+              pass
+            @JOverride
+            def write(self):
+              pass
+
+        @JImplements(itf1,itf2)
+        class MyImpl(object):
+            @JOverride
+            def testMethod1(self):
+              pass
+            @JOverride
+            def testMethod2(self):
+              pass
+            @JOverride
+            def write(self):
+              pass
+
+        @JImplements("jpype.proxy.TestInterface1")
+        class MyImpl(object):
+            @JOverride
+            def testMethod1(self):
+              pass
+
+        @JImplements(["jpype.proxy.TestInterface1","jpype.proxy.TestInterface2"])
+        class MyImpl(object):
+            @JOverride
+            def testMethod1(self):
+              pass
+            @JOverride
+            def testMethod2(self):
+              pass
+            @JOverride
+            def write(self):
+              pass
+
+        @JImplements("jpype.proxy.TestInterface1","jpype.proxy.TestInterface2")
+        class MyImpl(object):
+            @JOverride
+            def testMethod1(self):
+              pass
+            @JOverride
+            def testMethod2(self):
+              pass
+            @JOverride
+            def write(self):
+              pass
+
+    def testProxyImplementsFail1(self):
+        with self.assertRaisesRegex(TypeError, "least one Java interface"):
+            # Empty interfaces
+            @JImplements()
+            class MyImpl(object):
+                @JOverride
+                def testMethod1(self):
+                  pass
+
+    def testProxyImplementsFail2(self):
+        with self.assertRaisesRegex(TypeError, "is not a Java interface"):
+            # Wrong type
+            @JImplements(int(1))
+            class MyImpl(object):
+                @JOverride
+                def testMethod1(self):
+                  pass
+
+    def testProxyImplementsFail3(self):
+        with self.assertRaisesRegex(NotImplementedError, "requires method"):
+            # Missing implementation
+            @JImplements("jpype.proxy.TestInterface1")
+            class MyImpl(object):
+                def testMethod1(self):
+                  pass
+
+    def testProxyImplementsFail4(self):
+        with self.assertRaisesRegex(TypeError, "is not a Java interface"):
+            # extends
+            @JImplements("java.lang.StringBuilder")
+            class MyImpl(object):
+                def testMethod1(self):
+                  pass
 
     def testProxyWithDict(self):
         d = {


### PR DESCRIPTION
Fixes the problem reported by the user and give the test bench some TLC as this and a bunch of other things were being missed.  There were a lot of cases in this area where one form or another was not tested.  Fixing it took much longer than expected because all of the corner cases (must be list[str or JClass], or str, or JClass, but all must resolve to JInterface).  

Note.  This does make the change that both bare lists and defined lists are accepted in the old JProxy interface.
```
JProxy([intf1, intf2], dict={...})
JProxy(intf1, intf2, dict={...})
```

I wanted the new interface to be simple (though specifying a list explicitly is also accepted)
```
   Java:  
        public class Foo implements MyInterface1, MyInterface2
   Python (preferred): 
        @JImplements(MyInterface1, MyInterface2)  class Foo
   Python (acceptable): 
        @JImplements([MyInterface1, MyInterface2])  class Foo
```
I can kill the second form if it is too much.

This change may break the total nonsense form  ``JProxy(intf1, foo)`` where dict is being implied as based on position, which should never have worked.

A secondary change is it now reports an error on the old JProxy if either no interfaces are specified or the dict or inst is missing.  Letting it quietly pass by this sort of error just to blow up later offends me.

The error message also became more terse.  Giving the correct usage is the point of the documentation
and not the exception string.  I added checks to the test bench to make sure the error was reported for the right reason rather than any reason.  There needs to be an action item to do this universally, as people do get burned by deceptive messages. 

@marscher general question, do you prefer many small tests that test each aspect of a function individually and thus report the exact failure by the test that failed, or large tests that test multiple aspects of a function?  My personal preference is many small because otherwise I get burned when I fix something in a test and it just falls through the next part of the test.  But I will defer to you as we are already over 400 tests.
