### PR TITLE
Adds __doc__ to Java methods

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -6,6 +6,7 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 - **Next version - unreleased**
 
 - **0.7.0 - 2019**
+  - Doc strings are generated for classes and methods.
 
   - Complete rewrite of the core module code to deal unattached threads,
     improved hardening, and member management.  Massive number of internal 
@@ -14,28 +15,30 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
   - API breakage:
 
-     - Java strings no longer convert automatically to Python strings.
-       The previous behavior was switchable, but only the default
-       convert to Python was working. Converting to automatically
-       lead to problems in which is was impossible to work with
-       classes like StringBuilder in Java. To convert a Java
-       string use ``str()``.
+     - Java strings conversion behavior has changed.  The previous behavior was
+       switchable, but only the default convert to Python was working.
+       Converting to automatically lead to problems in which is was impossible
+       to work with classes like StringBuilder in Java. To convert a Java
+       string use ``str()``. Therefore, string conversion is currently selected
+       by a switch at the start of the JVM.  The default shall be False
+       starting in JPype 0.8.  New code is encouraged to use the future default
+       of False.  For the transition period the default will be True with a
+       warning if not policy was selected to encourage developers to pick the
+       string conversion policy that best applies to their application.
 
-     - Java exceptions are now derived from Python exception. The
-       old wrapper types have been removed. Catch the exception
-       with the actual Java exception type rather than ``JException``.
+     - Java exceptions are now derived from Python exception. The old wrapper
+       types have been removed. Catch the exception with the actual Java
+       exception type rather than ``JException``.
        
-     - Undocumented exceptions issued from within JPype have
-       been mapped to the corresponding Python exception types
-       such as ``TypeError`` and ``ValueError`` appropriately.
-       Code catching exceptions from previous versions should 
-       be checked to make sure all exception paths are being
+     - Undocumented exceptions issued from within JPype have been mapped to the
+       corresponding Python exception types such as ``TypeError`` and
+       ``ValueError`` appropriately.  Code catching exceptions from previous
+       versions should be checked to make sure all exception paths are being
        handled.
 
-     - Undocumented property import of Java bean pattern
-       get/set accessors was removed as the default. It is 
-       available with ``import jpype.beans``, but its
-       use is discouraged.
+     - Undocumented property import of Java bean pattern get/set accessors was
+       removed as the default. It is available with ``import jpype.beans``, but
+       its use is discouraged.
 
   - API rework:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # For some reason jpype.imports does not work if called in sphinx. Importing
 # it here solved the problem.
+import _jpype
 import jpype
 import jpype.imports
 
@@ -58,13 +59,14 @@ copyright = u'2014-18, Steve Menard, Luis Nell and others'
 #
 # The short X.Y version.
 import mock
-mock_modules = ('_jpype',
-        )
+mock_modules = ('_jpype',)
 for m in mock_modules:
     sys.modules[m] = mock.MagicMock()
 
 import jpype
-print(jpype.__path__)
+import java.lang
+import java.util
+import java.io
 version = jpype.__version__
 # The full version, including alpha/beta/rc tags.
 release = jpype.__version__
@@ -286,3 +288,5 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+napoleon_custom_sections = ["Static Methods","Virtual Methods","Constructors"]

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -360,3 +360,4 @@ def getJVMVersion():
         parts = version.split('_')
         version = parts[0]
     return tuple([int(i) for i in version.split('.')])
+

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -44,7 +44,6 @@ _jcustomizer._JCLASSES = _JCLASSES
 def _initialize():
     global _java_ClassLoader
 
-    _jpype.setResource('GetClassMethod', _JClassNew)
 
     # Due to bootstrapping, Object and Class must be defined first.
     global _java_lang_Object, _java_lang_Class
@@ -222,6 +221,7 @@ def _JClassNew(arg, loader=None, initialize=True):
     if name in _JCLASSES:
         return _JCLASSES[name]
     return _JClassFactory(name, javaClass)
