### PR TITLE
Explicit cast

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -7,8 +7,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
   - java.util.Map conforms to Python abc.Mapping API.
 
-  - float properly follows Java rules for conversion from double.
-    floats outside of range map to inf and -inf.
+  - JFloat properly follows Java rules for conversion from JDouble.
+    JFloats outside of range map to inf and -inf.
 
   - Add support for direct conversion of multi-dimensional primitive arrays
     with ``JArray.of(array, [dtype=type])``
@@ -24,12 +24,24 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
   - Proxies pass Python exceptions properly rather converting to 
     java.lang.RuntimeException
 
-  - java.lang.Number converts automatically from Python and Java numbers
+  - java.lang.Number converts automatically from Python and Java numbers.
+    Java primitive types will cast to their proper box type when passed
+    to methods and fields taking Number.
 
   - java.lang.Object and java.lang.Number box signed, sized numpy types 
     (int8, int16, int32, int64, float32, float64) to the Java boxed type
     with the same size automatically.  Architecture dependent numpy
-    types map to Long or Double.
+    types map to Long or Double like other Python types.
+
+  - Explicit casting using primitives such as JInt will not produce an
+    OverflowError.  Implicit casting from Python types such as int or float
+    will.
+
+  - Returns for number type primitives will retain their return type 
+    information.  These are derived from Python int and float types
+    thus no change in behavior unless chaining from a Java methods 
+    which is not allowed in Java without a cast.  
+    JBoolean and JChar still produce Python types only.
 
   - Proxies created with JImplements properly implement toString, hashCode,
     and equals.
@@ -39,6 +51,7 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
   - JProxy instances created with the convert=True argument will automatic
     unwrap when passed from Java to Python. 
+
 
 - **0.7.2 - 2-28-2019**
 

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -250,6 +250,18 @@ please file a ticket with the developer.
     _jpype._java_lang_Float = _jpype.JClass("java.lang.Float")
     _jpype._java_lang_Double = _jpype.JClass("java.lang.Double")
 
+    # Bind types
+    _jpype.JString.class_ = _jpype._java_lang_String
+    _jpype.JObject.class_ = _jpype._java_lang_Object
+    _jtypes.JBoolean.class_ = _jpype._java_lang_Boolean.TYPE
+    _jtypes.JByte.class_ = _jpype._java_lang_Byte.TYPE
+    _jtypes.JChar.class_ = _jpype._java_lang_Character.TYPE
+    _jtypes.JShort.class_ = _jpype._java_lang_Short.TYPE
+    _jtypes.JInt.class_ = _jpype._java_lang_Integer.TYPE
+    _jtypes.JLong.class_ = _jpype._java_lang_Long.TYPE
+    _jtypes.JFloat.class_ = _jpype._java_lang_Float.TYPE
+    _jtypes.JDouble.class_ = _jpype._java_lang_Double.TYPE
+
     # Table for automatic conversion to objects "JObject(value, type)"
     _jpype._object_classes = {}
     _jpype._object_classes[bool] = _jpype._java_lang_Boolean
@@ -282,18 +294,6 @@ please file a ticket with the developer.
     _jpype._type_classes[_jpype.JString] = _jpype._java_lang_String
     _jpype._type_classes[_jpype.JObject] = _jpype._java_lang_Object
     _jinit.runJVMInitializers()
-
-    # Bind types
-    _jpype.JString.class_ = _jpype._java_lang_String
-    _jpype.JObject.class_ = _jpype._java_lang_Object
-    _jtypes.JBoolean.class_ = _jpype._java_lang_Boolean.TYPE
-    _jtypes.JByte.class_ = _jpype._java_lang_Byte.TYPE
-    _jtypes.JChar.class_ = _jpype._java_lang_Character.TYPE
-    _jtypes.JShort.class_ = _jpype._java_lang_Short.TYPE
-    _jtypes.JInt.class_ = _jpype._java_lang_Integer.TYPE
-    _jtypes.JLong.class_ = _jpype._java_lang_Long.TYPE
-    _jtypes.JFloat.class_ = _jpype._java_lang_Float.TYPE
-    _jtypes.JDouble.class_ = _jpype._java_lang_Double.TYPE
 
 
 def attachToJVM(jvm):

--- a/native/common/include/jp_arrayclass.h
+++ b/native/common/include/jp_arrayclass.h
@@ -31,7 +31,7 @@ public:
 			jint modifiers);
 	virtual~ JPArrayClass();
 
-	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	virtual JPMatch::Type findJavaConversion(JPMatch &match);
 
 	JPValue newInstance(JPJavaFrame& frame, int length);

