### PR TITLE
Pass a python object into Java and return unharmed.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,12 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 - **Next version - unreleased**
 
+  - JProxy objects now are returned from Java as the Python objects 
+    that originate from. Older style proxy classes return the 
+    inst or dict. New style return the proxy class instance.
+    Thus proxy classes can be stored on generic Java containers
+    and retrieved as Python objects.
+
 - **0.7.0 - 2019**
   - Doc strings are generated for classes and methods.
 

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -256,7 +256,7 @@ class JInterface(object):
         elif not hasattr(self, '__javavalue__'):
             raise JClass("java.lang.InstantiationException")(
                 "`%s` is an interface." % str(self.class_.getName()))
-        super(JObject, self).__init__()
+        super(JInterface, self).__init__()
 
     def __str__(self):
         return self.toString()

--- a/native/common/include/jp_classloader.h
+++ b/native/common/include/jp_classloader.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _JPCLASSLOADER_H_
 #define _JPCLASSLOADER_H_
@@ -31,6 +31,7 @@ namespace JPClassLoader
 	 * @throws RuntimeException if the class is not found.
 	 */
 	jclass findClass(string name);
+
 } ;
 
 #endif // _JPCLASSLOADER_H_

--- a/native/common/include/jp_proxy.h
+++ b/native/common/include/jp_proxy.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _JPPROXY_H_
 #define _JPPROXY_H_
@@ -41,5 +41,17 @@ private:
 	JPClass::ClassList m_InterfaceClasses;
 	JPObjectRef   m_Interfaces;
 } ;
+
+// Special wrapper for round trip returns
+class JPProxyType : public JPClass
+{
+public:
+	JPProxyType();
+	virtual~ JPProxyType();
+
+public: // JPClass implementation
+	virtual JPPyObject convertToPythonObject(jvalue val) override;
+} ;
+
 
 #endif // JPPROXY_H

--- a/native/common/include/jp_typemanager.h
+++ b/native/common/include/jp_typemanager.h
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #ifndef _JPTYPE_MANAGER_H_
 #define _JPTYPE_MANAGER_H_
@@ -57,7 +57,7 @@ namespace JPTypeManager
 
 	/**
 	 * Find a class using a native name.
-	 * 
+	 *
 	 * The pointer returned is NOT owned by the caller
 	 */
 	JPClass* findClass(const string& str);
@@ -67,6 +67,17 @@ namespace JPTypeManager
 	void flushCache();
 
 	int getLoadedClasses();
+
+	/**
+	 * Special class registry for primary types.
+	 *
+	 * @param classWrapper
+	 * @return
+	 */
+	JPClass* registerClass(JPClass* classWrapper);
+
+	jclass getClassFor(jobject obj);
+
 } // namespace
 
 #endif // _JPCLASS_H_

--- a/native/common/jp_classloader.cpp
+++ b/native/common/jp_classloader.cpp
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
  *****************************************************************************/
 #include <Python.h>
 #include <jpype.h>
@@ -55,7 +55,7 @@ void JPClassLoader::init()
 	frame.CallVoidMethodA(classLoader, importJarID, &v);
 
 	// Set up the loader
-	findClassID = frame.GetMethodID(cls, "findClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+	findClassID = frame.GetMethodID(cls, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
 
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -177,7 +177,7 @@ jobject JPProxy::getProxy()
 	return frame.keep(proxy);
 }
 
-JPProxyType::JPProxyType() : JPClass(proxyClass)
+JPProxyType::JPProxyType() : JPClass(handlerClass)
 {
 }
 

--- a/native/java/org/jpype/Utility.java
+++ b/native/java/org/jpype/Utility.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018, Karl Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jpype;
+
+import java.lang.reflect.Proxy;
+
+/**
+ *
+ * @author Karl Einar Nelson
+ */
+public class Utility
+{
+  /**
+   * Get the class for an object.
+   * <p>
+   * This method is somewhat misplaced, but we don't have a good place for it in
+   * JPype 0.7. This prevents generation of pointless wrappers for lambda and
+   * other synthetic classes. This functionality moves to TypeManager in 0.8.
+   *
+   * @param obj is the object to probe.
+   * @return the class to use for JPype
+   */
+  public static Class<?> getClassFor(Object obj)
+  {
+    Class cls = obj.getClass();
+    if (Proxy.isProxyClass(cls) && (Proxy.getInvocationHandler(obj) instanceof org.jpype.proxy.JPypeInvocationHandler))
+    {
+      return Proxy.class;
+    }
+
+    if (cls.isSynthetic())
+    {
+      // We may be a lambda or a Proxy.
+
+      // We are a lambda (Lambda can only have one interface.
+      return cls.getInterfaces()[0];
+    }
+    return cls;
+  }
+}

--- a/native/java/org/jpype/Utility.java
+++ b/native/java/org/jpype/Utility.java
@@ -17,6 +17,7 @@
 package org.jpype;
 
 import java.lang.reflect.Proxy;
