### PR TITLE
Numbers2

### DIFF
--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -88,7 +88,6 @@ class JClass(_jpype._JClass, metaclass=JClassMeta):
             if len(params) > 0:
                 params = params.split(',')
             if len(params) > 0 and len(params) != len(ret.class_.getTypeParameters()):
-                print(params, len(params))
                 raise TypeError(
                     "Java generic class '%s' length mismatch" % (ret.__name__))
             return ret

--- a/native/common/include/jp_arrayclass.h
+++ b/native/common/include/jp_arrayclass.h
@@ -32,7 +32,7 @@ public:
 	virtual~ JPArrayClass();
 
 	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj);
+	virtual JPMatch::Type getJavaConversion(JPMatch &match);
 
 	JPValue newInstance(JPJavaFrame& frame, int length);
 	JPValue newInstance(JPJavaFrame& frame, JPPyObjectVector& args) override;

--- a/native/common/include/jp_arrayclass.h
+++ b/native/common/include/jp_arrayclass.h
@@ -35,7 +35,6 @@ public:
 	virtual JPMatch::Type findJavaConversion(JPMatch &match);
 
 	JPValue newInstance(JPJavaFrame& frame, int length);
-	JPValue newInstance(JPJavaFrame& frame, JPPyObjectVector& args) override;
 
 	/**
 	 * Create a new java array containing a set of items take from

--- a/native/common/include/jp_arrayclass.h
+++ b/native/common/include/jp_arrayclass.h
@@ -32,7 +32,7 @@ public:
 	virtual~ JPArrayClass();
 
 	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
-	virtual JPMatch::Type getJavaConversion(JPMatch &match);
+	virtual JPMatch::Type findJavaConversion(JPMatch &match);
 
 	JPValue newInstance(JPJavaFrame& frame, int length);
 	JPValue newInstance(JPJavaFrame& frame, JPPyObjectVector& args) override;

--- a/native/common/include/jp_booleantype.h
+++ b/native/common/include/jp_booleantype.h
@@ -42,7 +42,7 @@ public:
 		return context->_java_lang_Boolean;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch& match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch& match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_booleantype.h
+++ b/native/common/include/jp_booleantype.h
@@ -42,7 +42,7 @@ public:
 		return context->_java_lang_Boolean;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch& match, PyObject* pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch& match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_boxedtype.h
+++ b/native/common/include/jp_boxedtype.h
@@ -39,7 +39,7 @@ public:
 			JPPrimitiveType* primitiveType);
 	virtual ~JPBoxedType();
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 
 	JPPrimitiveType* getPrimitive()
 	{

--- a/native/common/include/jp_boxedtype.h
+++ b/native/common/include/jp_boxedtype.h
@@ -39,7 +39,7 @@ public:
 			JPPrimitiveType* primitiveType);
 	virtual ~JPBoxedType();
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 
 	JPPrimitiveType* getPrimitive()
 	{

--- a/native/common/include/jp_bytetype.h
+++ b/native/common/include/jp_bytetype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Byte;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_bytetype.h
+++ b/native/common/include/jp_bytetype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Byte;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_chartype.h
+++ b/native/common/include/jp_chartype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Character;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_chartype.h
+++ b/native/common/include/jp_chartype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Character;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_class.h
+++ b/native/common/include/jp_class.h
@@ -118,7 +118,7 @@ public:
 	 * @param pyobj is the Python object.
 	 * @return the quality of the match
 	 */
-	virtual JPMatch::Type getJavaConversion(JPMatch& match);
+	virtual JPMatch::Type findJavaConversion(JPMatch& match);
 
 	/** Create a new Python object to wrap a Java value.
 	 *

--- a/native/common/include/jp_class.h
+++ b/native/common/include/jp_class.h
@@ -118,7 +118,7 @@ public:
 	 * @param pyobj is the Python object.
 	 * @return the quality of the match
 	 */
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj);
+	virtual JPMatch::Type getJavaConversion(JPMatch& match);
 
 	/** Create a new Python object to wrap a Java value.
 	 *

--- a/native/common/include/jp_classhints.h
+++ b/native/common/include/jp_classhints.h
@@ -25,7 +25,7 @@ public:
 	// GCOVR_EXCL_START
 	// This is the default method used for any matches that have explicit
 	// type dependent checks.
-	virtual JPMatch::Type matches(JPMatch &match, JPJavaFrame *frame, JPClass *cls, PyObject *pyobj)
+	virtual JPMatch::Type matches(JPMatch &match, JPClass *cls)
 	{
 		return JPMatch::_none;
 	}
@@ -47,7 +47,7 @@ public:
 	 *
 	 * @returns the quality of the match
 	 */
-	JPMatch::Type getConversion(JPMatch& match, JPJavaFrame *context, JPClass *cls, PyObject *obj);
+	JPMatch::Type getConversion(JPMatch& match, JPClass *cls);
 
 	/**
 	 * Add a conversion based on a specified attribute.

--- a/native/common/include/jp_classhints.h
+++ b/native/common/include/jp_classhints.h
@@ -31,7 +31,7 @@ public:
 	}
 	// GCOVR_EXCL_STOP
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass* cls, PyObject*pyobj) = 0;
+	virtual jvalue convert(JPMatch &match) = 0;
 } ;
 
 class JPClassHints

--- a/native/common/include/jp_classhints.h
+++ b/native/common/include/jp_classhints.h
@@ -81,7 +81,7 @@ private:
 	std::list<JPConversion*> conversions;
 } ;
 
-
+extern JPConversion *hintsConversion;
 extern JPConversion *charArrayConversion;
 extern JPConversion *byteArrayConversion;
 extern JPConversion *sequenceConversion;

--- a/native/common/include/jp_classloader.h
+++ b/native/common/include/jp_classloader.h
@@ -44,7 +44,6 @@ public:
 	jclass findClass(JPJavaFrame& frame, string name);
 
 	// Classloader for Proxy
-	jobject getSystemClassLoader();
 	jobject getBootLoader();
 
 private:

--- a/native/common/include/jp_classtype.h
+++ b/native/common/include/jp_classtype.h
@@ -38,7 +38,7 @@ public:
 	virtual~ JPClassType();
 
 public: // JPClass implementation
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 } ;
 
 #endif // _JPCLASSTYPE_H_

--- a/native/common/include/jp_classtype.h
+++ b/native/common/include/jp_classtype.h
@@ -38,7 +38,7 @@ public:
 	virtual~ JPClassType();
 
 public: // JPClass implementation
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 } ;
 
 #endif // _JPCLASSTYPE_H_

--- a/native/common/include/jp_doubletype.h
+++ b/native/common/include/jp_doubletype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Double;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_doubletype.h
+++ b/native/common/include/jp_doubletype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Double;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_floattype.h
+++ b/native/common/include/jp_floattype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Float;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_floattype.h
+++ b/native/common/include/jp_floattype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Float;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_inttype.h
+++ b/native/common/include/jp_inttype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Integer;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch& match, PyObject* pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch& match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_inttype.h
+++ b/native/common/include/jp_inttype.h
@@ -43,7 +43,7 @@ public:
 		return context->_java_lang_Integer;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch& match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch& match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_longtype.h
+++ b/native/common/include/jp_longtype.h
@@ -42,7 +42,7 @@ public:
 		return context->_java_lang_Long;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch& match, PyObject* pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch& match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_longtype.h
+++ b/native/common/include/jp_longtype.h
@@ -42,7 +42,7 @@ public:
 		return context->_java_lang_Long;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch& match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch& match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_match.h
+++ b/native/common/include/jp_match.h
@@ -14,15 +14,10 @@ public:
 		_implicit = 2,
 		_exact = 3
 	} ;
+
 public:
 	JPMatch();
 	JPMatch(JPJavaFrame *frame, PyObject *object);
-
-	JPMatch::Type type;
-	JPConversion *conversion;
-	JPJavaFrame *frame;
-	PyObject *object;
-	JPValue *slot;
 
 	JPContext *getContext()
 	{
@@ -39,17 +34,23 @@ public:
 	 * @return the Java slot or 0 if not available.
 	 */
 	JPValue *getJavaSlot();
+
+	jvalue convert();
+
+public:
+	JPMatch::Type type;
+	JPConversion *conversion;
+	JPJavaFrame *frame;
+	PyObject *object;
+	JPValue *slot;
+	void *closure;
 } ;
 
 class JPMethodMatch
 {
 public:
-	JPMatch::Type type;
-	bool isVarIndirect;
-	JPMethod* overload;
-	char offset;
-	char skip;
-	std::vector<JPMatch> argument;
+
+	JPMethodMatch(JPJavaFrame &frame, JPPyObjectVector& args);
 
 	JPMatch& operator[](size_t i)
 	{
@@ -61,19 +62,13 @@ public:
 		return argument[i];
 	}
 
-	JPMethodMatch(JPJavaFrame &frame, JPPyObjectVector& args)
-	: argument(args.size())
-	{
-		type = JPMatch::_none;
-		isVarIndirect = false;
-		overload = 0;
-		offset = 0;
-		skip = 0;
-		for (size_t i = 0; i < args.size(); ++i)
-		{
-			argument[i] = JPMatch(&frame, args[i]);
-		}
-	}
+public:
+	JPMatch::Type type;
+	bool isVarIndirect;
+	JPMethod* overload;
+	char offset;
+	char skip;
+	std::vector<JPMatch> argument;
 } ;
 
 #endif /* JP_MATCH_H */

--- a/native/common/include/jp_match.h
+++ b/native/common/include/jp_match.h
@@ -15,8 +15,20 @@ public:
 		_exact = 3
 	} ;
 public:
+	JPMatch();
+	JPMatch(JPJavaFrame *frame, PyObject *object);
+
 	JPMatch::Type type;
-	JPConversion* conversion;
+	JPConversion *conversion;
+	JPJavaFrame *frame;
+	PyObject *object;
+
+	JPContext *getContext()
+	{
+		if (frame == NULL)
+			return NULL;
+		return frame->getContext();
+	}
 } ;
 
 class JPMethodMatch
@@ -39,14 +51,18 @@ public:
 		return argument[i];
 	}
 
