### PR TITLE
Changes to build makefiles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import warnings
 import setupext
 from setuptools import setup
 from setuptools import Extension
@@ -42,6 +41,7 @@ setup(
         'build_java': setupext.build_java.BuildJavaCommand,
         'build_thunk': setupext.build_thunk.BuildThunkCommand,
         'build_ext': setupext.build_ext.BuildExtCommand,
+        'build_makefile': setupext.build_makefile.BuildMakefileCommand,
         'test_java': setupext.test_java.TestJavaCommand,
         'sdist': setupext.sdist.BuildSourceDistribution,
         'test': setupext.pytester.PyTest,

--- a/setupext/__init__.py
+++ b/setupext/__init__.py
@@ -2,6 +2,7 @@ from . import utils
 from . import dist
 from . import platform
 from . import build_ext
+from . import build_makefile
 from . import build_java
 from . import build_thunk
 from . import test_java

--- a/setupext/build_ext.py
+++ b/setupext/build_ext.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
-import warnings
 from setuptools.command.build_ext import build_ext
-from setuptools import Extension
 
 
 class FeatureNotice(Warning):
@@ -77,6 +73,9 @@ class BuildExtCommand(build_ext):
         self._set_cflags()
         if tracing:
             jpypeLib.define_macros.append(('JP_TRACING_ENABLE', 1))
+        coverage = self.distribution.enable_coverage
+        if coverage:
+            jpypeLib.define_macros.append(('JP_INSTRUMENTATION', 1))
 
         # has to be last call
         build_ext.build_extensions(self)

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -4,7 +4,7 @@ import subprocess
 import distutils.cmd
 import distutils.log
 from distutils.errors import DistutilsPlatformError
-from distutils.dir_util import copy_tree, remove_tree
+from distutils.dir_util import copy_tree
 
 
 class BuildJavaCommand(distutils.cmd.Command):

--- a/setupext/build_makefile.py
+++ b/setupext/build_makefile.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+import os
+from setuptools.command.build_ext import build_ext
+
+# This setup target constructs a prototype Makefile suitable for compiling 
+# the _jpype extension module.  It is intended to help with development
+# of the extension library on unix systems.
+#
+# To create a Makefile use
+#    python setup.py build_makefile
+#
+# Then edit with the desired options
+
+class FeatureNotice(Warning):
+    """ indicate notices about features """
+
+class Makefile(object):
+    def __init__(self, actual):
+        self.actual = actual
+        self.compile_command = None
+        self.compile_pre = None
+        self.compile_post = None
+        self.objects = []
+        self.sources = []
+
+    def captureCompile(self, x):
+        command = x[0]
+        x = x[1:]
+        includes = [ i for i in x if i.startswith("-I")]
+        x = [ i for i in x if not i.startswith("-I")]
+        i0 = None
+        i1 = None
+        for i,v in enumerate(x):
+            if v == '-c': i1=i
+            elif v == '-o': i0=i
+        pre = set(x[:i1])
+        post = x[i0+2:]
+
+        self.compile_command = command
+        self.compile_pre = pre
+        self.compile_post = post
+        self.includes = includes
+        self.sources.append(x[i1+1])
+
+    def captureLink(self, x):
+        self.link_command = x[0]
+        x = x[1:]
+        self.library = x[-1]
+        print(x[-3:])
+        x = x[:-3]
+        self.objects = [ i for i in x if i.endswith(".o")]
+        self.link_options = [ i for i in x if not i.endswith(".o")]
+        u = self.objects[0].split("/")
+        self.build_dir = "/".join(u[:2])
+
+    def compile(self, *args, **kwargs):
+        self.actual.spawn = self.captureCompile
+        return self.actual.compile(*args, **kwargs)
+
+    def link_shared_object(self, *args, **kwargs):
+        self.actual.spawn = self.captureLink
+        return self.actual.link_shared_object(*args, **kwargs)
+
+    def detect_language(self, x):
+        return self.actual.detect_language(x)
+
+    def write(self):
+        library = os.path.basename(self.library)
+        link_command = self.link_command
+        compile_command = self.compile_command
+        compile_pre = " ".join(list(self.compile_pre))
+        compile_post = " ".join(list(self.compile_post))
+        build = self.build_dir
+        link_flags = " ".join(self.link_options)
+        includes = " ".join(self.includes)
+        sources = " \\\n     ".join(self.sources)
+        with open("Makefile", "w") as fd:
+            print("LIB = %s"%library, file=fd)
+            print("CC = %s"%compile_command, file=fd)
+            print("LINK = %s"%link_command, file=fd)
+            print("CFLAGS = %s %s"%(compile_pre,compile_post), file=fd)
+            print("INCLUDES = %s"%includes, file=fd)
+            print("BUILD = %s"%build, file=fd)
+            print("LINKFLAGS = %s"%link_flags, file=fd)
+            print("SRCS = %s"%sources, file=fd)
+            print("""
+all: $(LIB)
+
+DEPDIR = build/deps
+$(DEPDIR): ; @mkdir -p $@
+
+DEPFILES := $(SRCS:%.cpp=$(DEPDIR)/%.d)
+
+deps: $(DEPFILES)
+
+%/:
+	echo $@
+
+$(DEPDIR)/%.d: %.cpp 
+	mkdir -p $(dir $@)
+	$(CC) $(INCLUDES) -MT $(patsubst $(DEPDIR)%,'$$(BUILD)%',$(patsubst %.d,%.o,$@)) -MM $< -o $@
+
+OBJS = $(addprefix $(BUILD)/, $(SRCS:.cpp=.o))
+
+
+$(BUILD)/%.o: %.cpp
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
+
+$(LIB): $(OBJS)
+	$(LINK) $(LINKFLAGS) $(OBJS) -ldl -o $@
+
+
+-include $(DEPFILES)
+""", file=fd)
+
+
+# Customization of the build_ext
+class BuildMakefileCommand(build_ext):
+    """
+    Override some behavior in extension building:
+
+    1. handle compiler flags for different compilers via a dictionary.
+    2. try to disable warning -Wstrict-prototypes is valid for C/ObjC but not for C++
+    """
+
+    # extra compile args
+    copt = {'msvc': [],
+            'unix': ['-ggdb',],
+            'mingw32': [],
+            }
+    # extra link args
+    lopt = {
+        'msvc': [],
+        'unix': [],
+        'mingw32': [],
+    }
+
+    def initialize_options(self, *args):
+        """omit -Wstrict-prototypes from CFLAGS since its only valid for C code."""
+        import distutils.sysconfig
+        cfg_vars = distutils.sysconfig.get_config_vars()
+        replacement = {
+            '-Wstrict-prototypes': '',
+            '-Wimplicit-function-declaration': '',
+        }
+        replacement['-O3'] = '-O0'
+
+        for k, v in cfg_vars.items():
+            if not isinstance(v, str):
+                continue
+            if not k=="OPT" and not "FLAGS" in k:
+                continue
+            for r, t in replacement.items():
+                if v.find(r) != -1:
+                    v = v.replace(r, t)
+                    cfg_vars[k] = v
+        build_ext.initialize_options(self)
+
+    def _set_cflags(self):
+        # set compiler flags
+        c = self.compiler.compiler_type
+        if c == 'unix' and self.distribution.enable_coverage:
+           self.extensions[0].extra_compile_args.extend(['-O0', '--coverage', '-ftest-coverage'])
+           self.extensions[0].extra_link_args.extend(['--coverage'])
+        if c in self.copt:
+            for e in self.extensions:
+                e.extra_compile_args.extend(self.copt[c])
+        if c in self.lopt:
+            for e in self.extensions:
+                e.extra_link_args.extend(self.lopt[c])
+
+
+    def build_extensions(self):
+        # We need to create the thunk code
+        self.run_command("build_java")
+        self.run_command("build_thunk")
+
+        jpypeLib = self.extensions[0]
+        tracing = self.distribution.enable_tracing
+        self._set_cflags()
+        if tracing:
+            jpypeLib.define_macros.append(('JP_TRACING_ENABLE', 1))
+        coverage = self.distribution.enable_coverage
+        if coverage:
+            jpypeLib.define_macros.append(('JP_INSTRUMENTATION', 1))
+
+        self.compiler = Makefile(self.compiler)
+
+        # has to be last call
+        build_ext.build_extensions(self)
+
+        self.compiler.write()
+
+    def __init__(self, *args):
+        build_ext.__init__(self, *args)
+

--- a/setupext/build_thunk.py
+++ b/setupext/build_thunk.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 import os
-import subprocess
 import distutils.cmd
 import distutils.log
 import array

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -3,8 +3,6 @@ import warnings
 import setupext
 import os
 import sys
-from setuptools import setup
-from setuptools import Extension
 
 # This handles all of the work to make our platform specific extension options.
 
@@ -34,7 +32,6 @@ if os.path.exists(java_home) and sys.platform != "cygwin":
             break
 
     if not found_jni:
-        import warnings
         warnings.warn('Falling back to provided JNI headers, since your provided'
                       ' JAVA_HOME "%s" does not provide jni.h' % java_home)
 

--- a/setupext/sdist.py
+++ b/setupext/sdist.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
-import warnings
 import distutils
 from distutils.dir_util import copy_tree, remove_tree
 from setuptools.command.sdist import sdist
-from setuptools import Extension
 
 # Customization of the sdist
 class BuildSourceDistribution(sdist):


### PR DESCRIPTION
This pull request clears a number of warnings from LGTM and introduces a command to create a makefile to help with incremental builds.   The makefile currently only works for linux type systems, but otherwise should be fully functional.

To create a makefile use 

```
    python setup.py build_makefile
```

It is tied to the build ext system so unfortunately it doesn't run properly if the ``build`` directory already exists.  You can then edit the makefile and use it to test builds.  Once this is is working we can remove the project/jpype_cpython/Makefile.

This is backport of a portion of instrumentation pull request.