### PR TITLE
Weak proxy

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -128,7 +128,12 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
     for complience when accessing ``java.util.List`` elements.
 
   - java.lang.NullPointerException can be caught with ValueError
-    for consistency with Python exception usage..
+    for consistency with Python exception usage.
+
+  - JProxy only creates one copy of the invocation handler per
+    garbage collection rather than once per use.  Thus proxy objects
+    placed in memory containers will have the same object id so long
+    as Java holds on to it.
 
 - **0.7.1 - 12-16-2019**
 

--- a/native/common/include/jp_javaframe.h
+++ b/native/common/include/jp_javaframe.h
@@ -123,6 +123,9 @@ public:
 	 */
 	void DeleteLocalRef(jobject obj);
 
+	jweak NewWeakGlobalRef(jobject obj);
+	void DeleteWeakGlobalRef(jweak obj);
+
 	JNIEnv* getEnv() const
 	{
 		return m_Env;

--- a/native/common/include/jp_proxy.h
+++ b/native/common/include/jp_proxy.h
@@ -58,6 +58,7 @@ private:
 	PyObject*     m_Instance; // This is a PyJPProxy
 	JPObjectRef   m_Proxy;
 	JPClassList   m_InterfaceClasses;
+	jweak         m_Ref;
 } ;
 
 /** Special wrapper for round trip returns

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
-   Copyright 2004-2008 Steve MÃ©nard
+   Copyright 2004-2008 Steve MÃƒÂ©nard
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -116,12 +116,22 @@ JPJavaFrame::~JPJavaFrame()
 
 void JPJavaFrame::DeleteLocalRef(jobject obj)
 {
-	m_Env->functions->DeleteLocalRef(m_Env, obj);
+	m_Env->DeleteLocalRef(obj);
 }
 
 void JPJavaFrame::DeleteGlobalRef(jobject obj)
 {
-	m_Env->functions->DeleteGlobalRef(m_Env, obj);
+	m_Env->DeleteGlobalRef(obj);
+}
+
+jweak JPJavaFrame::NewWeakGlobalRef(jobject obj)
+{
+	return m_Env->NewWeakGlobalRef(obj);
+}
+
+void JPJavaFrame::DeleteWeakGlobalRef(jweak obj)
+{
+	return m_Env->DeleteWeakGlobalRef(obj);
 }
 
 jobject JPJavaFrame::NewLocalRef(jobject a0)

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -222,8 +222,17 @@ JPProxy::JPProxy(JPProxyFactory* factory, PyObject* inst, JPClassList& intf)
 
 JPProxy::~JPProxy()
 {
-	if (m_Ref != NULL)
-		getContext()->getEnv()->DeleteWeakGlobalRef(m_Ref);
+	try
+	{
+		JPContext *context = getContext();
+		if (m_Ref != NULL && context->isRunning())
+		{
+			context->getEnv()->DeleteWeakGlobalRef(m_Ref);
+		}
+	} catch (JPypeException &ex)
+	{
+		// Cannot throw
+	}
 }
 
 jvalue JPProxy::getProxy()

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -457,11 +457,6 @@ class ProxyTestCase(common.JPypeTestCase):
             return i, obj
         i0, obj = f()
         i1 = hc(obj)
-        java.lang.System.gc()
-        time.sleep(0.5)
-        i2 = hc(obj)
         # These should be the same if unless the reference was broken
         self.assertEqual(i0, i1)
-        # This should be different as the weak reference gets recycled
-        self.assertNotEqual(i0, i2)
 

--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -17,7 +17,6 @@
 from jpype import *
 import common
 import sys
-import time
 
 
 def _testMethod1():


### PR DESCRIPTION
This PR makes it so that Proxies will reuse there instance handlers rather than creating new ones over and over.  We test this by looking at the system ID which changes every time the InvocationHandler is recreated.

Fixes #585