### PR TITLE
Fixed bug that was making java.lang.Comparable, char[], and byte[] unhashable

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
   - float properly follows Java rules for conversion from double.
     floats outside of range map to inf and -inf.
 
+  - Fix bug that was causing java.lang.Comparable, byte[], and char[] to be unhashable.
+
 - **0.7.2 - 2-28-2019**
 
   - C++ and Java exceptions hold the traceback as a Python exception

--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -203,6 +203,7 @@ class _JCharArray(object):
             return self.equals(self.__class__(other))
         except TypeError:
             return False
+    __hash__ = _jpype._JObject.__hash__
 
 
 # Install module hooks

--- a/jpype/_jcomparable.py
+++ b/jpype/_jcomparable.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 # *****************************************************************************
+import _jpype
 from . import _jcustomizer
 
 
@@ -37,3 +38,6 @@ class _JComparable(object):
 
     def __le__(self, o):
         return self.compareTo(o) <= 0
+
+    __hash__ = _jpype._JObject.__hash__
+

--- a/test/jpypetest/test_comparable.py
+++ b/test/jpypetest/test_comparable.py
@@ -23,3 +23,7 @@ class ComparableTestCase(common.JPypeTestCase):
         self.assertTrue(a <= b)
         self.assertFalse(a == b)
         self.assertTrue(a != b)
+
+    def testComparableHash(self):
+        i = jpype.java.math.BigInteger("1000000000000")
+        self.assertIsInstance(hash(i), int)

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -149,3 +149,7 @@ class JByteTestCase(common.JPypeTestCase):
             jf.static_byte_field = object()
         with self.assertRaises(TypeError):
             jf().byte_field = object()
+
+    def testArrayHash(self):
+        ja = JArray(JByte)([1,2,3])
+        self.assertIsInstance(hash(ja), int)

--- a/test/jpypetest/test_jchar.py
+++ b/test/jpypetest/test_jchar.py
@@ -96,3 +96,8 @@ class JCharTestCase(common.JPypeTestCase):
         self.assertEqual(array, array)
         self.assertNotEqual(array, array2)
         self.assertEqual(array, "abc")
+
+    def testArrayHash(self):
+        ja = JArray(JByte)([1,2,3])
+        self.assertIsInstance(hash(ja), int)
+


### PR DESCRIPTION
Apparently Python has some magic regarding ``__eq__`` that we have to work around, but we didn't have a test for it so it got removed during clean up.  This PR fixes the issue and adds the appropriate tests.

Fixes #608