### PR TITLE
Fix three segfaults found in test

### DIFF
--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -983,7 +983,15 @@ public:
 
 	~JPStringAccessor()
 	{
-		frame_.ReleaseStringUTFChars(jstr_, cstr);
+		try
+		{
+			frame_.ReleaseStringUTFChars(jstr_, cstr);
+		}		catch (JPypeException &ex)
+		{
+			// Error during release must be eaten.
+			// If Java does not accept a release of the buffer it
+			// is Java's issue, not ours.
+		}
 	}
 } ;
 

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -33,7 +33,7 @@ static void releaseProxyPython(void* host)
 JPPyTuple getArgs(JPContext* context, jlongArray parameterTypePtrs,
 		jobjectArray args)
 {
-	JP_TRACE_IN("JProxy getArgs");
+	JP_TRACE_IN("JProxy::getArgs");
 	JPJavaFrame frame(context);
 	jsize argLen = frame.GetArrayLength(parameterTypePtrs);
 	JPPyTuple pyargs(JPPyTuple::newTuple(argLen));
@@ -46,6 +46,8 @@ JPPyTuple getArgs(JPContext* context, jlongArray parameterTypePtrs,
 		JP_TRACE("Convert", i, type->getCanonicalName());
 		jobject obj = frame.GetObjectArrayElement(args, i);
 		JPClass* type = frame.findClassForObject(obj);
+		if (type == NULL)
+			type = reinterpret_cast<JPClass*> (accessor.get()[i]);
 		JPValue val = type->getValueFromObject(JPValue(type, obj));
 		pyargs.setItem(i, type->convertToPythonObject(frame, val).get());
 	}

--- a/native/common/jp_tracer.cpp
+++ b/native/common/jp_tracer.cpp
@@ -116,11 +116,6 @@ void JPypeTracer::trace1(const char* msg)
 
 	if (jpype_tracer_last != NULL)
 		name = jpype_tracer_last->m_Name;
-	else
-	{
-		int *i = 0;
-		*i = 0;
-	}
 
 	for (int i = 0; i < jpype_traceLevel; i++)
 	{

--- a/test/jpypetest/test_fault.py
+++ b/test/jpypetest/test_fault.py
@@ -132,6 +132,9 @@ class FaultTestCase(common.JPypeTestCase):
         _jpype.fault("PyJPArray_assignSubscript")
         with self.assertRaisesRegex(SystemError, "fault"):
             ja[0] = 1
+        _jpype.fault("PyJPModule_getContext")
+        with self.assertRaisesRegex(SystemError, "fault"):
+            ja[0:2] = 1
 
     def testJPArray_assignSubscriptExc(self):
         ja = JArray(JInt)(5)
@@ -139,9 +142,6 @@ class FaultTestCase(common.JPypeTestCase):
             del ja[0:2]
         with self.assertRaises(ValueError):
             ja[slice(0, 0, 0)] = 1
-        _jpype.fault("PyJPModule_getContext")
-        with self.assertRaises(SystemError):
-            ja[0:2] = 1
 
     # FIXME investigate why the release is not happening
     # may indicate a leak. Disabling for now


### PR DESCRIPTION
Three segfaults were discovered in instrumentation that were not dealt with at the time.

JPProxy did not properly handle null pointers.
ReleaseString did not properly squash exceptions during a dtor as required.
JPProxy can't issue a fault during the trace block because there is not outer try block (nor should there be)  It already has a catch (...) clause so we just need to improve instrumentation on that unit.  Disabling that one as a false alarm.