--- a/native/common/include/jp_booleantype.h
+++ b/native/common/include/jp_booleantype.h
@@ -43,7 +43,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch& match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_boxedtype.h
+++ b/native/common/include/jp_boxedtype.h
@@ -47,6 +47,7 @@ public:
 	}
 
 	jobject box(JPJavaFrame &frame, jvalue v);
+	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 
 protected:
 	JPPrimitiveType* m_PrimitiveType;

--- a/native/common/include/jp_bytetype.h
+++ b/native/common/include/jp_bytetype.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_chartype.h
+++ b/native/common/include/jp_chartype.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_class.h
+++ b/native/common/include/jp_class.h
@@ -37,9 +37,9 @@ public:
 		m_Host = JPPyObject(JPPyRef::_use, host);
 	}
 
-	PyObject* getHost()
+	PyTypeObject* getHost()
 	{
-		return m_Host.get();
+		return (PyTypeObject*) m_Host.get();
 	}
 
 	void setHints(PyObject* host)
@@ -132,9 +132,15 @@ public:
 
 	/** Create a new Python object to wrap a Java value.
 	 *
+	 * Some conversion convert to a Python type such as Java boolean and char.
+	 * Null pointers match to Python None.  Objects convert automatically to
+	 * the most derived type. To disable this behavior the cast option can be
+	 * specified.
+	 *
+	 * @param cast force the wrapper to be the defined type.
 	 * @return a new Python object.
 	 */
