### PR TITLE
Support for java.lang.Number

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -24,6 +24,13 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
   - Proxies pass Python exceptions properly rather converting to 
     java.lang.RuntimeException
 
+  - java.lang.Number converts automatically from Python and Java numbers
+
+  - java.lang.Object and java.lang.Number box signed, sized numpy types 
+    (int8, int16, int32, int64, float32, float64) to the Java boxed type
+    with the same size automatically.  Architecture dependent numpy
+    types map to Long or Double.
+
 - **0.7.2 - 2-28-2019**
 
   - C++ and Java exceptions hold the traceback as a Python exception

--- a/native/common/include/jp_classhints.h
+++ b/native/common/include/jp_classhints.h
@@ -85,6 +85,7 @@ extern JPConversion *nullConversion;
 extern JPConversion *classConversion;
 extern JPConversion *objectConversion;
 extern JPConversion *javaObjectAnyConversion;
+extern JPConversion *javaNumberAnyConversion;
 extern JPConversion *javaValueConversion;
 extern JPConversion *stringConversion;
 extern JPConversion *boxConversion;

--- a/native/common/include/jp_numbertype.h
+++ b/native/common/include/jp_numbertype.h
@@ -1,0 +1,37 @@
+/*****************************************************************************
+   Copyright 2004 Steve M�nard
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ *****************************************************************************/
+#ifndef _JPNUMBERTYPE_H_
+#define _JPNUMBERTYPE_H_
+
+/**
+ * Wrapper for Class<java.lang.Number>
+ */
+class JPNumberType : public JPClass
+{
+public:
+	JPNumberType(JPJavaFrame& frame, jclass clss,
+			const string& name,
+			JPClass* super,
+			JPClassList& interfaces,
+			jint modifiers);
+
+	virtual~ JPNumberType();
+
+	JPMatch::Type getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj) override;
+} ;
+
+#endif // _JPNUMBERTYPE_H_

--- a/native/common/jp_numbertype.cpp
+++ b/native/common/jp_numbertype.cpp
@@ -1,0 +1,45 @@
+#include "jpype.h"
+#include "pyjp.h"
+#include "jp_numbertype.h"
+
+JPNumberType::JPNumberType(JPJavaFrame& frame,
+		jclass clss,
+		const string& name,
+		JPClass* super,
+		JPClassList& interfaces,
+		jint modifiers)
+: JPClass(frame, clss, name, super, interfaces, modifiers)
+{
+}
+
+JPNumberType::~JPNumberType()
+{
+}
+
+JPMatch::Type JPNumberType::getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj)
+{
+	// Rules for java.lang.Object
+	JP_TRACE_IN("JPNumberType::canConvertToJava");
+	if (nullConversion->matches(match, frame, this, pyobj)
+			|| javaNumberAnyConversion->matches(match, frame, this, pyobj)
+			|| boxLongConversion->matches(match, frame, this, pyobj)
+			|| boxDoubleConversion->matches(match, frame, this, pyobj)
+			)
+	{
+		return match.type;
+	}
+
+	// Apply user supplied conversions
+	if (!m_Hints.isNull())
+	{
+		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
+		if (hints->getConversion(match, frame, this, pyobj) != JPMatch::_none)
+		{
+			JP_TRACE("Match custom conversion");
+			return match.type;
+		}
+	}
+
+	return match.type = JPMatch::_none;
+	JP_TRACE_OUT;
+}

--- a/native/common/jp_typefactory.cpp
+++ b/native/common/jp_typefactory.cpp
@@ -20,6 +20,7 @@
 #include "jp_boxedtype.h"
 #include "jp_field.h"
 #include "jp_objecttype.h"
+#include "jp_numbertype.h"
 #include "jp_classtype.h"
 #include "jp_method.h"
 #include "jp_methoddispatch.h"
@@ -181,6 +182,10 @@ JNIEXPORT jlong JNICALL JPTypeFactory_defineObjectClass(
 				= new JPObjectType(frame, cls, className,
 				(JPClass*) superClass, interfaces, modifiers));
 
