### PR TITLE
Fix bug reported on null array slices.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
 - **Next version - unreleased**
+  
+  - Corrected segfault when converting null elements while accessing a slice
+    from a Java object array.
 
 - **0.7.0 - 2019**
   - Doc strings are generated for classes and methods.

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -201,6 +201,7 @@ void JPClass::setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* ob
 
 JPPyObject JPClass::getArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length)
 {
+	JP_TRACE_IN("JPClass::getArrayRange");
 	jobjectArray array = (jobjectArray) a;
 
 	JPPyTuple res(JPPyTuple::newTuple(length));
@@ -209,11 +210,14 @@ JPPyObject JPClass::getArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsi
 	for (int i = 0; i < length; i++)
 	{
 		v.l = frame.GetObjectArrayElement(array, i + start);
-		JPClass* t = JPTypeManager::findClassForObject(v.l);
-		res.setItem(i, t->convertToPythonObject(v).get());
+		JPClass* type = this;
+		if (v.l != NULL)
+			type = JPTypeManager::findClassForObject(v.l);
+		res.setItem(i, type->convertToPythonObject(v).get());
 	}
 
 	return res;
+	JP_TRACE_OUT;
 }
 
 void JPClass::setArrayRange(JPJavaFrame& frame, jarray a, jsize start, jsize length, PyObject* vals)

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -389,3 +389,8 @@ class ArrayTestCase(common.JPypeTestCase):
         self.assertFalse(array.equals(carray))
         # Copy is shallow
         self.assertTrue(array[0].equals(carray[0]))
+
+    def testObjectNullArraySlice(self):
+        # Check for bug in 0.7.0
+        array = jpype.JArray(jpype.JObject)([None,])
+        self.assertEqual(array[:], (None,))


### PR DESCRIPTION
This PR addresses a segmentation fault on array slices.  Apparently one path was missed on the last clean up and thus was not checking if the object was null before getting the object type.  This results in a segfault when the list element was accessed as part of a slice.

Fixes #499