### PR TITLE
Memory leak fix on JPClassHints

### DIFF
--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -80,6 +80,12 @@ JPClassHints::JPClassHints()
 
 JPClassHints::~JPClassHints()
 {
+	for (std::list<JPConversion*>::iterator iter = conversions.begin();
+			iter != conversions.end(); ++iter)
+	{
+		delete *iter;
+	}
+	conversions.clear();
 }
 
 JPMatch::Type JPClassHints::getConversion(JPMatch& match, JPClass *cls)


### PR DESCRIPTION
Adds a clean up routine to JPClassHints.

Fixes #654 