### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,92 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+pr:
+  - master
+  - releases/*
+
+jobs:
+- job: Documentation
+  pool:
+    vmImage: "ubuntu-16.04"
+  steps:
+  - script: |
+      pip install  Pygments==2.3.1
+      pip install  setuptools==41.0.1
+      pip install  docutils==0.14
+      pip install  mock==1.0.1
+      pip install  commonmark==0.8.1
+      pip install  recommonmark==0.5.0
+      pip install  sphinx
+      pip install  sphinx-rtd-theme
+      pip install  readthedocs-sphinx-ext
+      pip install  --exists-action=w --no-cache-dir -r test-requirements.txt
+    displayName: 'Install requirements'
+  - script: |
+      python -m sphinx -T -b readthedocs -d _build/doctrees-readthedocs -D language=en doc _build/html
+    displayName: 'Check documentation'
+
+- job: Coverage
+  pool:
+    vmImage: "ubuntu-16.04"
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
+  - task: Maven@3
+    inputs:
+      mavenOpts: -q -f project/coverage
+      mavenPomFile: 'pom.xml' 
+      goals: 'package' # Optional
+  - script: |
+      python setup.py test_java
+      pip install gcovr pytest-cov jedi
+    displayName: 'Install requirements'
+  - script: |
+      python setup.py --enable-coverage --enable-build-jar build_ext --inplace
+    displayName: 'Build'
+  - script: |
+      python -m pytest -v test/jpypetest --cov=jpype --cov-report=xml:coverage_py.xml --jar="build/classes" --jacoco --checkjni
+    displayName: 'Test'
+  - script: |
+      gcovr -r . --xml -o coverage.xml --exclude-unreachable-branches --exclude-throw-branches
+      java -jar project/coverage/org.jacoco.cli-0.8.5-nodeps.jar report jacoco.exec --classfiles build/classes/ --xml coverage_java.xml --sourcefiles native/java
+  #      - bash <(curl -s https://codecov.io/bash) -f coverage.xml -f coverage_py.xml -f coverage_java.xml
+    displayName: 'Report'
+
+- job: Test
+  strategy:
+    matrix:
+      linux:
+        imageName: "ubuntu-16.04"
+        jdk_version: "1.11"
+        python.version: '3.7'
+      windows:
+        imageName: "vs2017-win2016"
+        jdk_version: "1.11"
+        python.version: '3.7'
+      mac:
+        imageName: "macos-10.14"
+        jdk_version: "1.11"
+        python.version: '3.7'
+    maxParallel: 3
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+  - script: pip install -r requirements.txt
+    displayName: 'Install requirements'
+  - script: |
+      python setup.py sdist
+      python -m pip install dist/*
+  - script: python -c "import jpype"
+    displayName: 'Check module'
+  - script: |
+      python setup.py test_java
+      python install -r test-requirements.txt
+      python -m pytest -v test/jpypetest --checkjni  
+    displayName: 'Test module'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ jobs:
   - script: |
       python setup.py test_java
       pip install gcovr pytest-cov jedi
+      pip install -r test-requirements.txt
     displayName: 'Install requirements'
   - script: |
       python setup.py --enable-coverage --enable-build-jar build_ext --inplace
@@ -79,11 +80,12 @@ jobs:
       versionSpec: '$(python.version)'
   - script: |
       python setup.py sdist
-      python -m pip install dist/*
+      pip install dist/*
+    displayName: 'Build module'
   - script: python -c "import jpype"
     displayName: 'Check module'
   - script: |
       python setup.py test_java
-      python install -r test-requirements.txt
+      pip install -r test-requirements.txt
       python -m pytest -v test/jpypetest --checkjni  
     displayName: 'Test module'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,4 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
+# JPype CI pipeline
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
@@ -56,22 +55,26 @@ jobs:
   #      - bash <(curl -s https://codecov.io/bash) -f coverage.xml -f coverage_py.xml -f coverage_java.xml
     displayName: 'Report'
 
-- job: Test
+- job: Test_Linux
   strategy:
     matrix:
-      linux:
+      linux-3.6:
+        imageName: "ubuntu-16.04"
+        jdk_version: "1.11"
+        python.version: '3.6'
+      linux-3.7:
         imageName: "ubuntu-16.04"
         jdk_version: "1.11"
         python.version: '3.7'
-      windows:
-        imageName: "vs2017-win2016"
+      linux-3.8:
+        imageName: "ubuntu-16.04"
         jdk_version: "1.11"
-        python.version: '3.7'
-      mac:
+        python.version: '3.8'
+      mac-3.8:
         imageName: "macos-10.14"
         jdk_version: "1.11"
-        python.version: '3.7'
-    maxParallel: 3
+        python.version: '3.8'
+    maxParallel: 2
   pool:
     vmImage: $(imageName)
   steps:
@@ -81,6 +84,43 @@ jobs:
   - script: |
       python setup.py sdist
       pip install dist/*
+    displayName: 'Build module'
+  - script: python -c "import jpype"
+    displayName: 'Check module'
+  - script: |
+      python setup.py test_java
+      pip install -r test-requirements.txt
+      python -m pytest -v test/jpypetest --checkjni  
+    displayName: 'Test module'
+
+- job: Test_Windows
+  strategy:
+    matrix:
+#      windows-3.5:
+#        imageName: "vs2017-win2016"
+#        jdk_version: "1.11"
+#        python.version: '3.5'
+#      windows-3.6:
+#        imageName: "vs2017-win2016"
+#        jdk_version: "1.11"
+#        python.version: '3.6'
+#      windows-3.7:
+#        imageName: "vs2017-win2016"
+#        jdk_version: "1.11"
+#        python.version: '3.7'
+      windows-3.8:
+        imageName: "vs2017-win2016"
+        jdk_version: "1.11"
+        python.version: '3.8'
+    maxParallel: 2
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+  - script: |
+      python setup.py build_ext --inplace
     displayName: 'Build module'
   - script: python -c "import jpype"
     displayName: 'Check module'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,9 @@ jobs:
   pool:
     vmImage: "ubuntu-16.04"
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
   - script: |
       pip install  Pygments==2.3.1
       pip install  setuptools==41.0.1
@@ -35,11 +38,7 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.7'
-  - task: Maven@3
-    inputs:
-      mavenOpts: -q -f project/coverage
-      mavenPomFile: 'pom.xml' 
-      goals: 'package' # Optional
+  - script: mvn -q -f project/coverage package
   - script: |
       python setup.py test_java
       pip install gcovr pytest-cov jedi
@@ -78,8 +77,6 @@ jobs:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '$(python.version)'
-  - script: pip install -r requirements.txt
-    displayName: 'Install requirements'
   - script: |
       python setup.py sdist
       python -m pip install dist/*


### PR DESCRIPTION
This is a test of porting our current CI over to azure pipelines.

@marscher please look over and expand the matrix as needed.  We will need to disable our existing travis and appveyor, and push out artifacts as required.   I will also need to add you to the administrative controls.