-	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val);
+	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast);
 
 	/**
 	 * Get the Java value representing as an object.

--- a/native/common/include/jp_doubletype.h
+++ b/native/common/include/jp_doubletype.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame &frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_floattype.h
+++ b/native/common/include/jp_floattype.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_inttype.h
+++ b/native/common/include/jp_inttype.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch& match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_longtype.h
+++ b/native/common/include/jp_longtype.h
@@ -43,7 +43,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch& match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -182,7 +182,7 @@ public:
 } ;
 
 template <typename base_t>
-class JPConversionLongNumber : public JPConversion
+class JPConversionLongNumber : public JPConversionLong<base_t>
 {
 public:
 
@@ -196,18 +196,9 @@ public:
 
 	virtual jvalue convert(JPMatch &match) override
 	{
-		jvalue res;
-		PyObject *obj = PyNumber_Long(match.object);
-		JP_PY_CHECK();
-		jlong val = PyLong_AsLongLong(obj);
-		Py_DECREF(obj);
-		if (val == -1)
-			JP_PY_CHECK();
-		if (match.type == JPMatch::_exact)
-			base_t::field(res) = (typename base_t::type_t) val;
-		else
-			base_t::field(res) = (typename base_t::type_t) base_t::assertRange(val);
-		return res;
+		JPPyObject obj = JPPyObject(JPPyRef::_call, PyNumber_Long(match.object));
+		match.object = obj.get();
+		return JPConversionLong<base_t>::convert(match);
 	}
 } ;
 

--- a/native/common/include/jp_primitivetype.h
+++ b/native/common/include/jp_primitivetype.h
@@ -48,6 +48,9 @@ public:
 
 	virtual PyObject *newMultiArray(JPJavaFrame &frame,
 			JPPyBuffer& view, int subs, int base, jobject dims) = 0;
+
+	// Helper for Long types
+	PyObject *convertLong(PyTypeObject* wrapper, PyLongObject* tmp);
 } ;
 
 #endif

--- a/native/common/include/jp_proxy.h
+++ b/native/common/include/jp_proxy.h
@@ -74,7 +74,7 @@ public:
 	virtual~ JPProxyType();
 
 public: // JPClass implementation
-	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 
 private:
 	JPClassRef m_ProxyClass;

--- a/native/common/include/jp_shorttype.h
+++ b/native/common/include/jp_shorttype.h
@@ -43,7 +43,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	virtual JPValue     getValueFromObject(const JPValue& obj) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;

--- a/native/common/include/jp_stringtype.h
+++ b/native/common/include/jp_stringtype.h
@@ -30,7 +30,7 @@ public:
 	virtual ~JPStringType();
 
 public:
-	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 	JPMatch::Type findJavaConversion(JPMatch& match) override;
 	virtual JPValue newInstance(JPJavaFrame& frame, JPPyObjectVector& args) override;
 } ;

--- a/native/common/include/jp_voidtype.h
+++ b/native/common/include/jp_voidtype.h
@@ -30,7 +30,7 @@ public:
 	}
 
 	virtual JPMatch::Type findJavaConversion(JPMatch &match) override;
-	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val) override;
+	virtual JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
 
 	virtual JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	virtual JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -50,10 +50,18 @@ JPMatch::Type JPArrayClass::findJavaConversion(JPMatch &match)
 	JP_TRACE_OUT;
 }
 
-JPPyObject JPArrayClass::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPArrayClass::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool cast)
 {
 	JP_TRACE_IN("JPArrayClass::convertToPythonObject");
-	return PyJPValue_create(frame, JPValue(this, val));
+	if (!cast)
+	{
+		if (value.l == NULL)
+			return JPPyObject::getNone();
+	}
+	JPPyObject wrapper = PyJPClass_create(frame, this);
+	JPPyObject obj = PyJPArray_create(frame, (PyTypeObject*) wrapper.get(), JPValue(this, value));
+	PyJPValue_assignJavaSlot(frame, obj.get(), JPValue(this, value));
+	return obj;
 	JP_TRACE_OUT;
 }
 

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -28,7 +28,7 @@ JPBooleanType::~JPBooleanType()
 {
 }
 
-JPPyObject JPBooleanType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPBooleanType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
 	return JPPyObject(JPPyRef::_call, PyBool_FromLong(val.z));
 }
@@ -113,14 +113,14 @@ JPPyObject JPBooleanType::getStaticField(JPJavaFrame& frame, jclass c, jfieldID 
 {
 	jvalue v;
 	field(v) = frame.GetStaticBooleanField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPBooleanType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 {
 	jvalue v;
 	field(v) = frame.GetBooleanField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPBooleanType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue* val)
@@ -130,7 +130,7 @@ JPPyObject JPBooleanType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodI
 		JPPyCallRelease call;
 		field(v) = frame.CallStaticBooleanMethodA(claz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPBooleanType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jmethodID mth, jvalue* val)
@@ -143,7 +143,7 @@ JPPyObject JPBooleanType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, 
 		else
 			field(v) = frame.CallNonvirtualBooleanMethodA(obj, clazz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPBooleanType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
@@ -227,7 +227,7 @@ JPPyObject JPBooleanType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 	frame.GetBooleanArrayRegion(array, ndx, 1, &val);
 	jvalue v;
 	field(v) = val;
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPBooleanType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -28,9 +28,12 @@ JPByteType::~JPByteType()
 {
 }
 
-JPPyObject JPByteType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPByteType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
-	return JPPyObject(JPPyRef::_call, PyLong_FromLong(field(val)));
+	JPPyObject tmp = JPPyObject(JPPyRef::_call, PyLong_FromLong(field(val)));
+	JPPyObject out = JPPyObject(JPPyRef::_call, convertLong(getHost(), (PyLongObject*) tmp.get()));
+	PyJPValue_assignJavaSlot(frame, out.get(), JPValue(this, val));
+	return out;
 }
 
 JPValue JPByteType::getValueFromObject(const JPValue& obj)
@@ -81,14 +84,14 @@ JPPyObject JPByteType::getStaticField(JPJavaFrame& frame, jclass c, jfieldID fid
 {
 	jvalue v;
 	field(v) = frame.GetStaticByteField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPByteType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 {
 	jvalue v;
 	field(v) = frame.GetByteField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPByteType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue* val)
@@ -98,7 +101,7 @@ JPPyObject JPByteType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID m
 		JPPyCallRelease call;
 		field(v) = frame.CallStaticByteMethodA(claz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPByteType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jmethodID mth, jvalue* val)
@@ -111,7 +114,7 @@ JPPyObject JPByteType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 		else
 			field(v) = frame.CallNonvirtualByteMethodA(obj, clazz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPByteType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
@@ -194,7 +197,7 @@ JPPyObject JPByteType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 	frame.GetByteArrayRegion(array, ndx, 1, &val);
 	jvalue v;
 	field(v) = val;
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPByteType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -28,9 +28,16 @@ JPCharType::~JPCharType()
 {
 }
 
-JPPyObject JPCharType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPCharType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
-	return JPPyString::fromCharUTF16(val.c);
+	if (!cast)
+	{
+		return JPPyString::fromCharUTF16(val.c);
+	}
+	JPPyObject tmp = JPPyObject(JPPyRef::_call, PyLong_FromLong(field(val)));
+	JPPyObject out = JPPyObject(JPPyRef::_call, convertLong(getHost(), (PyLongObject*) tmp.get()));
+	PyJPValue_assignJavaSlot(frame, out.get(), JPValue(this, val));
+	return out;
 }
 
 JPValue JPCharType::getValueFromObject(const JPValue& obj)
@@ -106,14 +113,14 @@ JPPyObject JPCharType::getStaticField(JPJavaFrame& frame, jclass c, jfieldID fid
 {
 	jvalue v;
 	field(v) = frame.GetStaticCharField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPCharType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 {
 	jvalue v;
 	field(v) = frame.GetCharField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPCharType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue* val)
@@ -123,7 +130,7 @@ JPPyObject JPCharType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID m
 		JPPyCallRelease call;
 		field(v) = frame.CallStaticCharMethodA(claz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPCharType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jmethodID mth, jvalue* val)
@@ -136,7 +143,7 @@ JPPyObject JPCharType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 		else
 			field(v) = frame.CallNonvirtualCharMethodA(obj, clazz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPCharType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
@@ -186,7 +193,7 @@ JPPyObject JPCharType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 	frame.GetCharArrayRegion(array, ndx, 1, &val);
 	jvalue v;
 	field(v) = val;
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPCharType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -55,6 +55,7 @@ JPypeException::JPypeException(int type, void* errType, const string& msn, const
 
 // GCOVR_EXCL_START
 // This is only used during startup for OSError
+
 JPypeException::JPypeException(int type,  const string& msn, int errType, const JPStackInfo& stackInfo)
 {
 	JP_TRACE("EXCEPTION THROWN", errType, msn);
@@ -183,7 +184,7 @@ void JPypeException::convertJavaToPython()
 
 	// Create the exception object (this may fail)
 	v.l = th;
-	JPPyObject pyvalue = PyJPValue_create(frame, JPValue(cls, v));
+	JPPyObject pyvalue = cls->convertToPythonObject(frame, v, false);
 
 	// GCOVR_EXCL_START
 	// This sanity check can only be hit if the exception failed during

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -28,9 +28,13 @@ JPFloatType::~JPFloatType()
 {
 }
 
-JPPyObject JPFloatType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPFloatType::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool cast)
 {
-	return JPPyObject(JPPyRef::_call, PyFloat_FromDouble(field(val)));
+	PyTypeObject * wrapper = getHost();
+	JPPyObject obj = JPPyObject(JPPyRef::_call, wrapper->tp_alloc(wrapper, 0));
+	((PyFloatObject*) obj.get())->ob_fval = value.f;
+	PyJPValue_assignJavaSlot(frame, obj.get(), JPValue(this, value));
+	return obj;
 }
 
 JPValue JPFloatType::getValueFromObject(const JPValue& obj)
@@ -107,14 +111,14 @@ JPPyObject JPFloatType::getStaticField(JPJavaFrame& frame, jclass c, jfieldID fi
 {
 	jvalue v;
 	field(v) = frame.GetStaticFloatField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPFloatType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 {
 	jvalue v;
 	field(v) = frame.GetFloatField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPFloatType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue *val)
@@ -124,7 +128,7 @@ JPPyObject JPFloatType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID 
 		JPPyCallRelease call;
 		field(v) = frame.CallStaticFloatMethodA(claz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPFloatType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jmethodID mth, jvalue *val)
@@ -137,7 +141,7 @@ JPPyObject JPFloatType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jm
 		else
 			field(v) = frame.CallNonvirtualFloatMethodA(obj, clazz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPFloatType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject *obj)
@@ -221,7 +225,7 @@ JPPyObject JPFloatType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 	frame.GetFloatArrayRegion(array, ndx, 1, &val);
 	jvalue v;
 	field(v) = val;
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPFloatType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -28,9 +28,12 @@ JPLongType::~JPLongType()
 {
 }
 
-JPPyObject JPLongType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPLongType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
-	return JPPyObject(JPPyRef::_call, PyLong_FromLongLong(field(val)));
+	JPPyObject tmp = JPPyObject(JPPyRef::_call, PyLong_FromLongLong(field(val)));
+	JPPyObject out = JPPyObject(JPPyRef::_call, convertLong(getHost(), (PyLongObject*) tmp.get()));
+	PyJPValue_assignJavaSlot(frame, out.get(), JPValue(this, val));
+	return out;
 }
 
 JPValue JPLongType::getValueFromObject(const JPValue& obj)
@@ -101,14 +104,14 @@ JPPyObject JPLongType::getStaticField(JPJavaFrame& frame, jclass c, jfieldID fid
 {
 	jvalue v;
 	field(v) = frame.GetStaticLongField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPLongType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 {
 	jvalue v;
 	field(v) = frame.GetLongField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPLongType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue* val)
@@ -118,7 +121,7 @@ JPPyObject JPLongType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID m
 		JPPyCallRelease call;
 		field(v) = frame.CallStaticLongMethodA(claz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPLongType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jmethodID mth, jvalue* val)
@@ -131,7 +134,7 @@ JPPyObject JPLongType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 		else
 			field(v) = frame.CallNonvirtualLongMethodA(obj, clazz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPLongType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
@@ -215,7 +218,7 @@ JPPyObject JPLongType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 	frame.GetLongArrayRegion(array, ndx, 1, &val);
 	jvalue v;
 	field(v) = val;
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPLongType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -309,13 +309,13 @@ JPPyObject JPMethod::invokeCallerSensitive(JPMethodMatch& match, JPPyObjectVecto
 		JP_TRACE("Return primitive");
 		JPClass *boxed = ((JPPrimitiveType*) retType)->getBoxedClass(context);
 		JPValue out = retType->getValueFromObject(JPValue(boxed, o));
-		return retType->convertToPythonObject(frame, out.getValue());
+		return retType->convertToPythonObject(frame, out.getValue(), false);
 	} else
 	{
 		JP_TRACE("Return object");
 		jvalue v;
 		v.l = o;
-		return retType->convertToPythonObject(frame, v);
+		return retType->convertToPythonObject(frame, v, false);
 	}
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_primitivetype.cpp
+++ b/native/common/jp_primitivetype.cpp
@@ -29,3 +29,27 @@ bool JPPrimitiveType::isPrimitive() const
 {
 	return true;
 }
+
+
+// equivalent of long_subtype_new as it isn't exposed
+
+PyObject *JPPrimitiveType::convertLong(PyTypeObject* wrapper, PyLongObject* tmp)
+{
+	if (wrapper == NULL)
+		JP_RAISE(PyExc_SystemError, "bad wrapper");
+	Py_ssize_t n = Py_SIZE(tmp);
+	if (n < 0)
+		n = -n;
+
+	PyLongObject *newobj = (PyLongObject *) wrapper->tp_alloc(wrapper, n);
+	if (newobj == NULL)
+		return NULL;
+
+	((PyVarObject*) newobj)->ob_size = Py_SIZE(tmp);
+	for (Py_ssize_t i = 0; i < n; i++)
+	{
+		newobj->ob_digit[i] = tmp->ob_digit[i];
+	}
+	return (PyObject*) newobj;
+}
+

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -50,7 +50,7 @@ JPPyTuple getArgs(JPContext* context, jlongArray parameterTypePtrs,
 		if (type == NULL)
 			type = reinterpret_cast<JPClass*> (types[i]);
 		JPValue val = type->getValueFromObject(JPValue(type, obj));
-		pyargs.setItem(i, type->convertToPythonObject(frame, val).get());
+		pyargs.setItem(i, type->convertToPythonObject(frame, val, false).get());
 	}
 	return pyargs;
 	JP_TRACE_OUT;
@@ -260,7 +260,7 @@ JPProxyType::~JPProxyType()
 {
 }
 
-JPPyObject JPProxyType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPProxyType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
 	JP_TRACE_IN("JPProxyType::convertToPythonObject");
 	jobject ih = frame.CallStaticObjectMethodA(m_ProxyClass.get(),

--- a/native/common/jp_shorttype.cpp
+++ b/native/common/jp_shorttype.cpp
@@ -28,9 +28,12 @@ JPShortType::~JPShortType()
 {
 }
 
-JPPyObject JPShortType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPShortType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
-	return JPPyObject(JPPyRef::_call, PyLong_FromLong(field(val)));
+	JPPyObject tmp = JPPyObject(JPPyRef::_call, PyLong_FromLong(field(val)));
+	JPPyObject out = JPPyObject(JPPyRef::_call, convertLong(getHost(), (PyLongObject*) tmp.get()));
+	PyJPValue_assignJavaSlot(frame, out.get(), JPValue(this, val));
+	return out;
 }
 
 JPValue JPShortType::getValueFromObject(const JPValue& obj)
@@ -99,14 +102,14 @@ JPPyObject JPShortType::getStaticField(JPJavaFrame& frame, jclass c, jfieldID fi
 {
 	jvalue v;
 	field(v) = frame.GetStaticShortField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPShortType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 {
 	jvalue v;
 	field(v) = frame.GetShortField(c, fid);
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPShortType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue* val)
@@ -116,7 +119,7 @@ JPPyObject JPShortType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID 
 		JPPyCallRelease call;
 		field(v) = frame.CallStaticShortMethodA(claz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 JPPyObject JPShortType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jmethodID mth, jvalue* val)
@@ -129,7 +132,7 @@ JPPyObject JPShortType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jm
 		else
 			field(v) = frame.CallNonvirtualShortMethodA(obj, clazz, mth, val);
 	}
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPShortType::setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* obj)
@@ -213,7 +216,7 @@ JPPyObject JPShortType::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 	frame.GetShortArrayRegion(array, ndx, 1, &val);
 	jvalue v;
 	field(v) = val;
-	return convertToPythonObject(frame, v);
+	return convertToPythonObject(frame, v, false);
 }
 
 void JPShortType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObject* obj)

--- a/native/common/jp_voidtype.cpp
+++ b/native/common/jp_voidtype.cpp
@@ -68,7 +68,7 @@ JPPyObject JPVoidType::getField(JPJavaFrame& frame, jobject c, jfieldID fid)
 	JP_RAISE(PyExc_SystemError, "void cannot be the type of a field.");
 }
 
-JPPyObject JPVoidType::convertToPythonObject(JPJavaFrame& frame, jvalue val)
+JPPyObject JPVoidType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
 	return JPPyObject::getNone();
 }

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -150,10 +150,9 @@ int        PyJPValue_setattro(PyObject *self, PyObject *name, PyObject *value);
 #endif
 
 // C++ methods
-JPPyObject PyJPArray_create(JPJavaFrame &frame, PyTypeObject* wrapper, JPValue& value);
+JPPyObject PyJPArray_create(JPJavaFrame &frame, PyTypeObject* wrapper, const JPValue& value);
 JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls);
 JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPValue& value);
-JPPyObject PyJPValue_create(JPJavaFrame &frame, const JPValue& value);
 JPPyObject PyJPField_create(JPField* m);
 JPPyObject PyJPMethod_create(JPMethodDispatch *m, PyObject *instance);
 

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -512,7 +512,7 @@ void PyJPArray_initType(PyObject * module)
 	JP_PY_CHECK();
 }
 
-JPPyObject PyJPArray_create(JPJavaFrame &frame, PyTypeObject *type, JPValue & value)
+JPPyObject PyJPArray_create(JPJavaFrame &frame, PyTypeObject *type, const JPValue & value)
 {
 	PyObject *obj = type->tp_alloc(type, 0);
 	JP_PY_CHECK();

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -412,7 +412,7 @@ static PyObject *PyJPClass_class(PyObject *self, PyObject *closure)
 	JPValue* javaSlot = PyJPValue_getJavaSlot(self);
 	if (javaSlot == NULL)
 		JP_RAISE(PyExc_AttributeError, "Java slot is null");
-	return PyJPValue_create(frame, *javaSlot).keep();
+	return javaSlot->getClass()->convertToPythonObject(frame, javaSlot->getValue(), false).keep();
 	JP_PY_CATCH(NULL);
 }
 
@@ -537,17 +537,23 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 			return NULL;
 		}
 		jvalue v = match.convert();
-		return PyJPValue_create(frame, JPValue(type, v)).keep();
+		return type->convertToPythonObject(frame, v, true).keep();
 	}
 
 	// Cast on java object
 	//	if (!type->isSubTypeOf(val->getClass()))
 	jobject obj = val->getJavaObject();
 	if (obj == NULL)
-		return PyJPValue_create(frame, JPValue(type, 0)).keep();
+	{
+		jvalue v;
+		v.l = NULL;
+		return type->convertToPythonObject(frame, v, true).keep();
+	}
 	JPClass *otherClass = frame.findClassForObject(obj);
 	if (otherClass == NULL)
-		return PyJPValue_create(frame, JPValue(type, val->getJavaObject())).keep();
+	{
+		return type->convertToPythonObject(frame, val->getValue(), true).keep();
+	}
 
 	if (!otherClass->isAssignableFrom(frame, type))
 	{
@@ -567,12 +573,13 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 		if (array->m_Array->isSlice())
 		{
 			JPJavaFrame frame(context);
-			jobject ja = frame.keep(array->m_Array->clone(frame, other));
-			return PyJPValue_create(frame, JPValue(type, ja)).keep();
+			jvalue v;
+			v.l = frame.keep(array->m_Array->clone(frame, other));
+			return type->convertToPythonObject(frame, v, true).keep();
 		}
 	}
 
-	return PyJPValue_create(frame, JPValue(type, val->getJavaObject())).keep();
+	return type->convertToPythonObject(frame, val->getValue(), true).keep();
 
 	Py_RETURN_NONE;
 	JP_PY_CATCH(NULL);
@@ -601,7 +608,7 @@ static PyObject *PyJPClass_convertToJava(PyJPClass *self, PyObject *other)
 
 	// Otherwise give back a PyJPValue
 	jvalue v = match.convert();
-	return PyJPValue_create(frame, JPValue(cls, v)).keep();
+	return cls->convertToPythonObject(frame, v, true).keep();
 	JP_PY_CATCH(NULL);
 }
 
@@ -777,7 +784,7 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 	JP_TRACE_IN("PyJPClass_create", cls);
 
 	// Check the cache for speed
-	PyObject *host = cls->getHost();
+	PyObject *host = (PyObject*) cls->getHost();
 	if (host != NULL)
 	{
 		return JPPyObject(JPPyRef::_use, host);

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -176,7 +176,7 @@ static PyObject *PyJPMethod_getDoc(PyJPMethod *self, void *ctxt)
 		JP_TRACE("Set overload", i);
 		jvalue v;
 		v.l = (*iter)->getJava();
-		JPPyObject obj(PyJPValue_create(frame, JPValue(methodClass, v)));
+		JPPyObject obj(methodClass->convertToPythonObject(frame, v, true));
 		ov.setItem(i++, obj.get());
 	}
 
@@ -187,7 +187,7 @@ static PyObject *PyJPMethod_getDoc(PyJPMethod *self, void *ctxt)
 		args.setItem(0, (PyObject*) self);
 		jvalue v;
 		v.l = (jobject) self->m_Method->getClass()->getJavaClass();
-		JPPyObject obj(PyJPValue_create(frame, JPValue(context->_java_lang_Class, v)));
+		JPPyObject obj(context->_java_lang_Class->convertToPythonObject(frame, v, true));
 		args.setItem(1, obj.get());
 		args.setItem(2, ov.get());
 		JP_TRACE("Call Python");
@@ -230,7 +230,7 @@ PyObject *PyJPMethod_getAnnotations(PyJPMethod *self, void *ctxt)
 		JP_TRACE("Set overload", i);
 		jvalue v;
 		v.l = (*iter)->getJava();
-		JPPyObject obj(PyJPValue_create(frame, JPValue(methodClass, v)));
+		JPPyObject obj(methodClass->convertToPythonObject(frame, v, true));
 		ov.setItem(i++, obj.get());
 	}
 
@@ -241,7 +241,7 @@ PyObject *PyJPMethod_getAnnotations(PyJPMethod *self, void *ctxt)
 		args.setItem(0, (PyObject*) self);
 		jvalue v;
 		v.l = (jobject) self->m_Method->getClass()->getJavaClass();
-		JPPyObject obj(PyJPValue_create(frame, JPValue(context->_java_lang_Class, v)));
+		JPPyObject obj(context->_java_lang_Class->convertToPythonObject(frame, v, true));
 		args.setItem(1, obj.get());
 		args.setItem(2, ov.get());
 		JP_TRACE("Call Python");

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -327,7 +327,7 @@ static PyObject* PyJPModule_convertToDirectByteBuffer(PyObject* self, PyObject* 
 		context->getReferenceQueue()->registerRef(v.l, vw.view, &releaseView);
 		vw.view = 0;
 		JPClass *type = frame.findClassForObject(v.l);
-		return type->convertToPythonObject(frame, v).keep();
+		return type->convertToPythonObject(frame, v, false).keep();
 	}
 	JP_RAISE(PyExc_TypeError, "convertToDirectByteBuffer requires buffer support");
 	JP_PY_CATCH(NULL);
@@ -423,7 +423,7 @@ PyObject *PyJPModule_hasClass(PyObject* module, PyObject *obj)
 		JP_RAISE(PyExc_TypeError, "str is required");
 	}
 
-	PyObject *host = cls->getHost();
+	PyObject *host = (PyObject*) cls->getHost();
 	return PyBool_FromLong(host != NULL);
 	JP_PY_CATCH(NULL);
 }

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -72,7 +72,7 @@ class BuildJavaCommand(distutils.cmd.Command):
             raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
 
         # Coverage tool requires special placement of the source
-         if self.distribution.enable_coverage:
+        if self.distribution.enable_coverage:
             import shutil
             shutil.copyfile(os.path.join("build", "lib", "org.jpype.jar"), os.path.join(
                 "native", "org.jpype.jar"))

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -71,9 +71,8 @@ class BuildJavaCommand(distutils.cmd.Command):
             distutils.log.error(exc.output)
             raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
 
-        # Disable for now.  Java coverage tool needs work
         # Coverage tool requires special placement of the source
-        # if self.distribution.enable_coverage:
-        #    import shutil
-        #    shutil.copyfile(os.path.join("build", "lib", "org.jpype.jar"), os.path.join(
-        #        "native", "org.jpype.jar"))
+         if self.distribution.enable_coverage:
+            import shutil
+            shutil.copyfile(os.path.join("build", "lib", "org.jpype.jar"), os.path.join(
+                "native", "org.jpype.jar"))

--- a/setupext/build_java.py
+++ b/setupext/build_java.py
@@ -75,9 +75,3 @@ class BuildJavaCommand(distutils.cmd.Command):
         except subprocess.CalledProcessError as exc:
             distutils.log.error(exc.output)
             raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
-
-        # Coverage tool requires special placement of the source
-        if self.distribution.enable_coverage:
-            import shutil
-            shutil.copyfile(os.path.join("build", "lib", "org.jpype.jar"), os.path.join(
-                "native", "org.jpype.jar"))

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -113,6 +113,11 @@ class JByteTestCase(common.JPypeTestCase):
         with self.assertRaises(OverflowError):
             self.fixture.callByte(int(-1e10))
 
+    def testExplicitRange(self):
+        # These will not overflow as they are explicit casts
+        self.assertEqual(JByte(2**8), 0)
+        self.assertEqual(JByte(-2**8), 0)
+
     def testByteFromNone(self):
         with self.assertRaises(TypeError):
             self.fixture.callByte(None)

--- a/test/jpypetest/test_jint.py
+++ b/test/jpypetest/test_jint.py
@@ -232,6 +232,11 @@ class JIntTestCase(common.JPypeTestCase):
         self.checkTypeFail(2**31, exc=OverflowError)
         self.checkTypeFail(-2**31-1, exc=OverflowError)
 
+    def testExplicitRange(self):
+        # These will not overflow as they are explicit casts
+        self.assertEqual(JInt(2**32), 0)
+        self.assertEqual(JInt(-2**32), 0)
+
     def testCheckBool(self):
         self.checkType(True)
         self.checkType(False)

--- a/test/jpypetest/test_jlong.py
+++ b/test/jpypetest/test_jlong.py
@@ -232,6 +232,11 @@ class JLongTestCase(common.JPypeTestCase):
         self.checkTypeFail(2**63, exc=OverflowError)
         self.checkTypeFail(-2**63-1, exc=OverflowError)
 
+    def testExplicitRange(self):
+        # These will not overflow as they are explicit casts
+        self.assertEqual(JLong(2**64), 0)
+        self.assertEqual(JLong(-2**64), 0)
+
     def testCheckBool(self):
         self.checkType(True)
         self.checkType(False)

--- a/test/jpypetest/test_jmethod.py
+++ b/test/jpypetest/test_jmethod.py
@@ -243,8 +243,8 @@ class JMethodTestCase(common.JPypeTestCase):
     def testJMethod_self(self):
         Fixture = JClass("jpype.common.Fixture")
         fixture = JClass("jpype.common.Fixture")()
-        self.assertEquals(fixture.callInt.__self__, fixture)
-        self.assertEquals(Fixture.callStaticInt.__self__, None)
+        self.assertEqual(fixture.callInt.__self__, fixture)
+        self.assertEqual(Fixture.callStaticInt.__self__, None)
 
     def testJMethod_name(self):
         fixture = JClass("jpype.common.Fixture")()

--- a/test/jpypetest/test_jshort.py
+++ b/test/jpypetest/test_jshort.py
@@ -133,10 +133,8 @@ class JShortTestCase(common.JPypeTestCase):
     def testFromJShortWiden(self):
         self.assertEqual(JShort(JByte(123)), 123)
         self.assertEqual(JShort(JShort(12345)), 12345)
-        with self.assertRaises(OverflowError):
-            JShort(JInt(12345678))
-        with self.assertRaises(OverflowError):
-            JShort(JLong(12345678))
+        self.assertEqual(JShort(JInt(12345678)), JShort(12345678))
+        self.assertEqual(JShort(JLong(12345678)), JShort(12345678))
 
     def testFromNone(self):
         with self.assertRaises(TypeError):
@@ -224,6 +222,11 @@ class JShortTestCase(common.JPypeTestCase):
         self.checkType(-2**15)
         self.checkTypeFail(2**15, exc=OverflowError)
         self.checkTypeFail(-2**15-1, exc=OverflowError)
+
+    def testExplicitRange(self):
+        # These will not overflow as they are explicit casts
+        self.assertEqual(JShort(2**16), 0)
+        self.assertEqual(JShort(-2**16), 0)
 
     def testCheckBool(self):
         self.checkType(True)


### PR DESCRIPTION
Tonight's PR deals with explicit casting to primitives.  In Java casting will never produce an overflow error, thus we have replicated that behavior.  Implicit conversions still produce OverflowError as per Python conventions.   This was intended to be a very small pull request but unfortunately the casting operations required a different field for each type for proper sign convention which ran straight into the big bag of if statements in PyJPValue_create.   Those if statements were replaced with logic in the convertToPythonObject methods which were already part of the system.   A secondary bug with overflow from unsigned long was also deal with, but there may be an additional one with array assignments.

Fixes #602