### PR TITLE
Improved support for proxies

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -31,6 +31,15 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
     with the same size automatically.  Architecture dependent numpy
     types map to Long or Double.
 
+  - Proxies created with JImplements properly implement toString, hashCode,
+    and equals.
+
+  - JProxy.unwrap() will return the original instance object for proxies
+    created with JProxy.  Otherwise will return the proxy.
+
+  - JProxy instances created with the convert=True argument will automatic
+    unwrap when passed from Java to Python. 
+
 - **0.7.2 - 2-28-2019**
 
   - C++ and Java exceptions hold the traceback as a Python exception

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -167,7 +167,7 @@ class JProxy(_jpype._JProxy):
         inst (object, optional): specifies an object with methods
             whose names matches the java interfaces methods.
     """
-    def __new__(cls, intf, dict=None, inst=None):
+    def __new__(cls, intf, dict=None, inst=None, convert=False):
         # Convert the interfaces
         actualIntf = _convertInterfaces([intf])
 
@@ -176,9 +176,15 @@ class JProxy(_jpype._JProxy):
             raise TypeError("Specify only one of dict and inst")
 
         if dict is not None:
-            return _jpype._JProxy(_JFromDict(dict), actualIntf)
+            return _jpype._JProxy(_JFromDict(dict), actualIntf, convert)
 
         if inst is not None:
-            return _jpype._JProxy.__new__(cls, inst, actualIntf)
+            return _jpype._JProxy.__new__(cls, inst, actualIntf, convert)
 
         raise TypeError("a dict or inst must be specified")
+
+    @staticmethod
+    def unwrap(obj):
+        if not isinstance(obj, _jpype._JProxy):
+            return obj
+        return obj.__javainst__

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -265,8 +265,10 @@ JPPyObject JPProxyType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
 	JP_TRACE_IN("JPProxyType::convertToPythonObject");
 	jobject ih = frame.CallStaticObjectMethodA(m_ProxyClass.get(),
 			m_GetInvocationHandlerID, &val);
-	PyObject *target = (PyObject*) frame.GetLongField(ih, m_InstanceID);
+	PyJPProxy *target = (PyJPProxy*) frame.GetLongField(ih, m_InstanceID);
+	if (target->m_Target != Py_None && target->m_Convert)
+		return JPPyObject(JPPyRef::_use, target->m_Target);
 	JP_TRACE("Target", target);
-	return JPPyObject(JPPyRef::_use, target);
+	return JPPyObject(JPPyRef::_use, (PyObject*) target);
 	JP_TRACE_OUT;
 }

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -94,6 +94,7 @@ struct PyJPProxy
 	PyObject_HEAD
 	JPProxy* m_Proxy;
 	PyObject* m_Target;
+	bool m_Convert;
 } ;
 
 // JPype types

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -129,7 +129,6 @@ static PyObject *PyJPProxy_toString(PyJPProxy *self)
 
 static PyMethodDef proxyMethods[] = {
 	{"equals", (PyCFunction) (&PyJPProxy_equals), METH_O, ""},
-	{"getClass", (PyCFunction) (&PyJPProxy_class), METH_NOARGS, ""},
 	{"hashCode", (PyCFunction) (&PyJPProxy_hash), METH_NOARGS, ""},
 	{"toString", (PyCFunction) (&PyJPProxy_toString), METH_NOARGS, ""},
 	{NULL},

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -37,7 +37,8 @@ static PyObject *PyJPProxy_new(PyTypeObject *type, PyObject *args, PyObject *kwa
 	// Parse arguments
 	PyObject *target;
 	PyObject *pyintf;
-	if (!PyArg_ParseTuple(args, "OO", &target, &pyintf))
+	int convert = 0;
+	if (!PyArg_ParseTuple(args, "OO|p", &target, &pyintf, &convert))
 		return NULL;
 
 	// Pack interfaces
@@ -60,6 +61,7 @@ static PyObject *PyJPProxy_new(PyTypeObject *type, PyObject *args, PyObject *kwa
 
 	self->m_Proxy = context->getProxyFactory()->newProxy((PyObject*) self, interfaces);
 	self->m_Target = target;
+	self->m_Convert = (convert != 0);
 	Py_INCREF(target);
 
 	JP_TRACE("Proxy", self);
@@ -97,7 +99,44 @@ static PyObject *PyJPProxy_class(PyJPProxy *self, void *context)
 	return PyJPClass_create(frame, cls).keep();
 }
 
+static PyObject *PyJPProxy_inst(PyJPProxy *self, void *context)
+{
+	PyObject *out = self->m_Target;
+	if (out == Py_None)
+		out = (PyObject*) self;
+	Py_INCREF(out);
+	return out;
+}
+
+static PyObject *PyJPProxy_equals(PyJPProxy *self, PyObject *other)
+{
+	return PyObject_RichCompare((PyObject*) self, other, Py_EQ);
+}
+
+static PyObject *PyJPProxy_hash(PyJPProxy *self)
+{
+	if (self->m_Target != Py_None)
+		return PyLong_FromLong((int) PyObject_Hash(self->m_Target));
+	return PyLong_FromLong((int) PyObject_Hash((PyObject*) self));
+}
+
+static PyObject *PyJPProxy_toString(PyJPProxy *self)
+{
+	if (self->m_Target != Py_None)
+		return PyObject_Str(self->m_Target);
+	return PyObject_Str((PyObject*) self);
+}
+
+static PyMethodDef proxyMethods[] = {
+	{"equals", (PyCFunction) (&PyJPProxy_equals), METH_O, ""},
+	{"getClass", (PyCFunction) (&PyJPProxy_class), METH_NOARGS, ""},
+	{"hashCode", (PyCFunction) (&PyJPProxy_hash), METH_NOARGS, ""},
+	{"toString", (PyCFunction) (&PyJPProxy_toString), METH_NOARGS, ""},
+	{NULL},
+};
+
 static PyGetSetDef proxyGetSets[] = {
+	{"__javainst__", (getter) PyJPProxy_inst, NULL, ""},
 	{"__javaclass__", (getter) PyJPProxy_class, NULL, ""},
 	{0}
 };
@@ -108,6 +147,7 @@ static PyType_Slot proxySlots[] = {
 	{ Py_tp_traverse, (void*) PyJPProxy_traverse},
 	{ Py_tp_clear,    (void*) PyJPProxy_clear},
 	{ Py_tp_getset,   (void*) proxyGetSets},
+	{ Py_tp_methods,  (void*) proxyMethods},
 	{0}
 };
 
@@ -149,7 +189,12 @@ JPPyObject PyJPProxy_getCallable(PyObject *obj, const string& name)
 		JP_RAISE(PyExc_SystemError, "Incorrect type passed to proxy lookup");  // GCOVR_EXCL_LINE
 	PyJPProxy *proxy = (PyJPProxy*) obj;
 	if (proxy->m_Target != Py_None)
-		obj = proxy->m_Target;
+	{
+		// Attempt to use the pointed to object if available
+		JPPyObject ret = JPPyObject(JPPyRef::_accept, PyObject_GetAttrString(proxy->m_Target, name.c_str()));
+		if (!ret.isNull())
+			return ret;
+	}
 	return JPPyObject(JPPyRef::_accept, PyObject_GetAttrString(obj, name.c_str()));
 	JP_TRACE_OUT;
 }

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -402,20 +402,21 @@ class ProxyTestCase(common.JPypeTestCase):
 
     def testConvert(self):
         fixture = JClass("jpype.common.Fixture")()
+
         class R(object):
             pass
         r = R()
         # Verify with not asked to auto convert it doesn't
         s = JProxy("java.io.Serializable", inst=r)
         s2 = fixture.callObject(s)
-        self.assertEqual( s2, s)
-        self.assertNotEqual( s2, r)
+        self.assertEqual(s2, s)
+        self.assertNotEqual(s2, r)
 
         # Verify that when asked to auto convert it does
         s = JProxy("java.io.Serializable", inst=r, convert=True)
         s2 = fixture.callObject(s)
-        self.assertNotEqual( s2, s)
-        self.assertEqual( s2, r)
+        self.assertNotEqual(s2, s)
+        self.assertEqual(s2, r)
 
     def testMethods(self):
         fixture = JClass("jpype.common.Fixture")()
@@ -432,6 +433,7 @@ class ProxyTestCase(common.JPypeTestCase):
 
     def testMethods2(self):
         fixture = JClass("jpype.common.Fixture")()
+
         class R(object):
             pass
         r = JProxy("java.io.Serializable", inst=R())
@@ -441,13 +443,3 @@ class ProxyTestCase(common.JPypeTestCase):
         self.assertIsInstance(s.getClass(), java.lang.Class)
         self.assertIsInstance(s.toString(), java.lang.String)
         self.assertIsInstance(s.hashCode(), int)
-
-       
-
-
-
-        
-
-
-
-        

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -380,3 +380,74 @@ class ProxyTestCase(common.JPypeTestCase):
             java.util.Arrays.sort(arr, TooManyParams())
         with self.assertRaises(TypeError):
             java.util.Arrays.sort(arr, TooFewParams())
+
+    def testUnwrap(self):
+        fixture = JClass("jpype.common.Fixture")()
+        @JImplements("java.io.Serializable")
+        class Q(object):
+            pass
+
+        q = Q()
+        self.assertEqual(JProxy.unwrap(q), q)
+        q2 = fixture.callObject(q)
+        self.assertEqual(JProxy.unwrap(q2), q)
+
+        class R(object):
+            pass
+        r = R()
+        s = JProxy("java.io.Serializable", inst=r)
+        self.assertEqual(JProxy.unwrap(s), r)
+        s2 = fixture.callObject(s)
+        self.assertEqual(JProxy.unwrap(s2), r)
+
+    def testConvert(self):
+        fixture = JClass("jpype.common.Fixture")()
+        class R(object):
+            pass
+        r = R()
+        # Verify with not asked to auto convert it doesn't
+        s = JProxy("java.io.Serializable", inst=r)
+        s2 = fixture.callObject(s)
+        self.assertEqual( s2, s)
+        self.assertNotEqual( s2, r)
+
+        # Verify that when asked to auto convert it does
+        s = JProxy("java.io.Serializable", inst=r, convert=True)
+        s2 = fixture.callObject(s)
+        self.assertNotEqual( s2, s)
+        self.assertEqual( s2, r)
+
+    def testMethods(self):
+        fixture = JClass("jpype.common.Fixture")()
+        @JImplements("java.io.Serializable")
+        class R(object):
+            pass
+        r = R()
+        s = JObject(r)
+        # Check if Java will be able to work with this object safely
+        self.assertTrue(s.equals(s))
+        self.assertIsInstance(s.getClass(), java.lang.Class)
+        self.assertIsInstance(s.toString(), java.lang.String)
+        self.assertIsInstance(s.hashCode(), int)
+
+    def testMethods2(self):
+        fixture = JClass("jpype.common.Fixture")()
+        class R(object):
+            pass
+        r = JProxy("java.io.Serializable", inst=R())
+        s = JObject(r)
+        # Check if Java will be able to work with this object safely
+        self.assertTrue(s.equals(s))
+        self.assertIsInstance(s.getClass(), java.lang.Class)
+        self.assertIsInstance(s.toString(), java.lang.String)
+        self.assertIsInstance(s.hashCode(), int)
+
+       
+
+
+
+        
+
+
+
+        


### PR DESCRIPTION
In tonight's edition, we work on improving support for proxies in JPype.  We have added one keyword argument to JProxy which will automatically unwrap the instance object so that JProxy can be used to transparently pass a Python object wrapped as an interface though Java.  We also add an explicit "unwrap" function to retrieve the object if convert is not specified.

In addition we implement a bunch of required methods for Java.  These can be overridden by the user as needed.

Fixes #631

Test and changelog are included in the path.  Documentation at some later point.
 