### PR TITLE
Fixes for primitive type system and coverage

### DIFF
--- a/native/common/include/jp_boxedtype.h
+++ b/native/common/include/jp_boxedtype.h
@@ -46,8 +46,11 @@ public:
 		return m_PrimitiveType;
 	}
 
+	jobject box(JPJavaFrame &frame, jvalue v);
+
 protected:
 	JPPrimitiveType* m_PrimitiveType;
+	jmethodID        m_CtorID;
 } ;
 
 #endif // _JPBOXEDCLASS_H_

--- a/native/common/include/jp_longtype.h
+++ b/native/common/include/jp_longtype.h
@@ -76,6 +76,11 @@ public:
 		return (jdouble) field(v);
 	}
 
+	static jlong assertRange(const jlong& l)
+	{
+		return l;
+	}
+
 	virtual void getView(JPArrayView& view) override;
 	virtual void releaseView(JPArrayView& view) override;
 	virtual const char* getBufferFormat() override;

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -64,5 +64,57 @@ public:
 
 } ;
 
+template <typename base_t>
+class JPConversionLong : public JPConversion
+{
+public:
+
+	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	{
+		jvalue res;
+		jlong val = PyLong_AsLongLong(pyobj);
+		if (val == -1)
+			JP_PY_CHECK();
+		base_t::field(res) = (typename base_t::type_t) base_t::assertRange(val);
+		return res;
+	}
+} ;
+
+template <typename base_t>
+class JPConversionLongNumber : public JPConversion
+{
+public:
+
+	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	{
+		jvalue res;
+		PyObject *obj = PyNumber_Long(pyobj);
+		JP_PY_CHECK();
+		jlong val = PyLong_AsLongLong(obj);
+		Py_DECREF(obj);
+		if (val == -1)
+			JP_PY_CHECK();
+		base_t::field(res) = (typename base_t::type_t) base_t::assertRange(val);
+		return res;
+	}
+} ;
+
+extern "C" JPValue* PyJPValue_getJavaSlot(PyObject* self);
+
+template <typename base_t>
+class JPConversionLongWiden : public JPConversion
+{
+public:
+
+	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	{
+		JPValue *value = PyJPValue_getJavaSlot(pyobj);
+		jvalue ret;
+		base_t::field(ret) = (typename base_t::type_t) ((JPPrimitiveType*) value->getClass())->getAsLong(value->getValue());
+		return ret;
+	}
+} ;
+
+
 #endif /* JP_PRIMITIVE_ACCESSOR_H */
 

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -214,7 +214,10 @@ void JPBooleanType::setArrayRange(JPJavaFrame& frame, jarray a,
 	jsize index = start;
 	for (Py_ssize_t i = 0; i < length; ++i, index += step)
 	{
-		val[index] = PyObject_IsTrue(seq[i].get());
+		int v = PyObject_IsTrue(seq[i].get());
+		if (v == -1)
+			JP_PY_CHECK();
+		val[index] = v;
 	}
 	accessor.commit();
 	JP_TRACE_OUT;

--- a/native/common/jp_boxedtype.cpp
+++ b/native/common/jp_boxedtype.cpp
@@ -26,6 +26,11 @@ JPBoxedType::JPBoxedType(JPJavaFrame& frame, jclass clss,
 : JPClass(frame, clss, name, super, interfaces, modifiers),
 m_PrimitiveType(primitiveType)
 {
+	if (name != "java.lang.Void")
+	{
+		string s = string("(") + primitiveType->getTypeCode() + ")V";
+		m_CtorID = frame.GetMethodID(clss, "<init>", s.c_str());
+	}
 }
 
 JPBoxedType::~JPBoxedType()
@@ -46,4 +51,9 @@ JPMatch::Type JPBoxedType::getJavaConversion(JPJavaFrame *frame, JPMatch &match,
 	}
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
+}
+
+jobject JPBoxedType::box(JPJavaFrame &frame, jvalue v)
+{
+	return frame.NewObjectA(m_Class.get(), m_CtorID, &v);
 }

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -42,18 +42,8 @@ JPValue JPByteType::getValueFromObject(const JPValue& obj)
 	return JPValue(this, v);
 }
 
