### PR TITLE
Proxy convert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ doc/html
 native/jars
 docker/*.tar.gz
 docker/wheelhouse
+/.eggs
+/tmp*

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,11 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 - **Next version - unreleased**
 
+  - Fixed memory leak in Proxy invocation
+
+  - Fixed bug with Proxy not converting when passed as an argument to Python functions
+    during execution of proxies
+
 
 - **0.7.1 - 12-16-2019**
 

--- a/test/harness/jpype/proxy/ProxyTriggers.java
+++ b/test/harness/jpype/proxy/ProxyTriggers.java
@@ -67,4 +67,9 @@ public class ProxyTriggers
     	byte[] vals = { 1, 2, 3, 4};
     	return itf.write(vals , 12, 13);
     }
+
+    public boolean testEquals(Object o)
+    {
+	    return o.equals(o);
+    }
 }

--- a/test/harness/jpype/proxy/TestInterface5.java
+++ b/test/harness/jpype/proxy/TestInterface5.java
@@ -1,0 +1,7 @@
+
+package jpype.proxy;
+
+public interface TestInterface5 {
+   public boolean equals(Object o);
+}
+

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -296,3 +296,19 @@ class ProxyTestCase(common.JPypeTestCase):
                 pass
         self.assertIsInstance(JObject(MyClass(), jrun), jrun)
         self.assertIsInstance(JObject(MyClass()), jobj)
+
+    def testProxyConvert(self):
+        # This was tests that arguments and "self" both
+        # convert to the same object
+        TestInterface5 = JClass("jpype.proxy.TestInterface5")
+        ProxyTriggers = JClass("jpype.proxy.ProxyTriggers")
+
+        @JImplements(TestInterface5)
+        class Bomb(object):
+            @JOverride
+            def equals(self, other):
+                return type(self)==type(other)
+
+        b = Bomb()
+        t = ProxyTriggers()
+        self.assertTrue(t.testEquals(b))


### PR DESCRIPTION
Fixes #574 

This patch fixes one memory leak in which the JProxy handler was being reregistered every time a proxy was called and makes it such that proxies always get the most derived class when passing arguments rather than the class declared in the interface.   This bug was preventing the appropriate type converter from being found with a proxy was passed through.  It would also have prevented methods defined in derived type from being accessed as the wrapper was being forced to use the base class.

Pull request contains documentation, fix, and a test for the previous behavior.