### PR TITLE
Fix exceptions during proxies

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -14,6 +14,12 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
   - Corrected an issue with creation of Exceptions which lack a
     default constructor.
 
+  - Fixed segfault when methods called by proxy have incorrect number of 
+    arguments.
+
+  - Proxies pass Python exceptions properly rather converting to 
+    java.lang.RuntimeException
+
 - **0.7.2 - 2-28-2019**
 
   - C++ and Java exceptions hold the traceback as a Python exception

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -249,6 +249,9 @@ public:
 	jmethodID m_Class_GetNameID;
 	jmethodID m_Context_collectRectangularID;
 	jmethodID m_String_ToCharArrayID;
+	jmethodID m_Context_CreateExceptionID;
+	jmethodID m_Context_GetExcClassID;
+	jmethodID m_Context_GetExcValueID;
 
 private:
 	bool m_IsShutdown;

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -148,7 +148,6 @@ public:
 	void from(const JPStackInfo& info);
 
 	string getMessage();
-	string getPythonMessage();
 
 	void convertJavaToPython();
 	void convertPythonToJava(JPContext* context);
@@ -162,8 +161,6 @@ public:
 
 	/** Transfer handling of this exception to java. */
 	void toJava(JPContext* context);
-
-	jthrowable getJavaException();
 
 	int getExceptionType()
 	{

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -233,6 +233,12 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		m_Context_collectRectangularID = frame.GetMethodID(cls,
 				"collectRectangular",
 				"(Ljava/lang/Object;)[Ljava/lang/Object;");
+		m_Context_CreateExceptionID = frame.GetMethodID(cls, "createException",
+				"(JJ)Ljava/lang/Exception;");
+		m_Context_GetExcClassID = frame.GetMethodID(cls, "getExcClass",
+				"(Ljava/lang/Throwable;)J");
+		m_Context_GetExcValueID = frame.GetMethodID(cls, "getExcValue",
+				"(Ljava/lang/Throwable;)J");
 
 		// Launch
 		jvalue val[2];

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -108,71 +108,12 @@ string JPypeException::getMessage()
 	JP_TRACE_OUT;
 }
 
-string JPypeException::getPythonMessage()
-{
-	// Must be bullet proof
-	try
-	{
-		JPPyErrFrame eframe;
-		if (!eframe.good)
-			return "no error reported";
-		JPPyObject className(JPPyRef::_claim, PyObject_GetAttrString(eframe.exceptionClass.get(), "__name__"));
-		stringstream ss;
-		ss << JPPyString::asStringUTF8(className.get());
-
-		// Exception value
-		if (!eframe.exceptionValue.isNull())
-		{
-			// Special handling here so that we don't fail on exceptions.
-			string pyStrValue;
-			PyObject *sval = PyObject_Str(eframe.exceptionValue.get());
-			if (sval != NULL)
-			{
-				try
-				{
-					pyStrValue = JPPyString::asStringUTF8(sval);
-					ss << ": " << pyStrValue;
-
-				} catch (...)
-				{
-				}
-				Py_DECREF(sval);
-			}
-		}
-
-		return ss.str();
-	} catch (...)
-	{
-		return "unknown error";
-	}
-}
-
 bool isJavaThrowable(PyObject* exceptionClass)
 {
 	JPClass* cls = PyJPClass_getJPClass(exceptionClass);
 	if (cls == NULL)
 		return false;
 	return cls->isThrowable();
-}
-
-jthrowable JPypeException::getJavaException()
-{
-	// Must be bullet proof
-	try
-	{
-		JPPyErrFrame eframe;
-		if (eframe.good && isJavaThrowable(eframe.exceptionClass.get()))
-		{
-			eframe.good = false;
-			JPValue* javaExc = PyJPValue_getJavaSlot(eframe.exceptionClass.get());
-			if (javaExc != NULL)
-				return (jthrowable) javaExc->getJavaObject();
-		}
-		return NULL;
-	} catch (...)
-	{
-		return NULL;
-	}
 }
 
 void JPypeException::convertJavaToPython()
@@ -257,8 +198,6 @@ void JPypeException::convertPythonToJava(JPContext* context)
 	}
 
 	// Otherwise
-	string pyMessage = "Python exception thrown: " + getPythonMessage();
-	JP_TRACE(pyMessage);
 	jvalue v[2];
 	v[0].j = (jlong) eframe.exceptionClass.get();
 	v[1].j = (jlong) eframe.exceptionValue.get();
@@ -359,13 +298,16 @@ void JPypeException::toPython()
 		return;
 	} catch (JPypeException& ex)
 	{
+		// GCOVR_EXCL_START
 		// Print our parting words
 		JPTracer::trace("Fatal error in exception handling");
 		JPTracer::trace("Handling:", mesg);
 		JPTracer::trace("Type:", m_Error.l);
 		if (ex.m_Type == JPError::_python_error)
-			JPTracer::trace("Inner Python:", ex.getPythonMessage());
-		else if (ex.m_Type == JPError::_java_error)
+		{
+			JPPyErrFrame eframe;
+			JPTracer::trace("Inner Python:", ((PyTypeObject*) eframe.exceptionClass.get())->tp_name);
+		} else if (ex.m_Type == JPError::_java_error)
 			JPTracer::trace("Inner Java:", ex.getMessage());
 		else
 			JPTracer::trace("Inner:", ex.getMessage());
@@ -388,6 +330,7 @@ void JPypeException::toPython()
 		int *i = 0;
 		*i = 0;
 	}
