### PR TITLE
Inner class bug

### DIFF
--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -783,6 +783,7 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 {
 	JP_TRACE_IN("PyJPClass_create", cls);
 	// Check the cache for speed
+
 	PyObject *host = (PyObject*) cls->getHost();
 	if (host != NULL)
 	{
@@ -824,7 +825,7 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 	}
 
 	// Catch creation loop,  the process of creating our parent
-	host = cls->getHost();
+	host = (PyObject*) cls->getHost();
 	if (host != NULL)
 	{
 		return JPPyObject(JPPyRef::_use, host);

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -796,6 +796,13 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 	PyTuple_SetItem(args.get(), 0, JPPyString::fromStringUTF8(cls->getCanonicalName()).keep());
 	PyTuple_SetItem(args.get(), 1, PyJPClass_getBases(frame, cls).keep());
 
+	// Catch creation loop,  the process of creating our parent
+	host = (PyObject*) cls->getHost();
+	if (host != NULL)
+	{
+		return JPPyObject(JPPyRef::_use, host);
+	}
+
 	PyObject *members = PyDict_New();
 	PyTuple_SetItem(args.get(), 2, members);
 
@@ -822,13 +829,6 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 			PyDict_SetItem(members, methodName.keep(),
 					PyJPMethod_create(*iter, NULL).keep());
 		}
-	}
-
-	// Catch creation loop,  the process of creating our parent
-	host = (PyObject*) cls->getHost();
-	if (host != NULL)
-	{
-		return JPPyObject(JPPyRef::_use, host);
 	}
 
 	// Call the customizer to make any required changes to the tables.

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -796,6 +796,9 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 	PyTuple_SetItem(args.get(), 0, JPPyString::fromStringUTF8(cls->getCanonicalName()).keep());
 	PyTuple_SetItem(args.get(), 1, PyJPClass_getBases(frame, cls).keep());
 
+	PyObject *members = PyDict_New();
+	PyTuple_SetItem(args.get(), 2, members);
+
 	// Catch creation loop,  the process of creating our parent
 	host = (PyObject*) cls->getHost();
 	if (host != NULL)
@@ -803,8 +806,6 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 		return JPPyObject(JPPyRef::_use, host);
 	}
 
-	PyObject *members = PyDict_New();
-	PyTuple_SetItem(args.get(), 2, members);
 
 	const JPFieldList& instFields = cls->getFields();
 	for (JPFieldList::const_iterator iter = instFields.begin(); iter != instFields.end(); iter++)

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -782,7 +782,6 @@ static JPPyObject PyJPClass_getBases(JPJavaFrame &frame, JPClass* cls)
 JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 {
 	JP_TRACE_IN("PyJPClass_create", cls);
-
 	// Check the cache for speed
 	PyObject *host = (PyObject*) cls->getHost();
 	if (host != NULL)
@@ -822,6 +821,13 @@ JPPyObject PyJPClass_create(JPJavaFrame &frame, JPClass* cls)
 			PyDict_SetItem(members, methodName.keep(),
 					PyJPMethod_create(*iter, NULL).keep());
 		}
+	}
+
+	// Catch creation loop,  the process of creating our parent
+	host = cls->getHost();
+	if (host != NULL)
+	{
+		return JPPyObject(JPPyRef::_use, host);
 	}
 
 	// Call the customizer to make any required changes to the tables.

--- a/test/harness/jpype/types/InnerTest.java
+++ b/test/harness/jpype/types/InnerTest.java
@@ -1,0 +1,10 @@
+package jpype.types;
+
+public class InnerTest
+{
+  public Object test()
+  {
+	  return new Outer.Inner();
+  }
+
+}

--- a/test/harness/jpype/types/Outer.java
+++ b/test/harness/jpype/types/Outer.java
@@ -1,0 +1,15 @@
+package jpype.types;
+
+public interface Outer
+{
+  Object get();
+
+  public class Inner implements Outer
+  {
+	  public Object get()
+	  {
+		  return null;
+	  }
+  }
+
+}

--- a/test/jpypetest/test_jclass.py
+++ b/test/jpypetest/test_jclass.py
@@ -195,3 +195,12 @@ class JClassTestCase(common.JPypeTestCase):
             jpype.java.lang.Class._canConvertToJava(a.getClass()), "exact")
         self.assertEqual(
             jpype.java.lang.Class._canConvertToJava(JString), "exact")
+
+
+    def testInnerClass(self):
+        # This tests for problems when the inner class implements the
+        # outer interface which creates a race condition.  Success is 
+        # not throwing an exception
+        test = JClass("jpype.types.InnerTest")()
+        test.test()
+


### PR DESCRIPTION
Addresses the problem that inner classes are created by the outer class.  So if the inner class is requested first it attempts to create itself twice.   This needs some test code to verify that it is being dealt with properly, but for now I just have time a quick patch job.

This pull request deals with ``_hints`` cannot be set bug.

This still needs a test bench before it can be included.