+import org.jpype.proxy.JPypeInvocationHandler;
 
 /**
  *
@@ -39,7 +40,7 @@ public class Utility
     Class cls = obj.getClass();
     if (Proxy.isProxyClass(cls) && (Proxy.getInvocationHandler(obj) instanceof org.jpype.proxy.JPypeInvocationHandler))
     {
-      return Proxy.class;
+      return JPypeInvocationHandler.class;
     }
 
     if (cls.isSynthetic())

--- a/native/java/org/jpype/proxy/JPypeInvocationHandler.java
+++ b/native/java/org/jpype/proxy/JPypeInvocationHandler.java
@@ -2,7 +2,7 @@ package org.jpype.proxy;
 
 import java.lang.reflect.*;
 
-class JPypeInvocationHandler implements InvocationHandler
+public class JPypeInvocationHandler implements InvocationHandler
 {
   long hostObject;
 

--- a/project/jpype_java/build.xml
+++ b/project/jpype_java/build.xml
@@ -1,68 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="jpype_java" default="default" basedir=".">
-    <description>Builds, tests, and runs the project jpype_java.</description>
-		<!--
-				 This will be a non-standard project, so we will need to place rules for 
-     whatever functionality we will be needing.
+  <description>Builds, tests, and runs the project jpype_java.</description>
+  <!--
+                  This will be a non-standard project, so we will need to place rules for 
+  whatever functionality we will be needing. -->
 
-    <import file="nbproject/build-impl.xml"/>
-
-    There exist several targets which are by default empty and which can be 
-    used for execution of your tasks. These targets are usually executed 
-    before and after some main targets. They are: 
-
-      -pre-init:                 called before initialization of project properties
-      -post-init:                called after initialization of project properties
-      -pre-compile:              called before javac compilation
-      -post-compile:             called after javac compilation
-      -pre-compile-single:       called before javac compilation of single file
-      -post-compile-single:      called after javac compilation of single file
-      -pre-compile-test:         called before javac compilation of JUnit tests
-      -post-compile-test:        called after javac compilation of JUnit tests
-      -pre-compile-test-single:  called before javac compilation of single JUnit test
-      -post-compile-test-single: called after javac compilation of single JUunit test
-      -pre-jar:                  called before JAR building
-      -post-jar:                 called after JAR building
-      -post-clean:               called after cleaning build products
-
-    (Targets beginning with '-' are not intended to be called on their own.)
-
-    Example of inserting an obfuscator after compilation could look like this:
-
-        <target name="-post-compile">
-            <obfuscate>
-                <fileset dir="${build.classes.dir}"/>
-            </obfuscate>
-        </target>
-
-    For list of available properties check the imported 
-    nbproject/build-impl.xml file. 
-
-
-    Another way to customize the build is by overriding existing main targets.
-    The targets of interest are: 
-
-      -init-macrodef-javac:     defines macro for javac compilation
-      -init-macrodef-junit:     defines macro for junit execution
-      -init-macrodef-debug:     defines macro for class debugging
-      -init-macrodef-java:      defines macro for class execution
-      -do-jar:                  JAR building
-      run:                      execution of project 
-      -javadoc-build:           Javadoc generation
-      test-report:              JUnit report generation
-
-    An example of overriding the target for project execution could look like this:
-
-        <target name="run" depends="jpype_java-impl.jar">
-            <exec dir="bin" executable="launcher.exe">
-                <arg file="${dist.jar}"/>
-            </exec>
-        </target>
-
-    Notice that the overridden target depends on the jar target and not only on 
-    the compile target as the regular run target does. Again, for a list of available 
-    properties which you can use, check the target you are overriding in the
-    nbproject/build-impl.xml file. 
-
-    -->
+  <import file="nbproject/build-impl.xml"/>
 </project>

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -16,6 +16,7 @@
 # *****************************************************************************
 from jpype import *
 import common
+import sys
 
 try:
     import unittest2 as unittest
@@ -76,6 +77,36 @@ class ProxyTestCase(common.JPypeTestCase):
         proxy = JProxy([itf1, itf2], dict=d)
         proxy = JProxy("jpype.proxy.TestInterface1", dict=d)
         proxy = JProxy(["jpype.proxy.TestInterface1"], dict=d)
+
+    def testProxyRoundTrip(self):
+        
+        @JImplements(java.lang.Runnable)
+        class MyRun(object):
+            @JOverride
+            def run(self):
+                pass
+
+        al = JClass('java.util.ArrayList')()
+        runner = MyRun()
+        al.add(runner)
+        self.assertIs(al.get(0), runner)
+
+    def testProxyLeak(self):
+ 
+        @JImplements(java.lang.Runnable)
+        class MyRun(object):
+            @JOverride
+            def run(self):
+                pass
+
+        al = JClass('java.util.ArrayList')()
+        runner = MyRun()
+        al.add(runner)
+        initial = sys.getrefcount(runner)
+        for i in range(0,10):
+            self.assertIs(al.get(0), runner)
+        final = sys.getrefcount(runner)
+        self.assertEqual(initial, final)
 
     def testProxyDeclFail1(self):
         itf1 = self.package.TestInterface1


### PR DESCRIPTION
This is a follow up to #486.  The user was looking to store a Python object in a Java container.  This is the first half of a patch to allow that to happen.  In this PR, we delegate the lookup of  the class for an object to Java where it splits out common types from special cases such as lambda, anonymous classes, and proxies.  For proxies that belong to Python we cam the return the item. 

This is currently happening automatically.  The only potential breakage is a proxy that receives another proxy on the parameters will get the Python object rather than the Java mostly useless version. 

A  follow up should be able allow manual casting of any arbitrary Python class to be cast to Java and live  there, without the need to force implementation of an interface.