### PR TITLE
Fix array.array.frombytes for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - '3.5'
   - '3.6'
   - 'nightly'
-  - 'pypy'
   - 'pypy3'
 
 env:
@@ -16,7 +15,7 @@ env:
     - PIP=pip
     - INST=""
     # Moved numpy testing to Xenial
-    #   Testing with and without numpy on more than 2.7/3.7 for each arch
+    #   Testing with and without numpy on more than 3.7 for each arch
     #   is likely a waste.  The paths to a CPython module do not really
     #   change, but byte order and major version may make a difference.
 
@@ -28,7 +27,6 @@ addons:
 matrix:
   allow_failures:
     - python: nightly
-    - python: pypy
     - python: pypy3
 
   include:

--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -247,7 +247,7 @@ def _JArrayNewClass(cls, ndims=1):
 
 # FIXME JavaArrayClass likely should be exposed for isinstance, issubtype
 # FIXME are these not sequences?  They act like sequences but are they
-# connected to collections.Sequence
+# connected to collections.abc.Sequence
 # has: __len__, __iter__, __getitem__
 # missing: __contains__ (required for in)
 # Cannot be Mutable because java arrays are fixed in length

--- a/setupext/build_thunk.py
+++ b/setupext/build_thunk.py
@@ -33,7 +33,7 @@ def output(fout, l):
     print("    ", file=fout, end="")
     line = []
     buffer = array.array("B")
-    buffer.fromstring(l)
+    buffer.frombytes(l)
     for i in buffer:
         line.append("(jbyte)0x%02X" % i)
     print(",".join(line), file=fout, end="")

--- a/test/jpypetest/test_list.py
+++ b/test/jpypetest/test_list.py
@@ -45,7 +45,7 @@ class JListTestCase(common.JPypeTestCase):
                 stop = self.size() + stop
             for i in range(start, stop):
                 self.remove(start)
-            if isinstance(v, collections.Sequence):
+            if isinstance(v, collections.abc.Sequence):
                 ndx = start
                 for i in v:
                     self.add(ndx, i)


### PR DESCRIPTION
Fixes https://github.com/jpype-project/jpype/issues/570.

* array.fromstring was removed in favour of frombytes in Python 3.9
* Python 2 has been dropped, remove PyPy2 from CI
* Sequence is in collections.abc in Python 3.3+. This is commented code, but updated just in case it's uncommented in future

nightly on Travis CI now points to Python 3.9, and it's now green :)