### PR TITLE
Dealing with relative paths

### DIFF
--- a/jpype/_classpath.py
+++ b/jpype/_classpath.py
@@ -72,7 +72,7 @@ def addClassPath(path1):
     # of the caller rather than the JPype directory.
     path1 = Path(path1)
     if not path1.is_absolute():
-        path2 = Path(inspect.stack(1)[1].filename).parent
+        path2 = Path(inspect.stack(1)[1].filename).parent.resolve()
         path1 = path2.joinpath(path1)
 
     if _sys.platform == 'cygwin':

--- a/jpype/_classpath.py
+++ b/jpype/_classpath.py
@@ -33,6 +33,7 @@ if _sys.platform == 'cygwin':
         return parts
 
     def _posix2win(directory):
+        from pathlib import Path
         directory = str(directory)
         if len(directory) > 3 and directory[1:3] == ":\\":
             return Path(directory)
@@ -90,6 +91,7 @@ def getClassPath(env=True):
       env(Optional, bool): If true then environment is included.
         (default True)
     """
+    from pathlib import Path
     global _CLASSPATHS
     global _SEP
 


### PR DESCRIPTION
This deals with an issue in #652.  The user was attempting a path which was relative but the way that the addClassPath call was structured it was performing the lookup relative to the wrong location.   This pull request corrects that flaw so that paths are always relative to the call location rather than some arbitrary point like the starting directory or the installation directory.   We use inspect to get the callers file location.

This needs additional testing before it can be included.

Fixes #652
Fixes #657