### PR TITLE
BUG report: JProxy instance passed to JClass constructor not destroyed when out of scope

### DIFF
--- a/test/harness/jpype/interface_container/TestInterface.java
+++ b/test/harness/jpype/interface_container/TestInterface.java
@@ -1,0 +1,7 @@
+package jpype.interface_container;
+
+
+public interface TestInterface
+{
+  public void callback(String message);
+}

--- a/test/harness/jpype/interface_container/TestInterfaceContainer.java
+++ b/test/harness/jpype/interface_container/TestInterfaceContainer.java
@@ -1,0 +1,9 @@
+package jpype.interface_container;
+
+
+public class TestInterfaceContainer
+{
+    public TestInterfaceContainer(TestInterface interface_impl) {
+
+    }
+}

--- a/test/jpypetest/test_interface_container.py
+++ b/test/jpypetest/test_interface_container.py
@@ -1,0 +1,39 @@
+from jpype import JPackage, JArray, JByte, java, JClass, JProxy
+import common
+
+
+class DestructionTracker:
+    del_calls = 0
+
+    def __del__(self):
+        DestructionTracker.del_calls += 1
+
+    def callback(self, message):
+        pass
+
+
+class InterfaceContainerTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+
+    def testNoInterfaceLeak(self):
+        DestructionTracker.del_calls = 0
+
+        interface = JProxy(
+            "jpype.interface_container.TestInterface",
+            dict={'callback': DestructionTracker().callback})
+
+        del interface
+        self.assertEqual(DestructionTracker.del_calls, 1)
+
+    def testContainerLeak(self):
+        DestructionTracker.del_calls = 0
+
+        interface = JProxy(
+            "jpype.interface_container.TestInterface",
+            dict={'callback': DestructionTracker().callback})
+        interface_container = JClass(
+            "jpype.interface_container.TestInterfaceContainer")(interface)
+
+        del interface, interface_container
+        self.assertEqual(DestructionTracker.del_calls, 1)


### PR DESCRIPTION
I've put together a test case which demonstrates an issue with objects not being destroyed when I believe they should be. In particular I have a JProxy instance passed to the constructor of a JClass instance and am not holding a reference to it in the Java code. In this scenario the destructor of the object held by JProxy is never called even though there is no reference to it. If the JProxy object is never passed to the JClass constructor then the object is destroyed as expected.

Hopefully the test case demonstrates the scenario more clearly than the description above :wink:.

In the test cases provided, the test (``testNoInterfaceLeak``) which simply creates a JProxy object and then deletes it *does* call ``__del__`` on the object held by the proxy. The the test (```testContainerLeak```) which does the above as well as calling the JClass constructor does not result in the ``__del__`` method being called.



