### PR TITLE
Updates on deprecation

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -56,6 +56,12 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
     are direct.  They can be converted to numpy arrays with
     ``numpy.asarray(memoryview(obj))``.
 
+  - Undocumented feature of using a Python type in ``JObject(obj, type=tp)`` 
+    is deprecated to support casting to Python wrapper types in Java in a 
+    future release.
+
+  - jpype.reflect will be removed in the next release.  convertStrings
+    default will become false in the next release.
 
 - **0.7.2 - 2-28-2019**
 

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -264,13 +264,14 @@ please file a ticket with the developer.
 
     # Table for automatic conversion to objects "JObject(value, type)"
     _jpype._object_classes = {}
+    # These need to be deprecated so that we can support casting Python objects
     _jpype._object_classes[bool] = _jpype._java_lang_Boolean
     _jpype._object_classes[int] = _jpype._java_lang_Long
     _jpype._object_classes[float] = _jpype._java_lang_Double
     _jpype._object_classes[str] = _jpype._java_lang_String
     _jpype._object_classes[type] = _jpype._java_lang_Class
-    _jpype._object_classes[_jpype._JClass] = _jpype._java_lang_Class
     _jpype._object_classes[object] = _jpype._java_lang_Object
+    _jpype._object_classes[_jpype._JClass] = _jpype._java_lang_Class
     _jpype._object_classes[_jtypes.JBoolean] = _jpype._java_lang_Boolean
     _jpype._object_classes[_jtypes.JByte] = _jpype._java_lang_Byte
     _jpype._object_classes[_jtypes.JChar] = _jpype._java_lang_Character

--- a/jpype/_jobject.py
+++ b/jpype/_jobject.py
@@ -104,6 +104,10 @@ def _JObjectFactory(v=None, tp=None):
     elif isinstance(tp, str):
         tp = _jpype.JClass(tp)
     if tp in _jpype._object_classes:
+        if not isinstance(tp, _jpype.JClass):
+            import warnings
+            warnings.warn("Using JObject with a Python type is deprecated.",
+                              category=DeprecationWarning, stacklevel=3)
         tp = _jpype._object_classes[tp]
 
     # Given a Java class


### PR DESCRIPTION
A few undocumented features need to be dealt with.   In order to support placing Python objects into the Java object system, we need to be able to apply JObject with a specified type for the cast unless we want it to go implicitly.   Given the implicit conversions would introduce a lot of errors, explicit conversions seems like a better idea.  Unfortunately, the existing JObject has casting types that map to existing classes as an undocumented legacy feature.   This doesn't provide any meaningful utility as casting to specific Java types (JObject, JInt, JString, etc) already covers this usage.  Thus we are going to deprecate it so we can replace this with useful functionality.  For the most part the replacements will still function almost identically as we will be overloading the casting system so that we can convert these Python wrapped items through, but deprecating this misfeature now would be safest option.

In addition there are a few deprecated features that are still floating around that should be dealt with 
- JException creating a Class.  This was tagged as causing conflicts with potential support of multiple JVMs.
- jpype.reflect was left from 0.6 series before ``class_`` was supported
- convertStrings defaulting to true.

It is not clear yet if 0.8.0 will be the next release or the release following.  I added a notice of features that are bound of removal to the changelog.