-	JPMethodMatch(size_t size)
-	: argument(size)
+	JPMethodMatch(JPJavaFrame &frame, JPPyObjectVector& args)
+	: argument(args.size())
 	{
 		type = JPMatch::_none;
 		isVarIndirect = false;
 		overload = 0;
 		offset = 0;
 		skip = 0;
+		for (size_t i = 0; i < args.size(); ++i)
+		{
+			argument[i] = JPMatch(&frame, args[i]);
+		}
 	}
 } ;
 

--- a/native/common/include/jp_match.h
+++ b/native/common/include/jp_match.h
@@ -22,6 +22,7 @@ public:
 	JPConversion *conversion;
 	JPJavaFrame *frame;
 	PyObject *object;
+	JPValue *slot;
 
 	JPContext *getContext()
 	{
@@ -29,6 +30,15 @@ public:
 			return NULL;
 		return frame->getContext();
 	}
+
+	/**
+	 * Get the Java slot associated with the Python object.
+	 *
+	 * Thus uses caching.
+	 *
+	 * @return the Java slot or 0 if not available.
+	 */
+	JPValue *getJavaSlot();
 } ;
 
 class JPMethodMatch

--- a/native/common/include/jp_numbertype.h
+++ b/native/common/include/jp_numbertype.h
@@ -31,7 +31,7 @@ public:
 
 	virtual~ JPNumberType();
 
-	JPMatch::Type getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj) override;
+	JPMatch::Type getJavaConversion(JPMatch& match) override;
 } ;
 
 #endif // _JPNUMBERTYPE_H_

--- a/native/common/include/jp_numbertype.h
+++ b/native/common/include/jp_numbertype.h
@@ -31,7 +31,7 @@ public:
 
 	virtual~ JPNumberType();
 
-	JPMatch::Type getJavaConversion(JPMatch& match) override;
+	JPMatch::Type findJavaConversion(JPMatch& match) override;
 } ;
 
 #endif // _JPNUMBERTYPE_H_

--- a/native/common/include/jp_objecttype.h
+++ b/native/common/include/jp_objecttype.h
@@ -37,7 +37,7 @@ public:
 
 	virtual~ JPObjectType();
 
-	JPMatch::Type getJavaConversion(JPMatch& match) override;
+	JPMatch::Type findJavaConversion(JPMatch& match) override;
 } ;
 
 #endif // _JPOBJECTTYPE_H_

--- a/native/common/include/jp_objecttype.h
+++ b/native/common/include/jp_objecttype.h
@@ -37,7 +37,7 @@ public:
 
 	virtual~ JPObjectType();
 
-	JPMatch::Type getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj) override;
+	JPMatch::Type getJavaConversion(JPMatch& match) override;
 } ;
 
 #endif // _JPOBJECTTYPE_H_

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -1,6 +1,6 @@
 #ifndef JP_PRIMITIVE_ACCESSOR_H
 #define JP_PRIMITIVE_ACCESSOR_H
-
+#include <Python.h>
 #include "jp_exception.h"
 #include "jp_javaframe.h"
 