+		if (className == "java.lang.Number")
+			return (jlong) new JPNumberType(frame, cls, className, (JPClass*) superClass, interfaces, modifiers);
+
+
 		// Register the box types
 		if (className == "java.lang.Void")
 		{
@@ -285,7 +290,7 @@ JNIEXPORT jlong JNICALL JPTypeFactory_definePrimitive(
 		jlong boxedPtr,
 		jint modifiers)
 {
-	// These resources are created by the boxed types 
+	// These resources are created by the boxed types
 	JPContext* context = (JPContext*) contextPtr;
 	JPJavaFrame frame(context, env);
 	JP_JAVA_TRY("JPTypeFactory_definePrimitive");

--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -76,26 +76,17 @@ public class TypeManager
 
     // Create the required minimum classes
     this.java_lang_Object = createClass(Object.class, true);
-    createClass(Class.class, true);
-
-    // Create the boxed types
-    // These require special rules in the C++ layer so we will tag them
-    // as being different.
-    createClass(Void.class, true);
-    createClass(Boolean.class, true);
-    createClass(Byte.class, true);
-    createClass(Character.class, true);
-    createClass(Short.class, true);
-    createClass(Integer.class, true);
-    createClass(Long.class, true);
-    createClass(Float.class, true);
-    createClass(Double.class, true);
-    createClass(String.class, true);
-    createClass(CharSequence.class, true);
-    createClass(JPypeProxy.class, true);
-    createClass(Method.class, true);
-    createClass(Field.class, true);
-    createClass(Throwable.class, true);
+    Class[] cls =
+    {
+      Class.class, Void.class, Boolean.class, Byte.class, Character.class,
+      Short.class, Integer.class, Long.class, Float.class, Double.class,
+      String.class, CharSequence.class, JPypeProxy.class, Method.class,
+      Field.class, Throwable.class, Number.class
+    };
+    for (Class c : cls)
+    {
+      createClass(c, true);
+    }
 
     // Create the primitive types
     // Link boxed and primitive types so that the wrappers can find them.

--- a/project/jpype_cpython/nbproject/configurations.xml
+++ b/project/jpype_cpython/nbproject/configurations.xml
@@ -31,6 +31,7 @@
           <itemPath>../../native/common/include/jp_methoddispatch.h</itemPath>
           <itemPath>../../native/common/include/jp_modifier.h</itemPath>
           <itemPath>../../native/common/include/jp_monitor.h</itemPath>
+          <itemPath>../../native/common/include/jp_numbertype.h</itemPath>
           <itemPath>../../native/common/include/jp_objecttype.h</itemPath>
           <itemPath>../../native/common/include/jp_platform_linux.h</itemPath>
           <itemPath>../../native/common/include/jp_platform_win32.h</itemPath>
@@ -85,6 +86,7 @@
         <itemPath>../../native/common/jp_method.cpp</itemPath>
         <itemPath>../../native/common/jp_methoddispatch.cpp</itemPath>
         <itemPath>../../native/common/jp_monitor.cpp</itemPath>
+        <itemPath>../../native/common/jp_numbertype.cpp</itemPath>
         <itemPath>../../native/common/jp_objecttype.cpp</itemPath>
         <itemPath>../../native/common/jp_primitivetype.cpp</itemPath>
         <itemPath>../../native/common/jp_proxy.cpp</itemPath>
@@ -284,6 +286,11 @@
             tool="3"
             flavor2="0">
       </item>
+      <item path="../../native/common/include/jp_numbertype.h"
+            ex="false"
+            tool="3"
+            flavor2="0">
+      </item>
       <item path="../../native/common/include/jp_objecttype.h"
             ex="false"
             tool="3"
@@ -444,6 +451,11 @@
             flavor2="0">
       </item>
       <item path="../../native/common/jp_monitor.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../native/common/jp_numbertype.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
       </item>
       <item path="../../native/common/jp_objecttype.cpp"
             ex="false"

--- a/test/harness/jpype/common/Fixture.java
+++ b/test/harness/jpype/common/Fixture.java
@@ -121,4 +121,6 @@ public class Fixture {
 	private Object callPrivateObject(Object i) { return i; }
 	protected Object callProtectedObject(Object i) { return i; }
 
+	public static Number callNumber(Number n) { return n; }
+
 }

--- a/test/jpypetest/test_jobject.py
+++ b/test/jpypetest/test_jobject.py
@@ -16,7 +16,12 @@
 # *****************************************************************************
 import jpype
 from jpype.types import *
+from jpype import java
 import common
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 
 class JClassTestCase(common.JPypeTestCase):
@@ -166,3 +171,26 @@ class JClassTestCase(common.JPypeTestCase):
         self.assertEqual(self.fixture.object_field, 2.6125)
         self.assertIsInstance(self.fixture.object_field,
                               JClass('java.lang.Double'))
+
+    def testJavaPrimitives(self):
+        self.assertIsInstance(self.fixture.callObject(JByte(1)), java.lang.Byte)
+        self.assertIsInstance(self.fixture.callObject(JShort(1)), java.lang.Short)
+        self.assertIsInstance(self.fixture.callObject(JInt(1)), java.lang.Integer)
+        self.assertIsInstance(self.fixture.callObject(JLong(1)), java.lang.Long)
+        self.assertIsInstance(self.fixture.callObject(JFloat(1)), java.lang.Float)
+        self.assertIsInstance(self.fixture.callObject(JDouble(1)), java.lang.Double)
+
+    def testPythonPrimitives(self):
+        self.assertIsInstance(self.fixture.callObject(1), java.lang.Long)
+        self.assertIsInstance(self.fixture.callObject(1.0), java.lang.Double)
+
+    @common.requireNumpy
+    def testNumpyPrimitives(self):
+        self.assertIsInstance(self.fixture.callObject(np.int8(1)), java.lang.Byte)
+        self.assertIsInstance(self.fixture.callObject(np.int16(1)), java.lang.Short)
+        self.assertIsInstance(self.fixture.callObject(np.int32(1)), java.lang.Integer)
+        self.assertIsInstance(self.fixture.callObject(np.int64(1)), java.lang.Long)
+        self.assertIsInstance(self.fixture.callObject(np.float32(1)), java.lang.Float)
+        self.assertIsInstance(self.fixture.callObject(np.float64(1)), java.lang.Double)
+
+

--- a/test/jpypetest/test_number.py
+++ b/test/jpypetest/test_number.py
@@ -1,0 +1,40 @@
+import sys
+import jpype
+import common
+import random
+import _jpype
+import jpype
+from jpype import java
+from jpype.types import *
+try:
+    import numpy as np
+except ImportError:
+    pass
+
+class JNumberTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self.cls = JClass("jpype.common.Fixture")
+        self.fixture = self.cls()
+
+    def testJavaPrimitives(self):
+        self.assertIsInstance(self.fixture.callNumber(JByte(1)), java.lang.Byte)
+        self.assertIsInstance(self.fixture.callNumber(JShort(1)), java.lang.Short)
+        self.assertIsInstance(self.fixture.callNumber(JInt(1)), java.lang.Integer)
+        self.assertIsInstance(self.fixture.callNumber(JLong(1)), java.lang.Long)
+        self.assertIsInstance(self.fixture.callNumber(JFloat(1)), java.lang.Float)
+        self.assertIsInstance(self.fixture.callNumber(JDouble(1)), java.lang.Double)
+
+    def testPythonPrimitives(self):
+        self.assertIsInstance(self.fixture.callNumber(1), java.lang.Long)
+        self.assertIsInstance(self.fixture.callNumber(1.0), java.lang.Double)
+
+    @common.requireNumpy
+    def testNumpyPrimitives(self):
+        self.assertIsInstance(self.fixture.callNumber(np.int8(1)), java.lang.Byte)
+        self.assertIsInstance(self.fixture.callNumber(np.int16(1)), java.lang.Short)
+        self.assertIsInstance(self.fixture.callNumber(np.int32(1)), java.lang.Integer)
+        self.assertIsInstance(self.fixture.callNumber(np.int64(1)), java.lang.Long)
+        self.assertIsInstance(self.fixture.callNumber(np.float32(1)), java.lang.Float)
+        self.assertIsInstance(self.fixture.callNumber(np.float64(1)), java.lang.Double)
+


### PR DESCRIPTION
In today's pull request, we add support for java.lang.Number so that it auto boxes with the same rules as Java.  We also box numpy types to the appropriate Java box sized rather than always going to Long or Double.

I am not particularly happy with having to compare strings to support numpy types, but I could not find any way to determine the size other than using the name.  But this way we don't need to link to numpy.

Fixes #616 