### PR TITLE
Shutdown bug

### DIFF
--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -271,7 +271,14 @@ static int PyJPArray_assignSubscript(PyJPArray *self, PyObject *item, PyObject *
 static void PyJPArray_releaseBuffer(PyJPArray *self, Py_buffer *view)
 {
 	JP_PY_TRY("PyJPArrayPrimitive_releaseBuffer");
-	JPContext *context = PyJPModule_getContext();
+	JPContext* context = JPContext_global;
+	if (!context->isRunning())
+	{
+		delete self->m_View;
+		self->m_View = NULL;
+		return;
+	}
+	//	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame(context);
 	if (self->m_View == NULL || !self->m_View->unreference())
 		return;

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -140,10 +140,12 @@ void PyJPValue_finalize(void* obj)
 	JPValue* value = PyJPValue_getJavaSlot((PyObject*) obj);
 	if (value == NULL)
 		return;
+	JPContext *context = JPContext_global;
+	if (context == NULL || !context->isRunning())
+		return;
 	JPClass* cls = value->getClass();
 	// This one can't check for initialized because we may need to delete a stale
 	// resource after shutdown.
-	JPContext *context = PyJPModule_getContext();
 	if (cls != NULL && context->isRunning() && !cls->isPrimitive())
 	{
 		JP_TRACE("Value", cls->getCanonicalName(), &(value->getValue()));


### PR DESCRIPTION
This prevents an exception from being issued with ReleaseBuffer or freeing of resource left over after the JVM is shutdown.  There may be other bugs like this found.

This is built on #624

Fixes #625 
