### PR TITLE
NullPointerException to ValueError

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -127,6 +127,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
   - java.lang.IndexOutOfBoundsException can be caught with IndexError
     for complience when accessing ``java.util.List`` elements.
 
+  - java.lang.NullPointerException can be caught with ValueError
+    for consistency with Python exception usage..
 
 - **0.7.1 - 12-16-2019**
 

--- a/jpype/_jcustomizer.py
+++ b/jpype/_jcustomizer.py
@@ -263,3 +263,5 @@ def getClassHints(name):
 _jpype._hints = {}
 getClassHints("java.lang.IndexOutOfBoundsException").registerClassBase(
     IndexError)
+getClassHints("java.lang.NullPointerException").registerClassBase(
+    ValueError)

--- a/test/jpypetest/test_exc.py
+++ b/test/jpypetest/test_exc.py
@@ -16,6 +16,7 @@
 # *****************************************************************************
 import jpype
 from jpype import JException, java, JProxy, JClass
+from jpype.types import *
 import traceback
 import common
 
@@ -113,7 +114,13 @@ class ExceptionTestCase(common.JPypeTestCase):
         with self.assertRaises(IndexError):
             raise java.lang.IndexOutOfBoundsException("From Java")
 
+    def testValueError(self):
+        js = JObject(None, JString)
+        with self.assertRaises(ValueError):
+            js.substring(0)
+
     def testExcCtor(self):
         WE = jpype.JClass("jpype.exc.WierdException")
         with self.assertRaises(WE):
             WE.testThrow()
+


### PR DESCRIPTION
To be more consistent with Python handling rules, we will make NullPointerException catchable by Python ValueError.

Fixes #647 