### PR TITLE
Remove fatal handling on jp_trace

### DIFF
--- a/native/common/jp_tracer.cpp
+++ b/native/common/jp_tracer.cpp
@@ -116,11 +116,6 @@ void JPypeTracer::trace1(const char* msg)
 
 	if (jpype_tracer_last != NULL)
 		name = jpype_tracer_last->m_Name;
-	else
-	{
-		int *i = 0;
-		*i = 0;
-	}
 
 	for (int i = 0; i < jpype_traceLevel; i++)
 	{


### PR DESCRIPTION
A fatal error is being tripped during fatal error fault handling that is preventing the error message from being printed prior to abort.  This PR disables the bad check so that the error can proceed.