-class JPConversionAsByte : public JPConversion
-{
-	typedef JPByteType base_t;
-public:
-
-	virtual jvalue convert(JPJavaFrame *frame, JPClass* cls, PyObject* pyobj) override
-	{
-		jvalue res;
-		base_t::field(res) = (base_t::type_t) base_t::assertRange(JPPyLong::asLong(pyobj));
-		return res;
-	}
-} asByteConversion;
+JPConversionLong<JPByteType> byteConversion;
+JPConversionLongNumber<JPByteType> byteNumberConversion;
 
 JPMatch::Type JPByteType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
 {
@@ -88,13 +78,13 @@ JPMatch::Type JPByteType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, 
 
 	if (PyLong_CheckExact(pyobj) || PyIndex_Check(pyobj))
 	{
-		match.conversion = &asByteConversion;
+		match.conversion = &byteConversion;
 		return match.type = JPMatch::_implicit;
 	}
 
-	if (PyLong_Check(pyobj))
+	if (PyNumber_Check(pyobj))
 	{
-		match.conversion = &asByteConversion;
+		match.conversion = &byteNumberConversion;
 		return match.type = JPMatch::_explicit;
 	}
 

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -158,18 +158,6 @@ JPMatch::Type JPDoubleType::getJavaConversion(JPJavaFrame *frame, JPMatch &match
 		return match.type = JPMatch::_exact;
 	}
 
-	if (PyFloat_Check(pyobj))
-	{
-		match.conversion = &asDoubleConversion;
-		return match.type = JPMatch::_implicit;
-	}
-
-	if (PyLong_Check(pyobj) || PyIndex_Check(pyobj))
-	{
-		match.conversion = &asDoubleLongConversion;
-		return match.type = JPMatch::_implicit;
-	}
-
 	if (PyNumber_Check(pyobj))
 	{
 		match.conversion = &asDoubleConversion;
@@ -330,7 +318,7 @@ void JPDoubleType::releaseView(JPArrayView& view)
 	{
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseDoubleArrayElements((jdoubleArray) view.m_Array->getJava(),
-			(jdouble*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
+				(jdouble*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
 	}	catch (JPypeException& ex)
 	{
 		// This is called as part of the cleanup routine and exceptions

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -135,18 +135,6 @@ JPMatch::Type JPFloatType::getJavaConversion(JPJavaFrame *frame, JPMatch &match,
 		return match.type = JPMatch::_none;
 	}
 
-	if (PyFloat_Check(pyobj))
-	{
-		match.conversion = &asFloatConversion;
-		return match.type = JPMatch::_implicit;
-	}
-
-	if (PyLong_Check(pyobj) || PyIndex_Check(pyobj))
-	{
-		match.conversion = &asFloatLongConversion;
-		return match.type = JPMatch::_implicit;
-	}
-
 	if (PyNumber_Check(pyobj))
 	{
 		match.conversion = &asFloatConversion;

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -42,32 +42,9 @@ JPValue JPLongType::getValueFromObject(const JPValue& obj)
 	return JPValue(this, v);
 }
 
-class JPConversionAsLong : public JPConversion
-{
-	typedef JPLongType base_t;
-public:
-
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
-	{
-		jvalue res;
-		base_t::field(res) = JPPyLong::asLong(pyobj);
-		return res;
-	}
-} asLongConversion;
-
-class JPConversionLongWiden : public JPConversion
-{
-	typedef JPLongType base_t;
-public:
-
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
-	{
-		JPValue* value = PyJPValue_getJavaSlot(pyobj);
-		jvalue ret;
-		ret.j = ((JPPrimitiveType*) value->getClass())->getAsLong(value->getValue());
-		return ret;
-	}
-} longWidenConversion;
+JPConversionLong<JPLongType> longConversion;
+JPConversionLongNumber<JPLongType> longNumberConversion;
+JPConversionLongWiden<JPLongType> longWidenConversion;
 
 JPMatch::Type JPLongType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
 {
@@ -120,13 +97,13 @@ JPMatch::Type JPLongType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, 
 
 	if (PyLong_Check(pyobj) || PyIndex_Check(pyobj))
 	{
-		match.conversion = &asLongConversion;
+		match.conversion = &longNumberConversion;
 		return match.type = JPMatch::_implicit;
 	}
 
-	if (PyLong_Check(pyobj))
+	if (PyNumber_Check(pyobj))
 	{
-		match.conversion = &asLongConversion;
+		match.conversion = &longNumberConversion;
 		return match.type = JPMatch::_explicit;
 	}
 
@@ -244,7 +221,7 @@ void JPLongType::setArrayRange(JPJavaFrame& frame, jarray a,
 		jlong v = PyLong_AsLongLong(seq[i].get());
 		if (v == -1)
 			JP_PY_CHECK()
-		val[index] = (type_t) v;
+			val[index] = (type_t) v;
 	}
 	accessor.commit();
 	JP_TRACE_OUT;
@@ -284,7 +261,7 @@ void JPLongType::releaseView(JPArrayView& view)
 	{
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseLongArrayElements((jlongArray) view.m_Array->getJava(),
-			(jlong*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
+				(jlong*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
 	}	catch (JPypeException& ex)
 	{
 		// This is called as part of the cleanup routine and exceptions

--- a/native/common/jp_shorttype.cpp
+++ b/native/common/jp_shorttype.cpp
@@ -42,32 +42,9 @@ JPValue JPShortType::getValueFromObject(const JPValue& obj)
 	return JPValue(this, v);
 }
 
-class JPConversionAsShort : public JPConversion
-{
-	typedef JPShortType base_t;
-public:
-
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
-	{
-		jvalue res;
-		base_t::field(res) = (base_t::type_t) base_t::assertRange(JPPyLong::asLong(pyobj));
-		return res;
-	}
-} asShortConversion;
-
-class JPConversionShortWiden : public JPConversion
-{
-	typedef JPShortType base_t;
-public:
-
-	virtual jvalue convert(JPJavaFrame *frame, JPClass* cls, PyObject* pyobj) override
-	{
-		JPValue* value = PyJPValue_getJavaSlot(pyobj);
-		jvalue ret;
-		ret.s = (jshort) ((JPPrimitiveType*) value->getClass())->getAsLong(value->getValue());
-		return ret;
-	}
-} shortWidenConversion;
+JPConversionLong<JPShortType> shortConversion;
+JPConversionLongNumber<JPShortType> shortNumberConversion;
+JPConversionLongWiden<JPShortType> shortWidenConversion;
 
 JPMatch::Type JPShortType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
 {
@@ -118,13 +95,13 @@ JPMatch::Type JPShortType::getJavaConversion(JPJavaFrame *frame, JPMatch &match,
 
 	if (PyLong_CheckExact(pyobj) || PyIndex_Check(pyobj))
 	{
-		match.conversion = &asShortConversion;
+		match.conversion = &shortConversion;
 		return match.type = JPMatch::_implicit;
 	}
 
-	if (PyLong_Check(pyobj))
+	if (PyNumber_Check(pyobj))
 	{
-		match.conversion = &asShortConversion;
+		match.conversion = &shortNumberConversion;
 		return match.type = JPMatch::_explicit;
 	}
 
@@ -282,7 +259,7 @@ void JPShortType::releaseView(JPArrayView& view)
 	{
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseShortArrayElements((jshortArray) view.m_Array->getJava(),
-			(jshort*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
+				(jshort*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
 	}	catch (JPypeException& ex)
 	{
 		// This is called as part of the cleanup routine and exceptions

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -176,3 +176,24 @@ class ArrayTestCase(common.JPypeTestCase):
         a = JArray(JObject)(['a', 'b', 'c', 'd', 'e', 'f'])
         a[1:4] = ['x', 'y', 'z']
         self.assertEqual(list(a), ['a', 'x', 'y', 'z', 'e', 'f'])
+
+    def testJArrayDimTooBig(self):
+        with self.assertRaises(ValueError):
+            jpype.JArray(jpype.JInt, 10000)
+
+    def testJArrayDimWrong(self):
+        with self.assertRaises(TypeError):
+            jpype.JArray(jpype.JInt, 1.5)
+
+    def testJArrayArgs(self):
+        with self.assertRaises(TypeError):
+            jpype.JArray(jpype.JInt, 1, 'f')
+
+    def testJArrayTypeBad(self):
+        class John(object):
+            pass
+        with self.assertRaises(TypeError):
+            jpype.JArray(John)
+
+
+

--- a/test/jpypetest/test_coverage.py
+++ b/test/jpypetest/test_coverage.py
@@ -261,20 +261,3 @@ class CoverageCase(common.JPypeTestCase):
         self.assertIsInstance(jpype.JClass(jpype.java.lang.Class.forName(
             "java.lang.StringBuilder")), jpype.JClass)
 
-    def testJArrayDimTooBig(self):
-        with self.assertRaises(ValueError):
-            jpype.JArray(jpype.JInt, 10000)
-
-    def testJArrayDimWrong(self):
-        with self.assertRaises(TypeError):
-            jpype.JArray(jpype.JInt, 1.5)
-
-    def testJArrayArgs(self):
-        with self.assertRaises(TypeError):
-            jpype.JArray(jpype.JInt, 1, 'f')
-
-    def testJArrayTypeBad(self):
-        class John(object):
-            pass
-        with self.assertRaises(TypeError):
-            jpype.JArray(John)

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -5,6 +5,10 @@ import sys
 import logging
 import time
 import common
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 
 class JByteTestCase(common.JPypeTestCase):
@@ -153,3 +157,32 @@ class JByteTestCase(common.JPypeTestCase):
     def testArrayHash(self):
         ja = JArray(JByte)([1,2,3])
         self.assertIsInstance(hash(ja), int)
+
+    @common.requireNumpy
+    def testArrayBufferDims(self):
+        ja = JArray(JByte)(5)
+        a = np.zeros((5,2))
+        with self.assertRaisesRegex(TypeError, "incorrect"):
+            ja[:] = a
+
+    def testArrayBadItem(self):
+        class q(object):
+            def __index__(self):
+                raise SystemError("nope")
+        ja = JArray(JByte)(5)
+        a = [ 1, -1, q(), 3, 4]
+        with self.assertRaisesRegex(SystemError, "nope"):
+            ja[:] = a
+
+    def testArrayBadDims(self):
+        class q(bytes):
+            # Lie about our length
+            def __len__(self):
+                return 5
+        a = q([1,2,3])
+        ja = JArray(JByte)(5)
+        with self.assertRaisesRegex(ValueError, "Slice"):
+            ja[:] = [1, 2, 3]
+        with self.assertRaisesRegex(ValueError, "mismatch"):
+            ja[:] = a
+

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -167,6 +167,8 @@ class JByteTestCase(common.JPypeTestCase):
 
     def testArrayBadItem(self):
         class q(object):
+            def __int__(self):
+                raise SystemError("nope")
             def __index__(self):
                 raise SystemError("nope")
         ja = JArray(JByte)(5)

--- a/test/jpypetest/test_jdouble.py
+++ b/test/jpypetest/test_jdouble.py
@@ -384,3 +384,35 @@ class JDoubleTestCase(common.JPypeTestCase):
         self.assertEqual(ja[0], 321)
         with self.assertRaises(TypeError):
             ja[0:1] = [object()]
+
+    def testArrayHash(self):
+        ja = JArray(JDouble)([1,2,3])
+        self.assertIsInstance(hash(ja), int)
+
+    @common.requireNumpy
+    def testArrayBufferDims(self):
+        ja = JArray(JDouble)(5)
+        a = np.zeros((5,2))
+        with self.assertRaisesRegex(TypeError, "incorrect"):
+            ja[:] = a
+
+    def testArrayBadItem(self):
+        class q(object):
+            def __float__(self):
+                raise SystemError("nope")
+        ja = JArray(JDouble)(5)
+        a = [ 1, -1, q(), 3, 4]
+        with self.assertRaisesRegex(SystemError, "nope"):
+            ja[:] = a
+
+    def testArrayBadDims(self):
+        class q(bytes):
+            # Lie about our length
+            def __len__(self):
+                return 5
+        a = q([1,2,3])
+        ja = JArray(JDouble)(5)
+        with self.assertRaisesRegex(ValueError, "Slice"):
+            ja[:] = [1, 2, 3]
+        with self.assertRaisesRegex(ValueError, "mismatch"):
+            ja[:] = a

--- a/test/jpypetest/test_jfloat.py
+++ b/test/jpypetest/test_jfloat.py
@@ -392,3 +392,35 @@ class JFloatTestCase(common.JPypeTestCase):
         self.assertEqual(ja[0], 321)
         with self.assertRaises(TypeError):
             ja[0:1] = [object()]
+
+    def testArrayHash(self):
+        ja = JArray(JFloat)([1,2,3])
+        self.assertIsInstance(hash(ja), int)
+
+    @common.requireNumpy
+    def testArrayBufferDims(self):
+        ja = JArray(JFloat)(5)
+        a = np.zeros((5,2))
+        with self.assertRaisesRegex(TypeError, "incorrect"):
+            ja[:] = a
+
+    def testArrayBadItem(self):
+        class q(object):
+            def __float__(self):
+                raise SystemError("nope")
+        ja = JArray(JFloat)(5)
+        a = [ 1, -1, q(), 3, 4]
+        with self.assertRaisesRegex(SystemError, "nope"):
+            ja[:] = a
+
+    def testArrayBadDims(self):
+        class q(bytes):
+            # Lie about our length
+            def __len__(self):
+                return 5
+        a = q([1,2,3])
+        ja = JArray(JFloat)(5)
+        with self.assertRaisesRegex(ValueError, "Slice"):
+            ja[:] = [1, 2, 3]
+        with self.assertRaisesRegex(ValueError, "mismatch"):
+            ja[:] = a

--- a/test/jpypetest/test_jint.py
+++ b/test/jpypetest/test_jint.py
@@ -527,6 +527,8 @@ class JIntTestCase(common.JPypeTestCase):
 
     def testArrayBadItem(self):
         class q(object):
+            def __int__(self):
+                raise SystemError("nope")
             def __index__(self):
                 raise SystemError("nope")
         ja = JArray(JInt)(5)

--- a/test/jpypetest/test_jlong.py
+++ b/test/jpypetest/test_jlong.py
@@ -527,6 +527,8 @@ class JLongTestCase(common.JPypeTestCase):
 
     def testArrayBadItem(self):
         class q(object):
+            def __int__(self):
+                raise SystemError("nope")
             def __index__(self):
                 raise SystemError("nope")
         ja = JArray(JLong)(5)

--- a/test/jpypetest/test_jshort.py
+++ b/test/jpypetest/test_jshort.py
@@ -519,6 +519,8 @@ class JShortTestCase(common.JPypeTestCase):
 
     def testArrayBadItem(self):
         class q(object):
+            def __int__(self):
+                raise SystemError("nope")
             def __index__(self):
                 raise SystemError("nope")
         ja = JArray(JShort)(5)


### PR DESCRIPTION
Another PR trying to increase coverage and dealing with bugs in the type system.  In today's edition we try to hit all of the remaining paths in primitive arrays and then try to hit explicit conversions.  Unfortunately, explicit conversions are not possible to reach.   So we have to modify the return path on proxies so that it converts to a primitive first and then boxes it.  As an added bonus we move some the primitive conversions back into templates to make the system less repetitive.