### PR TITLE
Clean up following merge

### DIFF
--- a/test/jpypetest/test_proxy.py
+++ b/test/jpypetest/test_proxy.py
@@ -468,6 +468,7 @@ class ProxyTestCase(common.JPypeTestCase):
         @JImplements("java.io.Serializable")
         class MyObj(object):
             pass
+
         def f():
             obj = MyObj()
             jobj = JObject(obj)
@@ -477,6 +478,7 @@ class ProxyTestCase(common.JPypeTestCase):
         i1 = hc(obj)
         # These should be the same if unless the reference was broken
         self.assertEqual(i0, i1)
+
 
 @subrun.TestCase(individual=True)
 class TestProxyDefinitionWithoutJVM(common.JPypeTestCase):
@@ -529,4 +531,3 @@ class TestProxyDefinitionWithoutJVM(common.JPypeTestCase):
 
         startJVM()
         assert isinstance(MyImpl(), MyImpl)
-


### PR DESCRIPTION
Minor rearrangement following deferred proxy merge and autopep8.  This will be merged once it clears CI.  Moved common functions to global scope so they don't get reevaluated multiple times.  Split deferred and non-deferred declaration paths to save attribute lookups.