### PR TITLE
Selects Java version as 1.7 for building internal jar.

### DIFF
--- a/native/build.xml
+++ b/native/build.xml
@@ -1,6 +1,6 @@
 <project default="all" name="JPype - Native">
 
-	<property name="JAVA_VERSION" value="${ant.java.version}"/>
+	<property name="JAVA_VERSION" value="1.7"/>
 	<!-- src can't be "java" as it breaks nose tests -->
 	<property name="src" location="java"/>
 	<property name="build" location="build"/>


### PR DESCRIPTION
Sets the internal java jar at 1.7 so that binaries do not require latest Java build to use.  We could set it older, but 1.6 is long gone and I haven't tested it.