+
 
 
 class JInterface(object):
@@ -429,3 +429,27 @@ def typeLookup(tp, name):
 
     cache[name] = None
     return None
+
+def _jmethodDoc(method, cls, overloads):
+    """ Method hook for PyJPMethod.__doc__ property
+
+    Parameters:
+       method (PyJPMethod): method to generate doc string for.
+       cls (java.lang.Class): Class holding this method dispatch.
+       overloads (java.lang.reflect.Method[]): tuple holding all the methods that
+         are served by this method dispatch.
+
+    Returns:
+      the doc string for the method dispatch.
+    """
+    out = []
+    out.append("Java method dispatch '%s' for '%s'"%(method.getName(),cls.getName()))
+    out.append("")
+    out.append("Overloads:")
+    for ov in overloads:
+        out.append("   %s"%ov.toString())
+    out.append("")
+    return "\n".join(out)
+
+_jpype.setResource('GetClassMethod', _JClassNew)
+_jpype.setResource('GetMethodDoc', _jmethodDoc)

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -292,14 +292,9 @@ def _JClassFactory(name, jc):
         bases.append(JClass(ic))
 
     # Set up members
-    pkg = ""
-    cname = name
-    if '.' in cname:
-        (pkg, cname) = cname.rsplit('.', 1)
     members = {
         "__javaclass__": jc,
-        "__name__": cname,
-        "__module__": pkg,
+        "__name__": name,
     }
     fields = jc.getClassFields()
     for i in fields:
@@ -310,7 +305,7 @@ def _JClassFactory(name, jc):
 
     # Apply customizers
     _jcustomizer._applyCustomizers(name, jc, bases, members)
-    res = JClass(cname, tuple(bases), members)
+    res = JClass(name, tuple(bases), members)
     _JCLASSES[name] = res
 
     # Post customizers

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -440,7 +440,7 @@ def _jclassDoc(cls):
     Returns:
       The doc string for the class.
     """
-    from textwrap import wrap, indent
+    from textwrap import TextWrapper
     jclass = cls.class_
     out = []
     out.append("Java class '%s'" % (jclass.getName()))
@@ -455,9 +455,10 @@ def _jclassDoc(cls):
     intfs = jclass.getInterfaces()
     if intfs:
         out.append("  Interfaces:")
-        words = "".join(
-            wrap(", ".join([str(i.getCanonicalName()) for i in intfs])))
-        out.append(indent(words, '        '))
+        words = ", ".join([str(i.getCanonicalName()) for i in intfs])
+        wrapper = TextWrapper(initial_indent='        ',
+                              subsequent_indent='        ')
+        out.extend(wrapper.wrap(words))
         out.append("")
 
     ctors = jclass.getDeclaredConstructors()
@@ -522,7 +523,7 @@ def _jmethodDoc(method, cls, overloads):
     Returns:
       The doc string for the method dispatch.
     """
-    from textwrap import wrap, indent
+    from textwrap import TextWrapper
     out = []
     out.append("Java method dispatch '%s' for '%s'" %
                (method.getName(), cls.getName()))
@@ -563,8 +564,10 @@ def _jmethodDoc(method, cls, overloads):
 
     if returns:
         out.append("  Returns:")
-        words = "".join(wrap(", ".join([str(i) for i in set(returns)])))
-        out.append(indent(words, '    '))
+        words = ", ".join([str(i) for i in set(returns)])
+        wrapper = TextWrapper(initial_indent='    ',
+                              subsequent_indent='    ')
+        out.extend(wrapper.wrap(words))
         out.append("")
 
     return "\n".join(out)

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -496,7 +496,7 @@ def _jclassDoc(cls):
             if modifiers & 8:
                 fieldInfo.append("static")
             if field.isEnumConstant():
