### PR TITLE
Link Python and Java GC 

### DIFF
--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -152,4 +152,20 @@ class JPField;
 // Services
 #include "jp_proxy.h"
 
+namespace JPGarbageCollection
+{
+void init();
+
+/**
+ * Called when Python starts it Garbage collector
+ */
+void onStart();
+
+/**
+ * Called when Python finishes it Garbage collector
+ */
+void onEnd();
+
+}
+
 #endif // _JPYPE_H_

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -156,6 +156,8 @@ namespace JPGarbageCollection
 {
 void init();
 
+void shutdown();
+
 /**
  * Called when Python starts it Garbage collector
  */

--- a/native/common/jp_env.cpp
+++ b/native/common/jp_env.cpp
@@ -209,6 +209,8 @@ void JPEnv::shutdown()
 	if (s_JavaVM == NULL)
 		JP_RAISE(PyExc_RuntimeError, "Attempt to shutdown without a live JVM");
 
+	JPGarbageCollection::shutdown();
+
 	// Reference queue has to be be shutdown first as we need to close resources
 	JPReferenceQueue::shutdown();
 

--- a/native/common/jp_env.cpp
+++ b/native/common/jp_env.cpp
@@ -181,6 +181,7 @@ void JPEnv::loadJVM(const string& vmPath, const StringVector& args, bool ignoreU
 		JPReferenceQueue::init();
 		JPProxy::init();
 		JPReferenceQueue::startJPypeReferenceQueue();
+		JPGarbageCollection::init();
 	}	catch (JPypeException& ex)
 	{
 		// Special case, if we get a Java exception here we can't convert

--- a/native/common/jp_gc.cpp
+++ b/native/common/jp_gc.cpp
@@ -1,0 +1,165 @@
+#include <Python.h>
+#include "jpype.h"
+#include "jp_reference_queue.h"
+
+#ifndef WIN32
+#include <sys/resource.h>
+#endif
+
+namespace
+{
+bool in_python_gc = false;
+PyObject *python_gc = NULL;
+jclass _SystemClass = NULL;
+jmethodID _gcMethodID;
+//PyMemAllocatorEx raw_allocators;
+}
+
+void triggerPythonGC();
+
+extern "C" void callbackJavaGCTriggered(void* n)
+{
+	printf("Sentinel trigger\n");
+	// Install a new sentinel
+	JPJavaFrame frame;
+	jobject sentinel = frame.NewByteArray(0);
+	JPReferenceQueue::registerRef(sentinel, 0, callbackJavaGCTriggered);
+	if (!in_python_gc)
+	{
+		printf("Force Python\n");
+		// trigger Python gc
+		in_python_gc = true;
+		PyGC_Collect();
+	}
+}
+
+//extern "C" void* gc_malloc_raw(void *ctx, size_t sz)
+//{
+//	printf("Malloc %lu\n", sz);
+//	PyMemAllocatorEx *alloc = (PyMemAllocatorEx *) ctx;
+//	return raw_allocators.malloc(raw_allocators.ctx, sz);
+//}
+//
+//extern "C" void* gc_calloc_raw(void *ctx, size_t nelem, size_t elsize)
+//{
+//	printf("Calloc %lu\n", nelem * elsize);
+//	PyMemAllocatorEx *alloc = (PyMemAllocatorEx *) ctx;
+//	PyMemAllocatorEx *prior = (PyMemAllocatorEx *) alloc->ctx;
+//	return raw_allocators.calloc(raw_allocators.ctx, nelem, elsize);
+//}
+//
+//extern "C" void* gc_realloc_raw(void *ctx, void* ptr, size_t size)
+//{
+//	printf("Realloc %lu\n", size);
+//	PyMemAllocatorEx *alloc = (PyMemAllocatorEx *) ctx;
+//	PyMemAllocatorEx *prior = (PyMemAllocatorEx *) alloc->ctx;
+//	return raw_allocators.realloc(raw_allocators.ctx, ptr, size);
+//}
+//
+//extern "C" void gc_free_raw(void *ctx, void* ptr)
+//{
+//	printf("Free %p\n", ptr);
+//	PyMemAllocatorEx *alloc = (PyMemAllocatorEx *) ctx;
+//	PyMemAllocatorEx *prior = (PyMemAllocatorEx *) alloc->ctx;
+//	raw_allocators.free(raw_allocators.ctx, ptr);
+//}
+
+// Connection to numpy if using a weak import if possible
+//typedef void (*PyDataMem_EventHookFunc)(void *inp, void *outp, size_t size,
+//		void *user_data);
+
+void **PyArray_API;
+typedef void (PyDataMem_EventHookFunc) (void *inp, void *outp, size_t size,
+		void *user_data);
+typedef PyDataMem_EventHookFunc * PyDataMem_SetEventHook \
+       (PyDataMem_EventHookFunc *, void *, void **);
+#define PyDataMem_SetEventHook \
+        (*(PyDataMem_EventHookFunc * (*)(PyDataMem_EventHookFunc *, void *, void **)) \
+         PyArray_API[291])
+
+//static void myevent_hook(void *inp, void *outp, size_t size,
+//		void *user_data)
+//{
+//	if (inp == NULL)
+//	{
+//		ssize_t* q = (ssize_t*) outp;
+//		printf("Hook no in %d %p %d\n", size, outp, q[-1]);
+//	}
+//	if (size == 0)
+//	{
+//		ssize_t* q = (ssize_t*) inp;
+//		printf("Hook no size %p %d\n", inp, q[-1]);
+//	}
+//}
+
+void JPGarbageCollection::init()
+{
+	JPJavaFrame frame;
+	// Install a sentinel to detect when Java has started a GC cycle
+	jobject sentinel = frame.NewByteArray(0);
+	JPReferenceQueue::registerRef(sentinel, 0, callbackJavaGCTriggered);
+
+	// Get the Python garbage collector
+	JPPyObject gc(JPPyRef::_call, PyImport_ImportModule("gc"));
+	python_gc = gc.keep();
+
+	// Find the callbacks
+	JPPyObject callbacks(JPPyRef::_call, PyObject_GetAttrString(python_gc, "callbacks"));
+
+	// Hook up our callback
+	JPPyObject collect(JPPyRef::_call, PyObject_GetAttrString(PyJPModule, "_collect"));
+	PyList_Append(callbacks.get(), collect.get());
+	JP_PY_CHECK();
+
+	// Get the Java System gc so we can trigger
+	_SystemClass = (jclass) frame.NewGlobalRef(frame.FindClass("java/lang/System"));
+	_gcMethodID = frame.GetStaticMethodID(_SystemClass, "gc", "()V");
+
+
+	//	PyObject *numpy = PyImport_ImportModule("numpy.core._multiarray_umath");
+	//	if (numpy != NULL)
+	//	{
+	//		PyObject *c_api = PyObject_GetAttrString(numpy, "_ARRAY_API");
+	//		PyArray_API = (void **) PyCapsule_GetPointer(c_api, NULL);
+	//		printf("array %p\n", PyArray_API[291]);
+	//		void *old_data;
+	//		PyDataMem_SetEventHook(myevent_hook, NULL, &old_data);
+	//	} else
+	//	{
+	//		PyErr_Clear();
+	//	}
+	// Connect into Python so we know when we need to trigger a Java collection
+	//	PyMemAllocatorEx alloc;
+	//	alloc.malloc = gc_malloc_raw;
+	//	alloc.calloc = gc_calloc_raw;
+	//	alloc.realloc = gc_realloc_raw;
+	//	alloc.free = gc_free_raw;
+	//
+	//	alloc.ctx = &raw_allocators;
+	//	PyMem_GetAllocator(PYMEM_DOMAIN_MEM, &raw_allocators);
+	//	PyMem_SetAllocator(PYMEM_DOMAIN_MEM, &alloc);
+}
+
+void JPGarbageCollection::onStart()
+{
+	if (in_python_gc)
+		return;
+	printf("Start Python\n");
+	JPJavaFrame frame;
+	in_python_gc = true;
+	//	printf("Force Java\n");
+	//	frame.CallStaticVoidMethodA(_SystemClass, _gcMethodID, 0);
+}
+
+void JPGarbageCollection::onEnd()
+{
+	printf("End Python\n");
+	if (in_python_gc)
+	{
+		rusage usage;
+		getrusage(RUSAGE_SELF, &usage);
+		printf("usage %ld\n", usage.ru_maxrss);
+	}
+	// Remove our lock so that we can watch for triggers
+	in_python_gc = false;
+}

--- a/project/jpype_cpython/Makefile.linux
+++ b/project/jpype_cpython/Makefile.linux
@@ -31,7 +31,8 @@ SRCS = build/src/jp_thunk.cpp native/common/jp_array.cpp native/common/jp_arrayc
        native/python/pyjp_field.cpp native/python/pyjp_method.cpp native/python/pyjp_module.cpp \
        native/python/pyjp_monitor.cpp native/python/pyjp_object.cpp native/python/pyjp_proxy.cpp \
        native/python/pyjp_value.cpp \
-       native/python/pyjp_number.cpp
+       native/python/pyjp_number.cpp \
+       native/common/jp_gc.cpp
 
 all: $(LIB)
 

--- a/project/jpype_cpython/nbproject/configurations.xml
+++ b/project/jpype_cpython/nbproject/configurations.xml
@@ -75,6 +75,7 @@
         <itemPath>../../native/common/jp_exception.cpp</itemPath>
         <itemPath>../../native/common/jp_field.cpp</itemPath>
         <itemPath>../../native/common/jp_floattype.cpp</itemPath>
+        <itemPath>../../native/common/jp_gc.cpp</itemPath>
         <itemPath>../../native/common/jp_inttype.cpp</itemPath>
         <itemPath>../../native/common/jp_jniutil.cpp</itemPath>
         <itemPath>../../native/common/jp_longtype.cpp</itemPath>
@@ -396,6 +397,8 @@
             ex="false"
             tool="1"
             flavor2="0">
+      </item>
+      <item path="../../native/common/jp_gc.cpp" ex="false" tool="1" flavor2="0">
       </item>
       <item path="../../native/common/jp_inttype.cpp" ex="false" tool="1" flavor2="0">
       </item>

--- a/test/harness/jpype/interface_container/TestInterface.java
+++ b/test/harness/jpype/interface_container/TestInterface.java
@@ -1,0 +1,7 @@
+package jpype.interface_container;
+
+
+public interface TestInterface
+{
+	  public void callback(String message);
+}

--- a/test/harness/jpype/interface_container/TestInterfaceContainer.java
+++ b/test/harness/jpype/interface_container/TestInterfaceContainer.java
@@ -1,0 +1,9 @@
+package jpype.interface_container;
+
+
+public class TestInterfaceContainer
+{
+	    public TestInterfaceContainer(TestInterface interface_impl) {
+
+		        }
+}

--- a/test/jpypetest/subrun.py
+++ b/test/jpypetest/subrun.py
@@ -54,7 +54,7 @@ class Client(object):
         self.process = ctx.Process(target=_execute, args=[
                                    self.inQueue, self.outQueue], daemon=True)
         self.process.start()
-        self.timeout = 5
+        self.timeout = 20
 
     def execute(self, function, *args, **kwargs):
         self.inQueue.put([function.__name__, os.path.abspath(


### PR DESCRIPTION
(out of date,  need to be freshened)
This is an experimental PR designed to tie the Java and Python GC together.  It still requires additional tuning and a resolution as to why it causes shutdown to pause for a prolonged period.

@pelson This is my first hack at solving the problem.  

I used a few strategies to try to suppress the aggressive Python GC.   
1) Don't force a GC until we exceed what is expected from just running a normal Java process.
2) Once the process is over the limit wait until the memory grows.  (Thus will slowly climb the memory as we will trigger this with larger and larger amounts of freed memory)
3) Record the time to hit the growth cap and then predicatively call  the GC before we would be forced to.
4) If we hit a hard cap then be more aggressive about it.

There are still some minor issues before this is ready for prime time and some tuning required, but lets first see how bad this busts the test matrix.