@@ -154,6 +154,14 @@ class JPConversionLong : public JPConversion
 {
 public:
 
+	virtual JPMatch::Type matches(JPMatch &match, JPClass *cls)
+	{
+		if (!PyLong_CheckExact(match.object) && !PyIndex_Check(match.object))
+			return match.type = JPMatch::_none;
+		match.conversion = this;
+		return match.type = JPMatch::_implicit;
+	}
+
 	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
 	{
 		jvalue res;
@@ -169,6 +177,14 @@ template <typename base_t>
 class JPConversionLongNumber : public JPConversion
 {
 public:
+
+	virtual JPMatch::Type matches(JPMatch &match, JPClass *cls)
+	{
+		if (!PyNumber_Check(match.object))
+			return match.type = JPMatch::_none;
+		match.conversion = this;
+		return match.type = JPMatch::_explicit;
+	}
 
 	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
 	{
@@ -204,9 +220,9 @@ class JPConversionAsFloat : public JPConversion
 {
 public:
 
-	virtual JPMatch::Type matches(JPMatch &match, JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual JPMatch::Type matches(JPMatch &match, JPClass *cls) override
 	{
-		if (!PyNumber_Check(pyobj))
+		if (!PyNumber_Check(match.object))
 			return match.type = JPMatch::_none;
 		match.conversion = this;
 		return match.type = JPMatch::_implicit;
@@ -228,9 +244,9 @@ class JPConversionLongAsFloat : public JPConversion
 {
 public:
 
-	virtual JPMatch::Type matches(JPMatch &match, JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual JPMatch::Type matches(JPMatch &match, JPClass *cls) override
 	{
-		if (!PyLong_Check(pyobj))
+		if (!PyLong_Check(match.object))
 			return match.type = JPMatch::_none;
 		match.conversion = this;
 		return match.type = JPMatch::_implicit;

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -3,6 +3,7 @@
 #include <Python.h>
 #include "jp_exception.h"
 #include "jp_javaframe.h"
+#include "jp_match.h"
 
 template <typename array_t, typename ptr_t>
 class JPPrimitiveArrayAccessor
@@ -162,10 +163,10 @@ public:
 		return match.type = JPMatch::_implicit;
 	}
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
 		jvalue res;
-		jlong val = PyLong_AsLongLong(pyobj);
+		jlong val = PyLong_AsLongLong(match.object);
 		if (val == -1)
 			JP_PY_CHECK();
 		base_t::field(res) = (typename base_t::type_t) base_t::assertRange(val);
@@ -186,10 +187,10 @@ public:
 		return match.type = JPMatch::_explicit;
 	}
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
 		jvalue res;
-		PyObject *obj = PyNumber_Long(pyobj);
+		PyObject *obj = PyNumber_Long(match.object);
 		JP_PY_CHECK();
 		jlong val = PyLong_AsLongLong(obj);
 		Py_DECREF(obj);
@@ -205,9 +206,9 @@ class JPConversionLongWiden : public JPConversion
 {
 public:
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
-		JPValue *value = PyJPValue_getJavaSlot(pyobj);
+		JPValue *value = match.getJavaSlot();
 		jvalue ret;
 		base_t::field(ret) = (typename base_t::type_t) ((JPPrimitiveType*)
 				value->getClass())->getAsLong(value->getValue());
@@ -228,10 +229,10 @@ public:
 		return match.type = JPMatch::_implicit;
 	}
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
 		jvalue res;
-		double val = PyFloat_AsDouble(pyobj);
+		double val = PyFloat_AsDouble(match.object);
 		if (val == -1.0)
 			JP_PY_CHECK();
 		base_t::field(res) = (typename base_t::type_t) val;
@@ -252,10 +253,10 @@ public:
 		return match.type = JPMatch::_implicit;
 	}
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
 		jvalue res;
-		jdouble v = PyLong_AsDouble(pyobj);
+		jdouble v = PyLong_AsDouble(match.object);
 		if (v == -1.0)
 			JP_PY_CHECK();
 		base_t::field(res) = (typename base_t::type_t) v;
@@ -268,9 +269,9 @@ class JPConversionFloatWiden : public JPConversion
 {
 public:
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
-		JPValue *value = PyJPValue_getJavaSlot(pyobj);
+		JPValue *value = PyJPValue_getJavaSlot(match.object);
 		jvalue ret;
 		base_t::field(ret) = (typename base_t::type_t) ((JPPrimitiveType*) value->getClass())->getAsDouble(value->getValue());
 		return ret;

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -34,7 +34,7 @@ public:
 		{
 			if (_array)
 				((&_frame)->*_release)(_array, _elem, JNI_ABORT);
-		}		catch (JPypeException &ex) // GCOVR_EXCL_LINE
+		}		catch (JPypeException&) // GCOVR_EXCL_LINE
 		{
 			// We can't throw here because it would abort.
 			// But this is called on a non-op release, so
@@ -75,7 +75,7 @@ template <class type_t> PyObject *convertMultiArray(
 {
 	JPContext *context = frame.getContext();
 	Py_buffer& view = buffer.getView();
-	jconverter converter = getConverter(view.format, view.itemsize, code);
+	jconverter converter = getConverter(view.format, (int) view.itemsize, code);
 	if (converter == NULL)
 	{
 		PyErr_Format(PyExc_TypeError, "No type converter found");
@@ -93,7 +93,7 @@ template <class type_t> PyObject *convertMultiArray(
 	void *mem = frame.getEnv()->GetPrimitiveArrayCritical(a0, &isCopy);
 	type_t *dest = (type_t*) mem;
 
-	int step;
+	Py_ssize_t step;
 	if (view.strides == NULL)
 		step = view.itemsize;
 	else

--- a/native/common/include/jp_shorttype.h
+++ b/native/common/include/jp_shorttype.h
@@ -42,7 +42,7 @@ public:
 		return context->_java_lang_Short;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_shorttype.h
+++ b/native/common/include/jp_shorttype.h
@@ -42,7 +42,7 @@ public:
 		return context->_java_lang_Short;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 

--- a/native/common/include/jp_stringtype.h
+++ b/native/common/include/jp_stringtype.h
@@ -31,7 +31,7 @@ public:
 
 public:
 	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
-	JPMatch::Type getJavaConversion(JPMatch& match) override;
+	JPMatch::Type findJavaConversion(JPMatch& match) override;
 	virtual JPValue newInstance(JPJavaFrame& frame, JPPyObjectVector& args) override;
 } ;
 

--- a/native/common/include/jp_stringtype.h
+++ b/native/common/include/jp_stringtype.h
@@ -31,7 +31,7 @@ public:
 
 public:
 	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
-	JPMatch::Type getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj) override;
+	JPMatch::Type getJavaConversion(JPMatch& match) override;
 	virtual JPValue newInstance(JPJavaFrame& frame, JPPyObjectVector& args) override;
 } ;
 

--- a/native/common/include/jp_voidtype.h
+++ b/native/common/include/jp_voidtype.h
@@ -29,7 +29,7 @@ public:
 		return context->_java_lang_Void;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj) override;
+	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_voidtype.h
+++ b/native/common/include/jp_voidtype.h
@@ -29,7 +29,7 @@ public:
 		return context->_java_lang_Void;
 	}
 
-	virtual JPMatch::Type getJavaConversion(JPMatch &match) override;
+	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
 	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -41,29 +41,10 @@ JPMatch::Type JPArrayClass::findJavaConversion(JPMatch &match)
 	if (nullConversion->matches(match, this)
 			|| objectConversion->matches(match, this)
 			|| charArrayConversion->matches(match, this)
-			|| byteArrayConversion->matches(match, this))
+			|| byteArrayConversion->matches(match, this)
+			|| sequenceConversion->matches(match, this)
+			)
 		return match.type;
-
-	if (JPPyObject::isSequenceOfItems(match.object))
-	{
-		JP_TRACE("Sequence");
-		JPPySequence seq(JPPyRef::_use, match.object);
-		jlong length = seq.size();
-		match.type = JPMatch::_implicit;
-		for (jlong i = 0; i < length && match.type > JPMatch::_none; i++)
-		{
-			JPMatch imatch(match.frame, seq[i].get());
-			m_ComponentType->findJavaConversion(imatch);
-			if (imatch.type < match.type)
-			{
-				match.type = imatch.type;
-			}
-		}
-		match.closure = this;
-		match.conversion = sequenceConversion;
-		return match.type;
-	}
-
 	JP_TRACE("None");
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
@@ -97,9 +78,4 @@ JPValue JPArrayClass::newInstance(JPJavaFrame& frame, int length)
 	jvalue v;
 	v.l = frame.keep(m_ComponentType->newArrayInstance(frame, length));
 	return JPValue(this, v);
-}
-
-JPValue JPArrayClass::newInstance(JPJavaFrame& frame, JPPyObjectVector& args)
-{
-	JP_RAISE(PyExc_SystemError, "Not used");
 }

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -35,7 +35,7 @@ JPArrayClass::~JPArrayClass()
 {
 }
 
-JPMatch::Type JPArrayClass::getJavaConversion(JPMatch &match)
+JPMatch::Type JPArrayClass::findJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPArrayClass::getJavaConversion");
 	if (nullConversion->matches(match, this)
@@ -53,12 +53,13 @@ JPMatch::Type JPArrayClass::getJavaConversion(JPMatch &match)
 		for (jlong i = 0; i < length && match.type > JPMatch::_none; i++)
 		{
 			JPMatch imatch(match.frame, seq[i].get());
-			m_ComponentType->getJavaConversion(imatch);
+			m_ComponentType->findJavaConversion(imatch);
 			if (imatch.type < match.type)
 			{
 				match.type = imatch.type;
 			}
 		}
+		match.closure = this;
 		match.conversion = sequenceConversion;
 		return match.type;
 	}

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -35,25 +35,25 @@ JPArrayClass::~JPArrayClass()
 {
 }
 
-JPMatch::Type JPArrayClass::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
+JPMatch::Type JPArrayClass::getJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPArrayClass::getJavaConversion");
-	if (nullConversion->matches(match, frame, this, pyobj)
-			|| objectConversion->matches(match, frame, this, pyobj)
-			|| charArrayConversion->matches(match, frame, this, pyobj)
-			|| byteArrayConversion->matches(match, frame, this, pyobj))
+	if (nullConversion->matches(match, this)
+			|| objectConversion->matches(match, this)
+			|| charArrayConversion->matches(match, this)
+			|| byteArrayConversion->matches(match, this))
 		return match.type;
 
-	if (JPPyObject::isSequenceOfItems(pyobj))
+	if (JPPyObject::isSequenceOfItems(match.object))
 	{
 		JP_TRACE("Sequence");
-		JPPySequence seq(JPPyRef::_use, pyobj);
+		JPPySequence seq(JPPyRef::_use, match.object);
 		jlong length = seq.size();
 		match.type = JPMatch::_implicit;
-		JPMatch imatch;
 		for (jlong i = 0; i < length && match.type > JPMatch::_none; i++)
 		{
-			m_ComponentType->getJavaConversion(frame, imatch, seq[i].get());
+			JPMatch imatch(match.frame, seq[i].get());
+			m_ComponentType->getJavaConversion(imatch);
 			if (imatch.type < match.type)
 			{
 				match.type = imatch.type;

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -261,7 +261,7 @@ void JPBooleanType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseBooleanArrayElements((jbooleanArray) view.m_Array->getJava(),
 				(jboolean*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -77,7 +77,7 @@ JPMatch::Type JPBooleanType::getJavaConversion(JPMatch &match)
 		return match.type = JPMatch::_exact;
 	}
 
-	JPValue *value = PyJPValue_getJavaSlot(match.object);
+	JPValue *value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -48,7 +48,7 @@ public:
 
 	virtual JPMatch::Type matches(JPMatch &match, JPClass *cls)
 	{
-		if (!PyLong_Check(match.object)
+		if (!PyLong_CheckExact(match.object)
 				&& !PyIndex_Check(match.object))
 			return match.type = JPMatch::_none;
 		match.conversion = this;

--- a/native/common/jp_boxedtype.cpp
+++ b/native/common/jp_boxedtype.cpp
@@ -37,16 +37,17 @@ JPBoxedType::~JPBoxedType()
 {
 }
 
-JPMatch::Type JPBoxedType::getJavaConversion(JPMatch &match)
+JPMatch::Type JPBoxedType::findJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPBoxedType::getJavaConversion");
-	JPClass::getJavaConversion(match);
+	JPClass::findJavaConversion(match);
 	if (match.type != JPMatch::_none)
 		return match.type;
-	if (m_PrimitiveType->getJavaConversion(match) != JPMatch::_none)
+	if (m_PrimitiveType->findJavaConversion(match) != JPMatch::_none)
 	{
 		JP_TRACE("Primitive", match.type);
 		match.conversion = boxConversion;
+		match.closure = this;
 		return match.type = JPMatch::_explicit;
 	}
 	return match.type = JPMatch::_none;

--- a/native/common/jp_boxedtype.cpp
+++ b/native/common/jp_boxedtype.cpp
@@ -37,13 +37,13 @@ JPBoxedType::~JPBoxedType()
 {
 }
 
-JPMatch::Type JPBoxedType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
+JPMatch::Type JPBoxedType::getJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPBoxedType::getJavaConversion");
-	JPClass::getJavaConversion(frame, match, pyobj);
+	JPClass::getJavaConversion(match);
 	if (match.type != JPMatch::_none)
 		return match.type;
-	if (m_PrimitiveType->getJavaConversion(frame, match, pyobj) != JPMatch::_none)
+	if (m_PrimitiveType->getJavaConversion(match) != JPMatch::_none)
 	{
 		JP_TRACE("Primitive", match.type);
 		match.conversion = boxConversion;

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -228,7 +228,7 @@ void JPByteType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseByteArrayElements((jbyteArray) view.m_Array->getJava(),
 				(jbyte*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -53,7 +53,7 @@ JPMatch::Type JPByteType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(match.object);
+	JPValue *value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -63,7 +63,7 @@ JPMatch::Type JPCharType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(match.object);
+	JPValue *value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -55,17 +55,15 @@ public:
 	}
 } asCharConversion;
 
-JPMatch::Type JPCharType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
+JPMatch::Type JPCharType::getJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPCharType::getJavaConversion");
-	JPContext *context = NULL;
-	if (frame != NULL)
-		context = frame->getContext();
+	JPContext *context = match.getContext();
 
-	if (pyobj == Py_None)
+	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(pyobj);
+	JPValue *value = PyJPValue_getJavaSlot(match.object);
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();
@@ -86,7 +84,7 @@ JPMatch::Type JPCharType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, 
 		return match.type = JPMatch::_none;
 	}
 
-	if (JPPyString::checkCharUTF16(pyobj))
+	if (JPPyString::checkCharUTF16(match.object))
 	{
 		match.conversion = &asCharConversion;
 		return match.type = JPMatch::_implicit;
@@ -140,8 +138,8 @@ JPPyObject JPCharType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 
 void JPCharType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java char");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetStaticCharField(c, fid, val);
@@ -149,8 +147,8 @@ void JPCharType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyOb
 
 void JPCharType::setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java char");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetCharField(c, fid, val);
@@ -190,8 +188,8 @@ JPPyObject JPCharType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 
 void JPCharType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java char");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetCharArrayRegion((array_t) a, ndx, 1, &val);

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -207,7 +207,7 @@ void JPCharType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseCharArrayElements((jcharArray) view.m_Array->getJava(),
 				(jchar*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -47,18 +47,17 @@ class JPConversionAsChar : public JPConversion
 	typedef JPCharType base_t;
 public:
 
-	virtual jvalue convert(JPJavaFrame *frame, JPClass *cls, PyObject *pyobj) override
+	virtual jvalue convert(JPMatch &match) override
 	{
 		jvalue res;
-		res.c = JPPyString::asCharUTF16(pyobj);
+		res.c = JPPyString::asCharUTF16(match.object);
 		return res;
 	}
 } asCharConversion;
 
-JPMatch::Type JPCharType::getJavaConversion(JPMatch &match)
+JPMatch::Type JPCharType::findJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPCharType::getJavaConversion");
-	JPContext *context = match.getContext();
 
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
@@ -74,11 +73,8 @@ JPMatch::Type JPCharType::getJavaConversion(JPMatch &match)
 		}
 
 		// Implied conversion from boxed to primitive (JLS 5.1.8)
-		if (context != NULL && cls == context->_java_lang_Character)
-		{
-			match.conversion = unboxConversion;
-			return match.type = JPMatch::_implicit;
-		}
+		if (unboxConversion->matches(match, this))
+			return match.type;
 
 		// Unboxing must be to the from the exact boxed type (JLS 5.1.8)
 		return match.type = JPMatch::_none;
@@ -139,18 +135,18 @@ JPPyObject JPCharType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 void JPCharType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
 {
 	JPMatch match(&frame, obj);
-	if (getJavaConversion(match) < JPMatch::_implicit)
+	if (findJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java char");
-	type_t val = field(match.conversion->convert(&frame, this, obj));
+	type_t val = field(match.convert());
 	frame.SetStaticCharField(c, fid, val);
 }
 
 void JPCharType::setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* obj)
 {
 	JPMatch match(&frame, obj);
-	if (getJavaConversion(match) < JPMatch::_implicit)
+	if (findJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java char");
-	type_t val = field(match.conversion->convert(&frame, this, obj));
+	type_t val = field(match.convert());
 	frame.SetCharField(c, fid, val);
 }
 
@@ -189,9 +185,9 @@ JPPyObject JPCharType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 void JPCharType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)
 {
 	JPMatch match(&frame, obj);
-	if (getJavaConversion(match) < JPMatch::_implicit)
+	if (findJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java char");
-	type_t val = field(match.conversion->convert(&frame, this, obj));
+	type_t val = field(match.convert());
 	frame.SetCharArrayRegion((array_t) a, ndx, 1, &val);
 }
 

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -317,19 +317,9 @@ JPMatch::Type JPClass::findJavaConversion(JPMatch &match)
 	JP_TRACE("Python", JPPyObject::getTypeName(pyobj));
 	if (nullConversion->matches(match, this)
 			|| objectConversion->matches(match, this)
-			|| proxyConversion->matches(match, this))
+			|| proxyConversion->matches(match, this)
+			|| hintsConversion->matches(match, this))
 		return match.type;
-
-	// Apply user supplied conversions
-	if (!m_Hints.isNull())
-	{
-		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
-		if (hints->getConversion(match, this) != JPMatch::_none)
-		{
-			JP_TRACE("Match custom conversion");
-			return match.type;
-		}
-	}
 	JP_TRACE("No match");
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -185,13 +185,13 @@ void JPClass::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObjec
 {
 	JP_TRACE_IN("JPClass::setStaticField");
 	JPMatch match(&frame, obj);
-	if (getJavaConversion(match) < JPMatch::_implicit)
+	if (findJavaConversion(match) < JPMatch::_implicit)
 	{
 		stringstream err;
 		err << "unable to convert to " << getCanonicalName();
 		JP_RAISE(PyExc_TypeError, err.str().c_str());
 	}
-	jobject val = match.conversion->convert(&frame, this, obj).l;
+	jobject val = match.convert().l;
 	frame.SetStaticObjectField(c, fid, val);
 	JP_TRACE_OUT;
 }
@@ -200,13 +200,13 @@ void JPClass::setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* ob
 {
 	JP_TRACE_IN("JPClass::setField");
 	JPMatch match(&frame, obj);
-	if (getJavaConversion(match) < JPMatch::_implicit)
+	if (findJavaConversion(match) < JPMatch::_implicit)
 	{
 		stringstream err;
 		err << "unable to convert to " << getCanonicalName();
 		JP_RAISE(PyExc_TypeError, err.str().c_str());
 	}
-	jobject val = match.conversion->convert(&frame, this, obj).l;
+	jobject val = match.convert().l;
 	frame.SetObjectField(c, fid, val);
 	JP_TRACE_OUT;
 }
@@ -226,7 +226,7 @@ void JPClass::setArrayRange(JPJavaFrame& frame, jarray a,
 	{
 		JPPyObject v = seq[i];
 		JPMatch match(&frame, v.get());
-		if (getJavaConversion(match) < JPMatch::_implicit)
+		if (findJavaConversion(match) < JPMatch::_implicit)
 			JP_RAISE(PyExc_TypeError, "Unable to convert");
 	}
 
@@ -236,9 +236,8 @@ void JPClass::setArrayRange(JPJavaFrame& frame, jarray a,
 	{
 		JPPyObject v = seq[i];
 		JPMatch match(&frame, v.get());
-		getJavaConversion(match);
-		frame.SetObjectArrayElement(array, index,
-				match.conversion->convert(&frame, this, v.get()).l);
+		findJavaConversion(match);
+		frame.SetObjectArrayElement(array, index, match.convert().l);
 	}
 	JP_TRACE_OUT;
 }
@@ -247,13 +246,13 @@ void JPClass::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* va
 {
 	JP_TRACE_IN("JPClass::setArrayItem");
 	JPMatch match(&frame, val);
-	getJavaConversion(match);
+	findJavaConversion(match);
 	JP_TRACE("Type", getCanonicalName());
 	if ( match.type < JPMatch::_implicit)
 	{
 		JP_RAISE(PyExc_TypeError, "Unable to convert");
 	}
-	jvalue v = match.conversion->convert(&frame, this, val);
+	jvalue v = match.convert();
 	frame.SetObjectArrayElement((jobjectArray) a, ndx, v.l);
 	JP_TRACE_OUT;
 }
@@ -312,7 +311,7 @@ JPPyObject JPClass::convertToPythonObject(JPJavaFrame& frame, jvalue obj)
 	JP_TRACE_OUT;
 }
 
-JPMatch::Type JPClass::getJavaConversion(JPMatch &match)
+JPMatch::Type JPClass::findJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPClass::getJavaConversion");
 	JP_TRACE("Python", JPPyObject::getTypeName(pyobj));

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -496,7 +496,7 @@ public:
 	}
 } _javaObjectAnyConversion;
 
-class JPConversionJavaNumberAny : public JPConversion
+class JPConversionJavaNumberAny : public JPConversionJavaObjectAny
 {
 public:
 
@@ -511,7 +511,7 @@ public:
 				|| value->getClass() == context->_boolean
 				|| value->getClass() == context->_char)
 			return match.type = JPMatch::_none;
-		match.conversion = &_javaObjectAnyConversion;
+		match.conversion = this;
 		JPClass *oc = value->getClass();
 		// If it is the exact type, then it is exact
 		if (oc == cls)
@@ -525,12 +525,6 @@ public:
 		JP_TRACE_OUT;
 	}
 
-	virtual jvalue convert(JPMatch &match) override
-	{
-		jvalue  v;
-		v.l = 0;
-		return v;
-	}
 } _javaNumberAnyConversion;
 
 class JPConversionJavaValue : public JPConversion

--- a/native/common/jp_classloader.cpp
+++ b/native/common/jp_classloader.cpp
@@ -19,11 +19,6 @@
 #include <jp_classloader.h>
 #include <jp_thunk.h>
 
-jobject JPClassLoader::getSystemClassLoader()
-{
-	return m_SystemClassLoader.get();
-}
-
 jobject JPClassLoader::getBootLoader()
 {
 	return m_BootLoader.get();
@@ -62,7 +57,7 @@ JPClassLoader::JPClassLoader(JPJavaFrame& frame)
 	v.l = jar;
 	jmethodID importJarID = frame.GetMethodID(cls, "importJar", "([B)V");
 	frame.CallVoidMethodA(m_BootLoader.get(), importJarID, &v);
-	JP_TRACE_OUT;
+	JP_TRACE_OUT;  // GCOVR_EXCL_LINE
 }
 
 jclass JPClassLoader::findClass(JPJavaFrame& frame, string name)

--- a/native/common/jp_classtype.cpp
+++ b/native/common/jp_classtype.cpp
@@ -33,7 +33,7 @@ JPClassType::~JPClassType()
 {
 }
 
-JPMatch::Type JPClassType::getJavaConversion(JPMatch& match)
+JPMatch::Type JPClassType::findJavaConversion(JPMatch& match)
 {
 	JP_TRACE_IN("JPClass::getJavaConversion");
 	if (nullConversion->matches(match, this) != JPMatch::_none)

--- a/native/common/jp_classtype.cpp
+++ b/native/common/jp_classtype.cpp
@@ -33,14 +33,14 @@ JPClassType::~JPClassType()
 {
 }
 
-JPMatch::Type JPClassType::getJavaConversion(JPJavaFrame *frame, JPMatch& match, PyObject* pyobj)
+JPMatch::Type JPClassType::getJavaConversion(JPMatch& match)
 {
 	JP_TRACE_IN("JPClass::getJavaConversion");
-	if (nullConversion->matches(match, frame, this, pyobj) != JPMatch::_none)
+	if (nullConversion->matches(match, this) != JPMatch::_none)
 		return match.type;
-	if (objectConversion->matches(match, frame, this, pyobj) != JPMatch::_none)
+	if (objectConversion->matches(match, this) != JPMatch::_none)
 		return match.type;
-	if (classConversion->matches(match, frame, this, pyobj) != JPMatch::_none)
+	if (classConversion->matches(match, this) != JPMatch::_none)
 		return match.type;
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -54,7 +54,7 @@ JPMatch::Type JPDoubleType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(match.object);
+	JPValue *value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -256,7 +256,7 @@ void JPDoubleType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseDoubleArrayElements((jdoubleArray) view.m_Array->getJava(),
 				(jdouble*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -49,7 +49,6 @@ static JPConversionFloatWiden<JPDoubleType> doubleWidenConversion;
 JPMatch::Type JPDoubleType::findJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPDoubleType::getJavaConversion");
-	JPContext *context = match.getContext();
 
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -249,7 +249,7 @@ void JPFloatType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseFloatArrayElements((jfloatArray) view.m_Array->getJava(),
 				(jfloat*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -54,7 +54,7 @@ JPMatch::Type JPFloatType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(match.object);
+	JPValue *value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -46,17 +46,15 @@ static JPConversionAsFloat<JPFloatType> asFloatConversion;
 static JPConversionLongAsFloat<JPFloatType> asFloatLongConversion;
 static JPConversionFloatWiden<JPFloatType> floatWidenConversion;
 
-JPMatch::Type JPFloatType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
+JPMatch::Type JPFloatType::getJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPFloatType::getJavaConversion");
-	JPContext *context = NULL;
-	if (frame != NULL)
-		context = frame->getContext();
+	JPContext *context = match.getContext();
 
-	if (pyobj == Py_None)
+	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(pyobj);
+	JPValue *value = PyJPValue_getJavaSlot(match.object);
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();
@@ -96,8 +94,8 @@ JPMatch::Type JPFloatType::getJavaConversion(JPJavaFrame *frame, JPMatch &match,
 		return match.type = JPMatch::_none;
 	}
 
-	if (asFloatLongConversion.matches(match, frame, this, pyobj)
-			|| asFloatConversion.matches(match, frame, this, pyobj))
+	if (asFloatLongConversion.matches(match, this)
+			|| asFloatConversion.matches(match, this))
 		return match.type;
 
 	return match.type = JPMatch::_none;
@@ -148,8 +146,8 @@ JPPyObject JPFloatType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jm
 
 void JPFloatType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject *obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java float");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetStaticFloatField(c, fid, val);
@@ -157,8 +155,8 @@ void JPFloatType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyO
 
 void JPFloatType::setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject *obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java float");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetFloatField(c, fid, val);
@@ -232,8 +230,8 @@ JPPyObject JPFloatType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 
 void JPFloatType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java float");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetFloatArrayRegion((array_t) a, ndx, 1, &val);

--- a/native/common/jp_inttype.cpp
+++ b/native/common/jp_inttype.cpp
@@ -248,7 +248,7 @@ void JPIntType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseIntArrayElements((jintArray) view.m_Array->getJava(),
 				(jint*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_inttype.cpp
+++ b/native/common/jp_inttype.cpp
@@ -54,7 +54,7 @@ JPMatch::Type JPIntType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue *value = PyJPValue_getJavaSlot(match.object);
+	JPValue *value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -986,7 +986,7 @@ public:
 		try
 		{
 			frame_.ReleaseStringUTFChars(jstr_, cstr);
-		}		catch (JPypeException &ex)
+		}		catch (JPypeException&)
 		{
 			// Error during release must be eaten.
 			// If Java does not accept a release of the buffer it

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -248,7 +248,7 @@ void JPLongType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseLongArrayElements((jlongArray) view.m_Array->getJava(),
 				(jlong*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -54,7 +54,7 @@ JPMatch::Type JPLongType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue* value = PyJPValue_getJavaSlot(match.object);
+	JPValue* value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -49,7 +49,6 @@ JPConversionLongWiden<JPLongType> longWidenConversion;
 JPMatch::Type JPLongType::findJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPLongType::getJavaConversion");
-	JPContext *context = match.getContext();
 
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -46,17 +46,15 @@ JPConversionLong<JPLongType> longConversion;
 JPConversionLongNumber<JPLongType> longNumberConversion;
 JPConversionLongWiden<JPLongType> longWidenConversion;
 
-JPMatch::Type JPLongType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
+JPMatch::Type JPLongType::getJavaConversion(JPMatch &match)
 {
 	JP_TRACE_IN("JPLongType::getJavaConversion");
-	JPContext *context = NULL;
-	if (frame != NULL)
-		context = frame->getContext();
+	JPContext *context = match.getContext();
 
-	if (pyobj == Py_None)
+	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue* value = PyJPValue_getJavaSlot(pyobj);
+	JPValue* value = PyJPValue_getJavaSlot(match.object);
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();
@@ -95,17 +93,9 @@ JPMatch::Type JPLongType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, 
 		return match.type = JPMatch::_none;
 	}
 
-	if (PyLong_Check(pyobj) || PyIndex_Check(pyobj))
-	{
-		match.conversion = &longNumberConversion;
-		return match.type = JPMatch::_implicit;
-	}
-
-	if (PyNumber_Check(pyobj))
-	{
-		match.conversion = &longNumberConversion;
-		return match.type = JPMatch::_explicit;
-	}
+	if (longConversion.matches(match, this)
+			|| longNumberConversion.matches(match, this))
+		return match.type;
 
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
@@ -155,8 +145,8 @@ JPPyObject JPLongType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 
 void JPLongType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java int");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetStaticLongField(c, fid, val);
@@ -164,8 +154,8 @@ void JPLongType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyOb
 
 void JPLongType::setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java int");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetLongField(c, fid, val);
@@ -239,8 +229,8 @@ JPPyObject JPLongType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 
 void JPLongType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)
 {
-	JPMatch match;
-	if (getJavaConversion(&frame, match, obj) < JPMatch::_implicit)
+	JPMatch match(&frame, obj);
+	if (getJavaConversion(match) < JPMatch::_implicit)
 		JP_RAISE(PyExc_TypeError, "Unable to convert to Java int");
 	type_t val = field(match.conversion->convert(&frame, this, obj));
 	frame.SetLongArrayRegion((array_t) a, ndx, 1, &val);

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -199,7 +199,6 @@ void JPMethod::packArgs(JPJavaFrame &frame, JPMethodMatch &match,
 	JP_TRACE("Pack fixed total=", len - match.offset);
 	for (size_t i = match.skip; i < len; i++)
 	{
-		JPClass* type = m_ParameterTypes[i - match.offset];
 		v[i - match.skip] = match.argument[i].convert();
 	}
 	JP_TRACE_OUT;
@@ -212,7 +211,6 @@ JPPyObject JPMethod::invoke(JPJavaFrame& frame, JPMethodMatch& match, JPPyObject
 	if (isCallerSensitive())
 		return invokeCallerSensitive(match, arg, instance);
 
-	JPContext *context = m_Class->getContext();
 	size_t alen = m_ParameterTypes.size();
 	JPClass* retType = m_ReturnType;
 

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -64,7 +64,7 @@ JPMatch::Type matchVars(JPJavaFrame &frame, JPMethodMatch& match, JPPyObjectVect
 	JPMatch::Type lastMatch = JPMatch::_exact;
 	for (size_t i = start; i < len; i++)
 	{
-		JPMatch::Type quality = type->getJavaConversion(match[i]);
+		JPMatch::Type quality = type->findJavaConversion(match[i]);
 
 		if (quality < JPMatch::_implicit)
 		{
@@ -132,7 +132,7 @@ JPMatch::Type JPMethod::matches(JPJavaFrame &frame, JPMethodMatch& methodMatch, 
 		{
 			// Try direct
 			size_t last = tlen - 1 - methodMatch.offset;
-			methodMatch.type = type->getJavaConversion(methodMatch.argument[last]);
+			methodMatch.type = type->findJavaConversion(methodMatch.argument[last]);
 			JP_TRACE("Direct vargs", methodMatch.type);
 		}
 
@@ -162,7 +162,7 @@ JPMatch::Type JPMethod::matches(JPJavaFrame &frame, JPMethodMatch& methodMatch, 
 		size_t j = i + methodMatch.offset;
 		JPClass *type = m_ParameterTypes[i];
 		JP_TRACE("Compare", i, j, type->toString(), JPPyObject::getTypeName(arg[j]));
-		JPMatch::Type ematch = type->getJavaConversion(methodMatch.argument[j]);
+		JPMatch::Type ematch = type->findJavaConversion(methodMatch.argument[j]);
 		JP_TRACE("Result", ematch);
 		if (ematch < methodMatch.type)
 		{
@@ -200,11 +200,7 @@ void JPMethod::packArgs(JPJavaFrame &frame, JPMethodMatch &match,
 	for (size_t i = match.skip; i < len; i++)
 	{
 		JPClass* type = m_ParameterTypes[i - match.offset];
-		JPConversion *conversion = match.argument[i].conversion;
-		JP_TRACE("Convert", i - match.offset, i, type->getCanonicalName(), conversion);
-		if (conversion == NULL)
-			JP_RAISE(PyExc_RuntimeError, "Conversion is null");
-		v[i - match.skip] = conversion->convert(&frame, type, arg[i]);
+		v[i - match.skip] = match.argument[i].convert();
 	}
 	JP_TRACE_OUT;
 }
@@ -238,7 +234,7 @@ JPPyObject JPMethod::invoke(JPJavaFrame& frame, JPMethodMatch& match, JPPyObject
 		{
 			// This only can be hit by calling an instance method as a
 			// class object.  We already know it is safe to convert.
-			jvalue  v = match.argument[0].conversion->convert(&frame, m_Class, arg[0]);
+			jvalue  v = match.argument[0].convert();
 			c = v.l;
 		} else
 		{
@@ -295,8 +291,8 @@ JPPyObject JPMethod::invokeCallerSensitive(JPMethodMatch& match, JPPyObjectVecto
 			PyObject *u = arg[i + match.skip];
 			JPMatch conv(&frame, u);
 			JPClass *boxed = type->getBoxedClass(context);
-			boxed->getJavaConversion(conv);
-			jvalue v = conv.conversion->convert(&frame, boxed, u);
+			boxed->findJavaConversion(conv);
+			jvalue v = conv.convert();
 			frame.SetObjectArrayElement(ja, i, v.l);
 		} else
 		{

--- a/native/common/jp_methoddispatch.cpp
+++ b/native/common/jp_methoddispatch.cpp
@@ -45,7 +45,7 @@ void JPMethodDispatch::findOverload(JPJavaFrame& frame, JPMethodMatch &bestMatch
 	JP_TRACE("Checking overload", m_Name);
 	JP_TRACE("Got overloads to check", m_Overloads.size());
 	JPMethodList ambiguous;
-	JPMethodMatch match(arg.size());
+	JPMethodMatch match(frame, arg);
 	for (JPMethodList::iterator it = m_Overloads.begin(); it != m_Overloads.end(); ++it)
 	{
 		JPMethod* current = *it;
@@ -157,7 +157,7 @@ void JPMethodDispatch::findOverload(JPJavaFrame& frame, JPMethodMatch &bestMatch
 JPPyObject JPMethodDispatch::invoke(JPJavaFrame& frame, JPPyObjectVector& args, bool instance)
 {
 	JP_TRACE_IN("JPMethodDispatch::invoke");
-	JPMethodMatch match(args.size());
+	JPMethodMatch match(frame, args);
 	findOverload(frame, match, args, instance);
 	return match.overload->invoke(frame, match, args, instance);
 	JP_TRACE_OUT;
@@ -166,7 +166,7 @@ JPPyObject JPMethodDispatch::invoke(JPJavaFrame& frame, JPPyObjectVector& args, 
 JPValue JPMethodDispatch::invokeConstructor(JPJavaFrame& frame, JPPyObjectVector& args)
 {
 	JP_TRACE_IN("JPMethodDispatch::invokeConstructor");
-	JPMethodMatch match(args.size());
+	JPMethodMatch match(frame, args);
 	findOverload(frame, match, args, false);
 	return match.overload->invokeConstructor(frame, match, args);
 	JP_TRACE_OUT;

--- a/native/common/jp_numbertype.cpp
+++ b/native/common/jp_numbertype.cpp
@@ -16,6 +16,7 @@ JPNumberType::~JPNumberType()
 {
 }
 
+
 JPMatch::Type JPNumberType::findJavaConversion(JPMatch& match)
 {
 	// Rules for java.lang.Object
@@ -24,22 +25,9 @@ JPMatch::Type JPNumberType::findJavaConversion(JPMatch& match)
 			|| javaNumberAnyConversion->matches(match, this)
 			|| boxLongConversion->matches(match, this)
 			|| boxDoubleConversion->matches(match, this)
+			|| hintsConversion->matches(match, this)
 			)
-	{
 		return match.type;
-	}
-	
-	// Apply user supplied conversions
-	if (!m_Hints.isNull())
-	{
-		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
-		if (hints->getConversion(match, this) != JPMatch::_none)
-		{
-			JP_TRACE("Match custom conversion");
-			return match.type;
-		}
-	}
-
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_numbertype.cpp
+++ b/native/common/jp_numbertype.cpp
@@ -16,24 +16,24 @@ JPNumberType::~JPNumberType()
 {
 }
 
-JPMatch::Type JPNumberType::getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj)
+JPMatch::Type JPNumberType::getJavaConversion(JPMatch& match)
 {
 	// Rules for java.lang.Object
 	JP_TRACE_IN("JPNumberType::canConvertToJava");
-	if (nullConversion->matches(match, frame, this, pyobj)
-			|| javaNumberAnyConversion->matches(match, frame, this, pyobj)
-			|| boxLongConversion->matches(match, frame, this, pyobj)
-			|| boxDoubleConversion->matches(match, frame, this, pyobj)
+	if (nullConversion->matches(match, this)
+			|| javaNumberAnyConversion->matches(match, this)
+			|| boxLongConversion->matches(match, this)
+			|| boxDoubleConversion->matches(match, this)
 			)
 	{
 		return match.type;
 	}
-
+	
 	// Apply user supplied conversions
 	if (!m_Hints.isNull())
 	{
 		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
-		if (hints->getConversion(match, frame, this, pyobj) != JPMatch::_none)
+		if (hints->getConversion(match, this) != JPMatch::_none)
 		{
 			JP_TRACE("Match custom conversion");
 			return match.type;

--- a/native/common/jp_numbertype.cpp
+++ b/native/common/jp_numbertype.cpp
@@ -16,7 +16,7 @@ JPNumberType::~JPNumberType()
 {
 }
 
-JPMatch::Type JPNumberType::getJavaConversion(JPMatch& match)
+JPMatch::Type JPNumberType::findJavaConversion(JPMatch& match)
 {
 	// Rules for java.lang.Object
 	JP_TRACE_IN("JPNumberType::canConvertToJava");

--- a/native/common/jp_objecttype.cpp
+++ b/native/common/jp_objecttype.cpp
@@ -32,7 +32,7 @@ JPObjectType::~JPObjectType()
 {
 }
 
-JPMatch::Type JPObjectType::getJavaConversion(JPMatch& match)
+JPMatch::Type JPObjectType::findJavaConversion(JPMatch& match)
 {
 	// Rules for java.lang.Object
 	JP_TRACE_IN("JPObjectType::canConvertToJava");

--- a/native/common/jp_objecttype.cpp
+++ b/native/common/jp_objecttype.cpp
@@ -43,27 +43,10 @@ JPMatch::Type JPObjectType::findJavaConversion(JPMatch& match)
 			|| boxLongConversion->matches(match, this)
 			|| boxDoubleConversion->matches(match, this)
 			|| classConversion->matches(match, this)
+			|| proxyConversion->matches(match, this)
+			|| hintsConversion->matches(match, this)
 			)
 		return match.type;
-
-	JPProxy* proxy = PyJPProxy_getJPProxy(match.object);
-	if (proxy != NULL)
-	{
-		match.conversion = proxyConversion;
-		return match.type = JPMatch::_implicit;
-	}
-
-	// Apply user supplied conversions
-	if (!m_Hints.isNull())
-	{
-		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
-		if (hints->getConversion(match, this) != JPMatch::_none)
-		{
-			JP_TRACE("Match custom conversion");
-			return match.type;
-		}
-	}
-
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_objecttype.cpp
+++ b/native/common/jp_objecttype.cpp
@@ -32,21 +32,21 @@ JPObjectType::~JPObjectType()
 {
 }
 
-JPMatch::Type JPObjectType::getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj)
+JPMatch::Type JPObjectType::getJavaConversion(JPMatch& match)
 {
 	// Rules for java.lang.Object
 	JP_TRACE_IN("JPObjectType::canConvertToJava");
-	if (nullConversion->matches(match, frame, this, pyobj)
-			|| javaObjectAnyConversion->matches(match, frame, this, pyobj)
-			|| stringConversion->matches(match, frame, this, pyobj)
-			|| boxBooleanConversion->matches(match, frame, this, pyobj)
-			|| boxLongConversion->matches(match, frame, this, pyobj)
-			|| boxDoubleConversion->matches(match, frame, this, pyobj)
-			|| classConversion->matches(match, frame, this, pyobj)
+	if (nullConversion->matches(match, this)
+			|| javaObjectAnyConversion->matches(match, this)
+			|| stringConversion->matches(match, this)
+			|| boxBooleanConversion->matches(match, this)
+			|| boxLongConversion->matches(match, this)
+			|| boxDoubleConversion->matches(match, this)
+			|| classConversion->matches(match, this)
 			)
 		return match.type;
 
-	JPProxy* proxy = PyJPProxy_getJPProxy(pyobj);
+	JPProxy* proxy = PyJPProxy_getJPProxy(match.object);
 	if (proxy != NULL)
 	{
 		match.conversion = proxyConversion;
@@ -57,7 +57,7 @@ JPMatch::Type JPObjectType::getJavaConversion(JPJavaFrame* frame, JPMatch& match
 	if (!m_Hints.isNull())
 	{
 		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
-		if (hints->getConversion(match, frame, this, pyobj) != JPMatch::_none)
+		if (hints->getConversion(match, this) != JPMatch::_none)
 		{
 			JP_TRACE("Match custom conversion");
 			return match.type;

--- a/native/common/jp_platform.cpp
+++ b/native/common/jp_platform.cpp
@@ -85,8 +85,6 @@ public:
 #define  PLATFORM_ADAPTER Win32PlatformAdapter
 #else
 
-//AT's comments on porting:
-// this file should be better called jp_platform_unix.h
 #if defined(_HPUX) && !defined(_IA64)
 #include <dl.h>
 #else

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -48,7 +48,7 @@ JPPyTuple getArgs(JPContext* context, jlongArray parameterTypePtrs,
 		jobject obj = frame.GetObjectArrayElement(args, i);
 		JPClass* type = frame.findClassForObject(obj);
 		if (type == NULL)
-			type = reinterpret_cast<JPClass*> (accessor.get()[i]);
+			type = reinterpret_cast<JPClass*> (types[i]);
 		JPValue val = type->getValueFromObject(JPValue(type, obj));
 		pyargs.setItem(i, type->convertToPythonObject(frame, val).get());
 	}

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -129,23 +129,23 @@ JNIEXPORT jobject JNICALL JPype_InvocationHandler_hostInvoke(
 			if (returnClass->isPrimitive())
 			{
 				JP_TRACE("Box return");
-				if (returnClass->getJavaConversion(returnMatch) == JPMatch::_none)
+				if (returnClass->findJavaConversion(returnMatch) == JPMatch::_none)
 					JP_RAISE(PyExc_TypeError, "Return value is not compatible with required type.");
-				jvalue res = returnMatch.conversion->convert(&frame, returnClass, returnValue.get());
+				jvalue res = returnMatch.convert();
 				JPBoxedType *boxed =  (JPBoxedType *) ((JPPrimitiveType*) returnClass)->getBoxedClass(context);
 				jvalue res2;
 				res2.l = boxed->box(frame, res);
 				return frame.keep(res2.l);
 			}
 
-			if (returnClass->getJavaConversion(returnMatch) == JPMatch::_none)
+			if (returnClass->findJavaConversion(returnMatch) == JPMatch::_none)
 			{
 				JP_TRACE("Cannot convert");
 				JP_RAISE(PyExc_TypeError, "Return value is not compatible with required type.");
 			}
 
 			JP_TRACE("Convert return to", returnClass->getCanonicalName());
-			jvalue res = returnMatch.conversion->convert(&frame, returnClass, returnValue.get());
+			jvalue res = returnMatch.convert();
 			return frame.keep(res.l);
 		} catch (JPypeException& ex)
 		{

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -125,11 +125,11 @@ JNIEXPORT jobject JNICALL JPype_InvocationHandler_hostInvoke(
 			}
 
 			// We must box here.
-			JPMatch returnMatch;
+			JPMatch returnMatch(&frame, returnValue.get());
 			if (returnClass->isPrimitive())
 			{
 				JP_TRACE("Box return");
-				if (returnClass->getJavaConversion(&frame, returnMatch, returnValue.get()) == JPMatch::_none)
+				if (returnClass->getJavaConversion(returnMatch) == JPMatch::_none)
 					JP_RAISE(PyExc_TypeError, "Return value is not compatible with required type.");
 				jvalue res = returnMatch.conversion->convert(&frame, returnClass, returnValue.get());
 				JPBoxedType *boxed =  (JPBoxedType *) ((JPPrimitiveType*) returnClass)->getBoxedClass(context);
@@ -138,7 +138,7 @@ JNIEXPORT jobject JNICALL JPype_InvocationHandler_hostInvoke(
 				return frame.keep(res2.l);
 			}
 
-			if (returnClass->getJavaConversion(&frame, returnMatch, returnValue.get()) == JPMatch::_none)
+			if (returnClass->getJavaConversion(returnMatch) == JPMatch::_none)
 			{
 				JP_TRACE("Cannot convert");
 				JP_RAISE(PyExc_TypeError, "Return value is not compatible with required type.");

--- a/native/common/jp_shorttype.cpp
+++ b/native/common/jp_shorttype.cpp
@@ -246,7 +246,7 @@ void JPShortType::releaseView(JPArrayView& view)
 		JPJavaFrame frame(view.getContext());
 		frame.ReleaseShortArrayElements((jshortArray) view.m_Array->getJava(),
 				(jshort*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException& ex)
+	}	catch (JPypeException&)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_shorttype.cpp
+++ b/native/common/jp_shorttype.cpp
@@ -54,7 +54,7 @@ JPMatch::Type JPShortType::getJavaConversion(JPMatch &match)
 	if (match.object == Py_None)
 		return match.type = JPMatch::_none;
 
-	JPValue* value = PyJPValue_getJavaSlot(match.object);
+	JPValue* value = match.getJavaSlot();
 	if (value != NULL)
 	{
 		JPClass *cls = value->getClass();

--- a/native/common/jp_stringtype.cpp
+++ b/native/common/jp_stringtype.cpp
@@ -52,14 +52,25 @@ JPPyObject JPStringType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
 	JP_TRACE_OUT;
 }
 
-JPMatch::Type JPStringType::getJavaConversion(JPJavaFrame* frame, JPMatch& match, PyObject* pyobj)
+JPMatch::Type JPStringType::getJavaConversion(JPMatch& match)
 {
 	JP_TRACE_IN("JPStringType::getJavaConversion");
-	if (nullConversion->matches(match, frame, this, pyobj) != JPMatch::_none
-			|| objectConversion->matches(match, frame, this, pyobj) != JPMatch::_none
-			|| stringConversion->matches(match, frame, this, pyobj) != JPMatch::_none
+	if (nullConversion->matches(match, this) != JPMatch::_none
+			|| objectConversion->matches(match, this) != JPMatch::_none
+			|| stringConversion->matches(match, this) != JPMatch::_none
 			)
 		return match.type;
+
+	// Apply user supplied conversions
+	if (!m_Hints.isNull())
+	{
+		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
+		if (hints->getConversion(match, this) != JPMatch::_none)
+		{
+			JP_TRACE("Match custom conversion");
+			return match.type;
+		}
+	}
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_stringtype.cpp
+++ b/native/common/jp_stringtype.cpp
@@ -52,7 +52,7 @@ JPPyObject JPStringType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
 	JP_TRACE_OUT;
 }
 
-JPMatch::Type JPStringType::getJavaConversion(JPMatch& match)
+JPMatch::Type JPStringType::findJavaConversion(JPMatch& match)
 {
 	JP_TRACE_IN("JPStringType::getJavaConversion");
 	if (nullConversion->matches(match, this) != JPMatch::_none

--- a/native/common/jp_stringtype.cpp
+++ b/native/common/jp_stringtype.cpp
@@ -55,22 +55,12 @@ JPPyObject JPStringType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
 JPMatch::Type JPStringType::findJavaConversion(JPMatch& match)
 {
 	JP_TRACE_IN("JPStringType::getJavaConversion");
-	if (nullConversion->matches(match, this) != JPMatch::_none
-			|| objectConversion->matches(match, this) != JPMatch::_none
-			|| stringConversion->matches(match, this) != JPMatch::_none
+	if (nullConversion->matches(match, this)
+			|| objectConversion->matches(match, this)
+			|| stringConversion->matches(match, this)
+			|| hintsConversion->matches(match, this)
 			)
 		return match.type;
-
-	// Apply user supplied conversions
-	if (!m_Hints.isNull())
-	{
-		JPClassHints *hints = ((PyJPClassHints*) m_Hints.get())->m_Hints;
-		if (hints->getConversion(match, this) != JPMatch::_none)
-		{
-			JP_TRACE("Match custom conversion");
-			return match.type;
-		}
-	}
 	return match.type = JPMatch::_none;
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_voidtype.cpp
+++ b/native/common/jp_voidtype.cpp
@@ -73,7 +73,7 @@ JPPyObject JPVoidType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
 	return JPPyObject::getNone();
 }
 
-JPMatch::Type JPVoidType::getJavaConversion(JPMatch &match)
+JPMatch::Type JPVoidType::findJavaConversion(JPMatch &match)
 {
 	return match.type = JPMatch::_none;
 }

--- a/native/common/jp_voidtype.cpp
+++ b/native/common/jp_voidtype.cpp
@@ -73,7 +73,7 @@ JPPyObject JPVoidType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
 	return JPPyObject::getNone();
 }
 
-JPMatch::Type JPVoidType::getJavaConversion(JPJavaFrame *frame, JPMatch &match, PyObject *pyobj)
+JPMatch::Type JPVoidType::getJavaConversion(JPMatch &match)
 {
 	return match.type = JPMatch::_none;
 }

--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -76,12 +76,18 @@ public class TypeManager
 
     // Create the required minimum classes
     this.java_lang_Object = createClass(Object.class, true);
+
+    // Note that order is very important when creating these initial wrapper
+    // types. If something inherits from another type then the super class
+    // will be created without the special flag and the type system won't
+    // be able to handle the duplicate type properly.
     Class[] cls =
     {
-      Class.class, Void.class, Boolean.class, Byte.class, Character.class,
+      Class.class, Number.class, CharSequence.class, Throwable.class,
+      Void.class, Boolean.class, Byte.class, Character.class,
       Short.class, Integer.class, Long.class, Float.class, Double.class,
-      String.class, CharSequence.class, JPypeProxy.class, Method.class,
-      Field.class, Throwable.class, Number.class
+      String.class, JPypeProxy.class,
+      Method.class, Field.class
     };
     for (Class c : cls)
     {

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -10,12 +10,7 @@ static void assertValid(PyObject *obj)
 	if (obj->ob_refcnt >= 1)
 		return;
 
-	// This condition can only be triggered by a fatal error in
-	// the reference management system which will result in some
-	// other fatal error later as we have incorrectly registered
-	// a deleted object with Python which most certainly will crash
-	// it at some point.
-#ifndef JP_INSTRUMENTATION
+	// GCOVR_EXCL_START
 	// At this point our car has traveled beyond the end of the
 	// cliff and it will hit the ground some twenty
 	// python calls later with a nearly untracable fault, thus
@@ -23,7 +18,7 @@ static void assertValid(PyObject *obj)
 	// a noble death here.
 	JP_TRACE_PY("pyref FAULT", obj);
 	JP_RAISE(PyExc_SystemError, "Deleted reference");
-#endif
+	// GCOVR_EXCL_STOP
 }
 
 JPPyObject::JPPyObject(JPPyRef::Type usage, PyObject* obj)

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -495,7 +495,7 @@ static PyObject *PyJPClass_canConvertToJava(PyJPClass *self, PyObject *other)
 
 	// Test the conversion
 	JPMatch match(&frame, other);
-	cls->getJavaConversion(match);
+	cls->findJavaConversion(match);
 
 	// Report to user
 	if (match.type == JPMatch::_none)
@@ -524,7 +524,7 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 	if ( val == NULL || val->getClass()->isPrimitive())
 	{
 		JPMatch match(&frame, other);
-		type->getJavaConversion(match);
+		type->findJavaConversion(match);
 		// Otherwise, see if we can convert it
 		if (match.type == JPMatch::_none)
 		{
@@ -535,7 +535,7 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 					);
 			return NULL;
 		}
-		jvalue v = match.conversion->convert(&frame, type, other);
+		jvalue v = match.convert();
 		return PyJPValue_create(frame, JPValue(type, v)).keep();
 	}
 
@@ -589,7 +589,7 @@ static PyObject *PyJPClass_convertToJava(PyJPClass *self, PyObject *other)
 
 	// Test the conversion
 	JPMatch match(&frame, other);
-	cls->getJavaConversion(match);
+	cls->findJavaConversion(match);
 
 	// If there is no conversion report a failure
 	if (match.type == JPMatch::_none)
@@ -599,7 +599,7 @@ static PyObject *PyJPClass_convertToJava(PyJPClass *self, PyObject *other)
 	}
 
 	// Otherwise give back a PyJPValue
-	jvalue v = match.conversion->convert(&frame, cls, other);
+	jvalue v = match.convert();
 	return PyJPValue_create(frame, JPValue(cls, v)).keep();
 	JP_PY_CATCH(NULL);
 }

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -58,6 +58,9 @@ PyObject *PyJPClass_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 		return NULL;
 	}
 
+	// GCOVR_EXCL_START
+	// This sanity check is trigger if the user attempts to build their own
+	// type wrapper with a __del__ method defined.  It is hard to trigger.
 	if (typenew->tp_alloc != (allocfunc) PyJPValue_alloc
 			&& typenew->tp_alloc != PyBaseObject_Type.tp_alloc)
 	{
@@ -65,6 +68,7 @@ PyObject *PyJPClass_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 		PyErr_SetString(PyExc_TypeError, "alloc conflict");
 		return NULL;
 	}
+	// GCOVR_EXCL_STOP
 
 	typenew->tp_alloc = (allocfunc) PyJPValue_alloc;
 	typenew->tp_finalize = (destructor) PyJPValue_finalize;
@@ -118,14 +122,8 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 	{
 		switch (slot->slot)
 		{
-			case Py_tp_finalize:
-				type->tp_finalize = (destructor) slot->pfunc;
-				break;
 			case Py_tp_free:
 				type->tp_free = (freefunc) slot->pfunc;
-				break;
-			case Py_tp_alloc:
-				type->tp_alloc = (allocfunc) slot->pfunc;
 				break;
 			case Py_tp_new:
 				type->tp_new = (newfunc) slot->pfunc;
@@ -151,9 +149,6 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 			case Py_tp_methods:
 				type->tp_methods = (PyMethodDef*) slot->pfunc;
 				break;
-			case  Py_sq_ass_item:
-				heap->as_sequence.sq_ass_item = (ssizeobjargproc) slot->pfunc;
-				break;
 			case Py_sq_item:
 				heap->as_sequence.sq_item = (ssizeargfunc) slot->pfunc;
 				break;
@@ -175,16 +170,18 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 			case Py_tp_richcompare:
 				type->tp_richcompare = (richcmpfunc) slot->pfunc;
 				break;
+				// GCOVR_EXCL_START
 			default:
 				PyErr_Format(PyExc_TypeError, "slot %d not implemented", slot->slot);
 				JP_RAISE_PYTHON();
+				// GCOVR_EXCL_STOP
 		}
 	}
 	PyType_Ready(type);
 	//heap->ht_cached_keys = _PyDict_NewKeysForClass();
 	PyDict_SetItemString(type->tp_dict, "__module__", PyUnicode_FromString("_jpype"));
 	return (PyObject*) type;
-	JP_PY_CATCH(NULL);
+	JP_PY_CATCH(NULL); // GCOVR_EXCL_LINE
 }
 
 int PyJPClass_init(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -212,7 +209,7 @@ int PyJPClass_init(PyObject *self, PyObject *args, PyObject *kwargs)
 	// Call the type init
 	int rc = PyType_Type.tp_init(self, args, kwargs);
 	if (rc == -1)
-		return rc;
+		return rc; // GCOVR_EXCL_LINE no clue how to trigger this one
 
 	return rc;
 	JP_PY_CATCH(-1);
@@ -357,12 +354,16 @@ PyObject* PyJPClass_subclasscheck(PyTypeObject *type, PyTypeObject *test)
 	if (test == type)
 		Py_RETURN_TRUE;
 
+	// GCOVR_EXCL_START
+	// This is triggered only if the user asks for isInstance when the
+	// JVM is shutdown. It should not happen in normal operations.
 	if (!JPContext_global->isRunning())
 	{
 		if ((PyObject*) type == _JObject)
 			return PyBool_FromLong(Py_IsSubClassSingle(PyJPObject_Type, test));
 		return PyBool_FromLong(Py_IsSubClassSingle(type, test));
 	}
+	// GCOVR_EXCL_STOP
 
 	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame(context);
@@ -443,7 +444,7 @@ static PyObject *PyJPClass_hints(PyObject *self, PyObject *closure)
 	PyJPClass *cls = (PyJPClass*) self;
 	PyObject *hints = cls->m_Class->getHints();
 	if (hints == NULL)
-		Py_RETURN_NONE;
+		Py_RETURN_NONE; // GCOVR_EXCL_LINE only triggered if JClassPost failed
 	Py_INCREF(hints);
 	return hints;
 	JP_PY_CATCH(NULL);
@@ -508,7 +509,7 @@ static PyObject *PyJPClass_canConvertToJava(PyJPClass *self, PyObject *other)
 		return JPPyString::fromStringUTF8("exact").keep();
 
 	// Not sure how this could happen
-	Py_RETURN_NONE;
+	Py_RETURN_NONE; // GCOVR_EXCL_NONE
 	JP_PY_CATCH(NULL);
 }
 
@@ -684,9 +685,9 @@ JPClass* PyJPClass_getJPClass(PyObject* obj)
 			return NULL;
 		JPJavaFrame frame(cls->getContext());
 		return frame.findClass((jclass) javaSlot->getJavaObject());
-	}	catch (...)
+	}	catch (...) // GCOVR_EXCL_LINE
 	{
-		return NULL;
+		return NULL; // GCOVR_EXCL_LINE
 	}
 }
 

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -494,8 +494,8 @@ static PyObject *PyJPClass_canConvertToJava(PyJPClass *self, PyObject *other)
 	JPClass *cls = self->m_Class;
 
 	// Test the conversion
-	JPMatch match;
-	cls->getJavaConversion(&frame, match, other);
+	JPMatch match(&frame, other);
+	cls->getJavaConversion(match);
 
 	// Report to user
 	if (match.type == JPMatch::_none)
@@ -523,8 +523,8 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 	// Cast on non-Java
 	if ( val == NULL || val->getClass()->isPrimitive())
 	{
-		JPMatch match;
-		type->getJavaConversion(&frame, match, other);
+		JPMatch match(&frame, other);
+		type->getJavaConversion(match);
 		// Otherwise, see if we can convert it
 		if (match.type == JPMatch::_none)
 		{
@@ -588,8 +588,8 @@ static PyObject *PyJPClass_convertToJava(PyJPClass *self, PyObject *other)
 	JPClass *cls = self->m_Class;
 
 	// Test the conversion
-	JPMatch match;
-	cls->getJavaConversion(&frame, match, other);
+	JPMatch match(&frame, other);
+	cls->getJavaConversion(match);
 
 	// If there is no conversion report a failure
 	if (match.type == JPMatch::_none)

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -47,8 +47,8 @@ static PyObject *PyJPNumber_new(PyTypeObject *type, PyObject *args, PyObject *kw
 	if (PyTuple_Size(args) == 1)
 	{
 		PyObject *arg = PyTuple_GetItem(args, 0);
-		JPMatch match;
-		cls->getJavaConversion(&frame, match, arg);
+		JPMatch match(&frame, arg);
+		cls->getJavaConversion(match);
 		if (match.type >= JPMatch::_implicit)
 		{
 			val = match.conversion->convert(&frame, cls, arg);
@@ -72,8 +72,8 @@ static PyObject *PyJPNumber_new(PyTypeObject *type, PyObject *args, PyObject *kw
 
 	if (!converted)
 	{
-		JPMatch match;
-		cls->getJavaConversion(&frame, match, self);
+		JPMatch match(&frame, self);
+		cls->getJavaConversion(match);
 		val = match.conversion->convert(&frame, cls, self);
 	}
 	PyJPValue_assignJavaSlot(frame, self, JPValue(cls, val));
@@ -273,8 +273,8 @@ static PyObject *PyJPChar_new(PyTypeObject *type, PyObject *args, PyObject *kwar
 	JPClass *cls = PyJPClass_getJPClass((PyObject*) type);
 	if (cls == NULL)
 		JP_RAISE(PyExc_TypeError, "Class type incorrect");
-	JPMatch match;
-	cls->getJavaConversion(&frame, match, self);
+	JPMatch match(&frame, self);
+	cls->getJavaConversion(match);
 	jvalue val = match.conversion->convert(&frame, cls, self);
 	PyJPValue_assignJavaSlot(frame, self, JPValue(cls, val));
 	JP_TRACE("new", self);

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -48,10 +48,10 @@ static PyObject *PyJPNumber_new(PyTypeObject *type, PyObject *args, PyObject *kw
 	{
 		PyObject *arg = PyTuple_GetItem(args, 0);
 		JPMatch match(&frame, arg);
-		cls->getJavaConversion(match);
+		cls->findJavaConversion(match);
 		if (match.type >= JPMatch::_implicit)
 		{
-			val = match.conversion->convert(&frame, cls, arg);
+			val = match.convert();
 			converted = true;
 		}
 	}
@@ -73,8 +73,8 @@ static PyObject *PyJPNumber_new(PyTypeObject *type, PyObject *args, PyObject *kw
 	if (!converted)
 	{
 		JPMatch match(&frame, self);
-		cls->getJavaConversion(match);
-		val = match.conversion->convert(&frame, cls, self);
+		cls->findJavaConversion(match);
+		val = match.convert();
 	}
 	PyJPValue_assignJavaSlot(frame, self, JPValue(cls, val));
 
@@ -274,8 +274,8 @@ static PyObject *PyJPChar_new(PyTypeObject *type, PyObject *args, PyObject *kwar
 	if (cls == NULL)
 		JP_RAISE(PyExc_TypeError, "Class type incorrect");
 	JPMatch match(&frame, self);
-	cls->getJavaConversion(match);
-	jvalue val = match.conversion->convert(&frame, cls, self);
+	cls->findJavaConversion(match);
+	jvalue val = match.convert();
 	PyJPValue_assignJavaSlot(frame, self, JPValue(cls, val));
 	JP_TRACE("new", self);
 	return self;

--- a/project/jpype_cpython/nbproject/configurations.xml
+++ b/project/jpype_cpython/nbproject/configurations.xml
@@ -71,6 +71,7 @@
         <itemPath>../../native/common/jp_class.cpp</itemPath>
         <itemPath>../../native/common/jp_classhints.cpp</itemPath>
         <itemPath>../../native/common/jp_classloader.cpp</itemPath>
+        <itemPath>../../native/common/jp_classtype.cpp</itemPath>
         <itemPath>../../native/common/jp_context.cpp</itemPath>
         <itemPath>../../native/common/jp_convert.cpp</itemPath>
         <itemPath>../../native/common/jp_doubletype.cpp</itemPath>
@@ -390,6 +391,11 @@
             flavor2="0">
       </item>
       <item path="../../native/common/jp_classloader.cpp"
+            ex="false"
+            tool="1"
+            flavor2="0">
+      </item>
+      <item path="../../native/common/jp_classtype.cpp"
             ex="false"
             tool="1"
             flavor2="0">

--- a/test/harness/jpype/common/Fixture.java
+++ b/test/harness/jpype/common/Fixture.java
@@ -123,4 +123,8 @@ public class Fixture {
 
 	public static Number callNumber(Number n) { return n; }
 	public Object callSupplier(java.util.function.Supplier s) { return s.get(); }
+
+	public Object callCharArray(char[] c) { return c; }
+	public Object callByteArray(byte[] c) { return c; }
+	public Object callClass(Class c) { return c; }
 }

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -479,6 +479,7 @@ class ArrayTestCase(common.JPypeTestCase):
     def testArrayOfDoubleCast(self):
         self.checkArrayOfCast(JDouble, np.float64)
 
+    @common.requireNumpy
     def testArrayOfExc(self):
         a = np.random.randint(0, 2*8-1, size=1, dtype=np.uint8)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
This pull require is the ground work for further improvements in the type system.  In particular, we need to be able to control when a match requires checking and when it does not.  The current system with just a function and no communication between the caller and conversion other than through the argument list does not support that.  

This pull request is completely under the hood, but is a prerequisite for a lot minor improvements, and once merged will allow all the rest of the PRs to be reviewed cleanly.

- Fixes a nasty bug with the order that special C++ wrappers were created that was causing duplicates for Number and CharSequence
- Adds a closure and slot cache for match so that type lookups only occur once per conversion with time saving when matching against overloads.
- Corrects warnings from Visual studio.
- Renamed getJavaConversion to findJavaConversion and removed all of the arguments in place of the single match structure.  This was both a style and performance change.  Passing a huge list of arguments over and over was both repetitive and a waste of CPU.  Thus now everything is stored in match and the function was renamed to better represent the function.  It should look a lot cleaner.