-                fieldnfo.append("enum constant")
+                fieldInfo.append("enum constant")
             else:
                 fieldInfo.append("field")
             fielddesc.append("    %s (%s): %s" % (field.getName(),

--- a/native/common/include/jp_method.h
+++ b/native/common/include/jp_method.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _JPMETHOD_H_
 #define _JPMETHOD_H_
@@ -34,7 +34,11 @@ private:
 
 public:
 	const string& getName() const;
-	string getClassName() const;
+
+	JPClass* getClass() const
+	{
+		return m_Class;
+	}
 
 	void addOverload(JPClass* clazz, jobject mth);
 
@@ -59,7 +63,7 @@ public:
 
 private:
 	/** Search for a matching overload.
-	 * 
+	 *
 	 * @param searchInstance is true if the first argument is to be skipped
 	 * when matching with a non-static.
 	 */

--- a/native/common/include/jp_methodoverload.h
+++ b/native/common/include/jp_methodoverload.h
@@ -68,6 +68,11 @@ public:
 	JPPyObject invoke(JPMatch& match, JPPyObjectVector&  arg, bool instance);
 	JPValue  invokeConstructor(JPMatch& match, JPPyObjectVector& arg);
 
+	jobject getJava() const
+	{
+		return m_Method.get();
+	}
+
 	bool isStatic() const
 	{
 		return m_IsStatic;

--- a/native/common/include/jp_tracer.h
+++ b/native/common/include/jp_tracer.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _JP_TRACER_H__
 #define _JP_TRACER_H__
@@ -27,7 +27,7 @@
 #define JP_TRACE_IN(n)  try {
 #define JP_TRACE_OUT } catch (JPypeException &ex) { ex.from(JP_STACKINFO()); throw; }
 #define JP_TRACE(...)
-#define JP_TRACE_PY(m, obj) 
+#define JP_TRACE_PY(m, obj)
 #endif
 
 // Enable this option to get all the py referencing information

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #include <Python.h>
 #include <jpype.h>
@@ -70,16 +70,16 @@ void JPypeException::from(const JPStackInfo& info)
 	m_Trace.push_back(info);
 }
 
-// Okay from this point on we have to suit up in full Kevlar because 
+// Okay from this point on we have to suit up in full Kevlar because
 // this code must handle every conceivable and still reach a resolution.
 // Exceptions may be throws during initialization where only a fraction
 // of the resources are available, during the middle of normal operation,
 // or worst of all as the system is being yanked out from under us during
-// shutdown.  Each and every one of these cases must be considered.  
+// shutdown.  Each and every one of these cases must be considered.
 // Further each and every function called here must be hardened similarly
 // or they will become the weak link. And remember it is not paranoia if
 // they are actually out to get you.
-// 
+//
 // Onward my friends to victory or a glorious segfault!
 
 string JPypeException::getMessage()
@@ -213,7 +213,7 @@ void JPypeException::convertJavaToPython()
 
 void JPypeException::convertPythonToJava()
 {
-	JP_TRACE_IN("JPypeException::toPython");
+	JP_TRACE_IN("JPypeException::convertPythonToJava");
 	JPJavaFrame frame;
 	jthrowable th;
 	{
@@ -236,7 +236,7 @@ void JPypeException::convertPythonToJava()
 		}
 	}
 
-	// Otherwise 
+	// Otherwise
 	string pyMessage = "Python exception thrown: " + getPythonMessage();
 	JP_TRACE(pyMessage);
 	PyErr_Clear();
@@ -260,7 +260,6 @@ void JPypeException::toPython()
 
 			case JPError::_python_error:
 				JP_TRACE("Python exception");
-				JP_TRACE(getPythonMessage());
 				// Error is already in the stack
 				return;
 

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -36,17 +36,12 @@ const string& JPMethod::getName() const
 	return m_Name;
 }
 
-string JPMethod::getClassName() const
-{
-	return m_Class->getCanonicalName();
-}
-
 void JPMethod::addOverload(JPClass* claz, jobject mth)
 {
 	//	printf("JPMethodOverload %s\n", JPJni::toStringC(mth));
 	JPMethodOverload* over = new JPMethodOverload(claz, mth);
 
-	// The same overload can be repeated each time it is overriden. 
+	// The same overload can be repeated each time it is overriden.
 	bool found = false;
 	for (OverloadList::iterator it = m_Overloads.begin(); it != m_Overloads.end(); ++it)
 	{
@@ -81,9 +76,9 @@ void JPMethod::addOverload(JPClass* claz, jobject mth)
 	//		m_BeanMutator = true;
 	//	}
 
-	// We can't check the order of specificity here because we do not want to 
+	// We can't check the order of specificity here because we do not want to
 	// load the argument types here.  Thus we need to wait for the first
-	// used. 
+	// used.
 }
 
 void JPMethod::ensureOverloadCache()

--- a/native/python/include/jp_pythonenv.h
+++ b/native/python/include/jp_pythonenv.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 class JPStackInfo;
+struct PyJPMethod;
 
 /** This is all of the calls that are specific to creating and handling
  * the python wrapper classes of jpype.
@@ -12,36 +13,36 @@ namespace JPPythonEnv
 	void init();
 
 	/** Convert a JPClass to the corresponding Python wrapper class.
-	 * 
+	 *
 	 * @returns a jpype.JavaClass or jpype.JavaArrayClass.
 	 */
 	JPPyObject newJavaClass(JPClass* jc);
 
 	/** Convert a JPValue to the corresponding Python wrapper class.
-	 * 
+	 *
 	 * @returns instance of jpype.JavaClass or jpype.JavaArrayClass.
 	 */
 	JPPyObject newJavaObject(const JPValue& value);
 
 	/** Get the JPValue from a python object.
-	 * 
+	 *
 	 * @returns a JPValue or NULL if not a JPValue container.
 	 */
 	JPValue* getJavaValue(PyObject* obj);
 
-	/** Get the JPClass from a Python object. 
-	 * 
-	 * Note, always check the getJavaValue before the gettJavaClass.  All objects 
+	/** Get the JPClass from a Python object.
+	 *
+	 * Note, always check the getJavaValue before the gettJavaClass.  All objects
 	 * inherit __javaclass__ from their Python class. Thus object instances may
 	 * appear as classes if not properly checked.
 
-	 * 
+	 *
 	 * @returns a JPClass or NULL if not a JPClass container.
 	 */
 	JPClass* getJavaClass(PyObject* obj);
 
 	/** Get the JPProxy from a Python object.
-	 * 
+	 *
 	 * @returns JPProxy or NULL in not a JPProxy container.
 	 */
 	JPProxy* getJavaProxy(PyObject* obj);
@@ -49,21 +50,23 @@ namespace JPPythonEnv
 	JPPyObject getJavaProxyCallable(PyObject* obj, const string& name);
 
 	/** Register a python resource with jpype.
-	 * 
-	 * @throws if python resource name is not known. 
+	 *
+	 * @throws if python resource name is not known.
 	 */
 	void setResource(const string& name, PyObject* resource);
 
 	/** Convert exceptions generated in C++ to Python.
-	 * 
-	 * This is part of the standard exception handling in the module.  The 
-	 * action depends on the current exception thrown.  JPPythonException 
-	 * simply return to python as the error state should already be set 
-	 * properly. JavaException will attempt to convert to a Python type 
-	 * wrapper appropriate for python to receive as an exception. 
+	 *
+	 * This is part of the standard exception handling in the module.  The
+	 * action depends on the current exception thrown.  JPPythonException
+	 * simply return to python as the error state should already be set
+	 * properly. JavaException will attempt to convert to a Python type
+	 * wrapper appropriate for python to receive as an exception.
 	 * JPypeException are converted directly to RuntimeErrors.
 	 */
 	void rethrow(const JPStackInfo& info);
+
+	JPPyObject getMethodDoc(PyJPMethod* javaMethod);
 }
 
 #endif

--- a/native/python/include/pyjp_method.h
+++ b/native/python/include/pyjp_method.h
@@ -34,13 +34,15 @@ struct PyJPMethod
 	static int        clear(PyJPMethod *self);
 
 	static PyObject*  __get__(PyJPMethod* self, PyObject* obj, PyObject* type);
-	static PyObject*  __str__(PyJPMethod* o);
+	static PyObject*  __str__(PyJPMethod* self);
+	static PyObject*  __repr__(PyJPMethod *self);
 	static PyObject*  __call__(PyJPMethod* self, PyObject* args, PyObject* kwargs);
 	static PyObject*  isBeanMutator(PyJPMethod* self, PyObject* arg);
 	static PyObject*  isBeanAccessor(PyJPMethod* self, PyObject* arg);
 	static PyObject*  getName(PyJPMethod* self, PyObject* arg);
 	static PyObject*  matchReport(PyJPMethod* self, PyObject* arg);
 	static PyObject*  dump(PyJPMethod* self, PyObject* arg);
+	static PyObject*  __doc__(PyJPMethod *method, void *context);
 
 	JPMethod* m_Method;
 	PyObject* m_Instance;

--- a/native/python/jp_pythonenv.cpp
+++ b/native/python/jp_pythonenv.cpp
@@ -185,7 +185,7 @@ JPPyObject JPPythonEnv::getMethodDoc(PyJPMethod* javaMethod)
 	JPPyTuple ov(JPPyTuple::newTuple(overloads.size()));
 	int i = 0;
 	JPClass* methodClass = JPTypeManager::findClass("java.lang.reflect.Method");
-	for (JPMethod::OverloadList::const_iterator iter = overloads.cbegin(); iter != overloads.cend(); ++iter)
+	for (JPMethod::OverloadList::const_iterator iter = overloads.begin(); iter != overloads.end(); ++iter)
 	{
 		JP_TRACE("Set overload", i);
 		jvalue v;

--- a/native/python/jp_pythonenv.cpp
+++ b/native/python/jp_pythonenv.cpp
@@ -2,7 +2,7 @@
 #include <jpype.h>
 
 /** Python seems to delete static variables after the Python resources
- * have already been claimed, so we need to make sure these objects 
+ * have already been claimed, so we need to make sure these objects
  * never get deleted.
  *
  * FIXME figure out how to connect to module unloading.
@@ -11,6 +11,7 @@ class JPResources
 {
 public:
 	JPPyObject s_GetClassMethod;
+	JPPyObject s_GetMethodDoc;
 };
 
 namespace
@@ -23,7 +24,7 @@ namespace
 
 void JPPythonEnv::init()
 {
-	// Nothing frees this currently.  We lack a way to shutdown or reload 
+	// Nothing frees this currently.  We lack a way to shutdown or reload
 	// this module.
 	s_Resources = new JPResources();
 }
@@ -35,6 +36,8 @@ void JPPythonEnv::setResource(const string& name, PyObject* resource)
 	JP_TRACE_PY("hold", resource);
 	if (name == "GetClassMethod")
 		s_Resources->s_GetClassMethod = JPPyObject(JPPyRef::_use, resource);
+	else if (name == "GetMethodDoc")
+		s_Resources->s_GetMethodDoc = JPPyObject(JPPyRef::_use, resource);
 	else
 	{
 		stringstream ss;
@@ -165,3 +168,45 @@ void JPPythonEnv::rethrow(const JPStackInfo& info)
 	JP_TRACE_OUT;
 }
 
+JPPyObject JPPythonEnv::getMethodDoc(PyJPMethod* javaMethod)
+{
+	JP_TRACE_IN("JPPythonEnv::getMethodDoc");
+	if (s_Resources->s_GetMethodDoc.isNull())
+	{
+		JP_TRACE("Resource not set.");
+		return JPPyObject();
+	}
+
+	ASSERT_NOT_NULL(javaMethod);
+
+	// Convert the overloads
+	JP_TRACE("Convert overloads");
+	const JPMethod::OverloadList& overloads = javaMethod->m_Method->getMethodOverloads();
+	JPPyTuple ov(JPPyTuple::newTuple(overloads.size()));
+	int i = 0;
+	JPClass* methodClass = JPTypeManager::findClass("java.lang.reflect.Method");
+	for (JPMethod::OverloadList::const_iterator iter = overloads.cbegin(); iter != overloads.cend(); ++iter)
+	{
+		JP_TRACE("Set overload", i);
+		jvalue v;
+		v.l = (*iter)->getJava();
+		JPPyObject obj(JPPythonEnv::newJavaObject(JPValue(methodClass, v)));
+		ov.setItem(i++, obj.get());
+	}
+
+	// Pack the arguments
+	{
+		JP_TRACE("Pack arguments");
+		JPPyTuple args(JPPyTuple::newTuple(3));
+		args.setItem(0, (PyObject*) javaMethod);
+		jvalue v;
+		v.l = (jobject) javaMethod->m_Method->getClass()->getJavaClass();
+		JPPyObject obj(JPPythonEnv::newJavaObject(JPValue(JPTypeManager::_java_lang_Class, v)));
+		args.setItem(1, obj.get());
+		args.setItem(2, ov.get());
+		JP_TRACE("Call Python");
+		return s_Resources->s_GetMethodDoc.call(args.get(), NULL);
+	}
+
+	JP_TRACE_OUT;
+}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -95,10 +95,10 @@ void JPPyObject::decref()
 {
 	if (pyobj->ob_refcnt <= 0)
 	{
-		// At this point our car has traveled beyond the end of the 
+		// At this point our car has traveled beyond the end of the
 		// cliff and it will hit the ground some twenty
 		// python calls later with a nearly untracable fault, thus
-		// rather than waiting for the inevitable, we chose to take 
+		// rather than waiting for the inevitable, we chose to take
 		// a noble death here.
 		JPypeTracer::trace("Python referencing fault");
 		int *i = 0;
@@ -199,7 +199,7 @@ JPPyObject JPPyBool::fromLong(jlong value)
 
 JPPyObject JPPyInt::fromInt(jint l)
 {
-#if PY_MAJOR_VERSION >= 3 
+#if PY_MAJOR_VERSION >= 3
 	return JPPyObject(JPPyRef::_call, PyLong_FromLong(l));
 #else
 	return JPPyObject(JPPyRef::_call, PyInt_FromLong(l));
@@ -208,7 +208,7 @@ JPPyObject JPPyInt::fromInt(jint l)
 
 JPPyObject JPPyInt::fromLong(jlong l)
 {
-#if PY_MAJOR_VERSION >= 3 
+#if PY_MAJOR_VERSION >= 3
 	return JPPyObject(JPPyRef::_call, PyLong_FromLongLong(l));
 #else
 	return JPPyObject(JPPyRef::_call, PyInt_FromLong((int) l));
@@ -378,7 +378,7 @@ jchar JPPyString::asCharUTF16(PyObject* pyobj)
 		return (jchar) val;
 	}
 
-#if PY_MAJOR_VERSION < 3 
+#if PY_MAJOR_VERSION < 3
 	if (PyString_Check(pyobj))
 	{
 		Py_ssize_t sz = PyString_Size(pyobj);
@@ -456,7 +456,7 @@ jchar JPPyString::asCharUTF16(PyObject* pyobj)
 }
 
 /** Check if the object is a bytes or unicode.
- * 
+ *
  * @returns true if the object is bytes or unicode.
  */
 bool JPPyString::check(PyObject* obj)
@@ -578,11 +578,9 @@ bool JPPyTuple::check(PyObject* obj)
 void JPPyTuple::setItem(jlong ndx, PyObject* val)
 {
 	ASSERT_NOT_NULL(val);
+	Py_INCREF(val);
 	PyTuple_SetItem(pyobj, (Py_ssize_t) ndx, val); // steals reference
 	JP_PY_CHECK();
-
-	// Return the stolen reference, but only after transfer has been completed.
-	Py_INCREF(val);
 }
 
 PyObject* JPPyTuple::getItem(jlong ndx)
@@ -769,7 +767,7 @@ JPPyCallAcquire::~JPPyCallAcquire()
 	delete save;
 }
 
-// This is used when leaving python from to perform some 
+// This is used when leaving python from to perform some
 
 JPPyCallRelease::JPPyCallRelease()
 {

--- a/native/python/pyjp_monitor.cpp
+++ b/native/python/pyjp_monitor.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #include <pyjp.h>
 

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -102,7 +102,7 @@ JPPyObject PyJPValue::alloc(JPClass* cls, jvalue value)
 	// New value instance
 	self->m_Value = JPValue(cls, value);
 	self->m_Cache = NULL;
-	JP_TRACE("Value", self->m_Value.getClass(), &(self->m_Value.getValue()));
+	JP_TRACE("Value", self->m_Value.getClass()->getCanonicalName(), &(self->m_Value.getValue()));
 	return JPPyObject(JPPyRef::_claim, (PyObject*) self);
 	JP_TRACE_OUT;
 }
@@ -200,11 +200,11 @@ void PyJPValue::__dealloc__(PyJPValue* self)
 	JP_TRACE_IN("PyJPValue::__dealloc__");
 	JPValue& value = self->m_Value;
 	JPClass* cls = value.getClass();
-
 	// This one can't check for initialized because we may need to delete a stale
 	// resource after shutdown.
 	if (cls != NULL && JPEnv::isInitialized() && dynamic_cast<JPPrimitiveType*> (cls) != cls)
 	{
+		JP_TRACE("Value", cls->getCanonicalName(), &(value.getValue()));
 		// If the JVM has shutdown then we don't need to free the resource
 		// FIXME there is a problem with initializing the sytem twice.
 		// Once we shut down the cls type goes away so this will fail.  If

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     package_dir={
         'jpype': 'jpype',
     },
-    #setup_requires=['setuptools_scm'],
     tests_require=['pytest', 'mock', 'unittest2'],
     extras_require={'numpy': ['numpy>=1.6']},
     cmdclass={

--- a/test/jpypetest/test_docstring.py
+++ b/test/jpypetest/test_docstring.py
@@ -1,0 +1,37 @@
+# *****************************************************************************
+#   Copyright 2017 Karl Einar Nelson
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# *****************************************************************************
+import jpype
+import common
+
+
+class DocStringTestCase(common.JPypeTestCase):
+
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testDocClass(self):
+        cls = jpype.JClass('java.util.Iterator')
+        self.assertIsNotNone( cls.__doc__)
+
+    def testDocMethod(self):
+        cls = jpype.JClass('java.lang.String')
+        self.assertIsNotNone( cls.substring.__doc__)
+
+    def testDocEnumClass(self):
+        cls = jpype.JClass('java.lang.Character.UnicodeScript')
+        self.assertIsNotNone( cls.__doc__)
+


### PR DESCRIPTION
Adds support for dynamically creating ``__doc__`` for Java methods on request.  We could do this for fields and classes as well.  Currently pretty minimal but we can get as fancy as we want.  The ``__doc__`` attribute just calls a method defined by setResource which must be a Python method accepting the method dispatch, the java.lang.Class holding the dispatch, and the list of overloaded methods (in the order that they are matched).

I haven't developed any tests for this one yet, so it is possible that the stability on it is less than stellar.  We may want to wait to apply this in 0.7.1. 