+	// GCOVR_EXCL_STOP
 	JP_TRACE_OUT;
 }
 

--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -61,6 +61,7 @@ import org.jpype.ref.JPypeReferenceQueue;
  */
 public class JPypeContext
 {
+
   private static JPypeContext instance = null;
   // This is the C++ portion of the context.
   private long context;
@@ -232,6 +233,37 @@ public class JPypeContext
     if (!collect(out, o, 0, shape, d))
       return null;
     return out.toArray();
+  }
+
+  public static class PyExceptionProxy extends RuntimeException
+  {
+
+    long cls, value;
+
+    public PyExceptionProxy(long l0, long l1)
+    {
+      cls = l0;
+      value = l1;
+    }
+  }
+
+  public long getExcClass(Throwable th)
+  {
+    if (th instanceof PyExceptionProxy)
+      return ((PyExceptionProxy) th).cls;
+    return 0;
+  }
+
+  public long getExcValue(Throwable th)
+  {
+    if (th instanceof PyExceptionProxy)
+      return ((PyExceptionProxy) th).value;
+    return 0;
+  }
+
+  public Exception createException(long l0, long l1)
+  {
+    return new PyExceptionProxy(l0, l1);
   }
 
 }

--- a/native/python/include/jp_pythontypes.h
+++ b/native/python/include/jp_pythontypes.h
@@ -421,6 +421,11 @@ public:
 		if (good)
 			JPPyErr::restore(exceptionClass, exceptionValue, exceptionTrace);
 	}
+
+	void clear()
+	{
+		good = false;
+	}
 } ;
 
 /** Used to establish a python lock when called from a

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -407,9 +407,9 @@ bool JPPyErr::fetch(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JPPy
 	PyErr_Fetch(&v1, &v2, &v3);
 	if (v1 == NULL && v2 == NULL && v3 == NULL)
 		return false;
-	exceptionClass = JPPyObject(JPPyRef::_claim, v1);
-	exceptionValue = JPPyObject(JPPyRef::_claim, v2);
-	exceptionTrace = JPPyObject(JPPyRef::_claim, v3);
+	exceptionClass = JPPyObject(JPPyRef::_accept, v1);
+	exceptionValue = JPPyObject(JPPyRef::_accept, v2);
+	exceptionTrace = JPPyObject(JPPyRef::_accept, v3);
 	return true;
 }
 

--- a/test/jpypetest/test_exc.py
+++ b/test/jpypetest/test_exc.py
@@ -117,3 +117,4 @@ class ExceptionTestCase(common.JPypeTestCase):
         WE = jpype.JClass("jpype.exc.WierdException")
         with self.assertRaises(WE):
             WE.testThrow()
+

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -316,3 +316,66 @@ class ProxyTestCase(common.JPypeTestCase):
     def testProxyFail(self):
         with self.assertRaises(TypeError):
             JProxy(inst=object(), dict={}, intf="java.io.Serializable")
+
+    def testValid(self):
+        @JImplements("java.util.Comparator")
+        class ValidComparator(object):
+            @JOverride
+            def compare(self, _o1, _o2):
+                return 0
+
+            @JOverride
+            def equals(self, _obj):
+                return True
+        arr = JArray(JString)(["a","b"])
+        java.util.Arrays.sort(arr, ValidComparator())
+
+    def testRaisePython(self):
+        @JImplements("java.util.Comparator")
+        class RaiseException(object):
+            def __init__(self, exc):
+                self.exc = exc
+            @JOverride
+            def compare(self, _o1, _o2):
+                raise self.exc("nobody expects the Python exception!")
+
+            @JOverride
+            def equals(self, _obj):
+                return True
+        arr = JArray(JString)(["a","b"])
+        with self.assertRaises(TypeError):
+            java.util.Arrays.sort(arr, RaiseException(TypeError))
+        with self.assertRaises(ValueError):
+            java.util.Arrays.sort(arr, RaiseException(ValueError))
+        with self.assertRaises(SyntaxError):
+            java.util.Arrays.sort(arr, RaiseException(SyntaxError))
+        with self.assertRaises(java.lang.RuntimeException):
+            java.util.Arrays.sort(arr, RaiseException(java.lang.RuntimeException))
+
+    def testBad(self):
+        @JImplements("java.util.Comparator")
+        class TooManyParams(object):
+            @JOverride
+            def compare(self, _o1, _o2, _o3):
+                return 0
+
+            @JOverride
+            def equals(self, _obj):
+                return True
+
+        @JImplements("java.util.Comparator")
+        class TooFewParams(object):
+            @JOverride
+            def compare(self, _o1):
+                return 0
+
+            @JOverride
+            def equals(self, _obj):
+                return True
+
+        arr = JArray(JString)(["a","b"])
+        with self.assertRaises(TypeError):
+            java.util.Arrays.sort(arr, TooManyParams())
+        with self.assertRaises(TypeError):
+            java.util.Arrays.sort(arr, TooFewParams())
+


### PR DESCRIPTION
This nights edition fixes exception handling for proxies.  There was a bug in proxy exceptions in which placing too many or too few arguments to the proxy would result in a fatal handling error.  Apparently exceptions thrown under Python do not have a traceback as assumed by the error handling.  

In addition we captured the Python proxy and reflect it back to Python after passing through Java. 

Fixes #614