### PR TITLE
Exception bug

### DIFF
--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -262,6 +262,10 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 				"(Ljava/lang/Object;)I");
 
 		m_GC->init(frame);
+
+		// Testing code to make sure C++ exceptions are handled.
+		// FIXME find a way to call this from instrumentation.
+		// throw std::runtime_error("Failed");
 		// Everything is started.
 	}
 	m_IsInitialized = true;

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -663,6 +663,14 @@ void PyJPModule_rethrow(const JPStackInfo& info)
 		ex.from(info); // this likely wont be necessary, but for now we will add the entry point.
 		ex.toPython();
 		return;
+	} catch (std::exception &ex)
+	{
+		PyErr_Format(PyExc_RuntimeError, "Unhandled C++ exception occurred: %s", ex.what());
+		return;
+	} catch (...)
+	{
+		PyErr_Format(PyExc_RuntimeError, "Unhandled C++ exception occurred");
+		return;
 	}
 	JP_TRACE_OUT;
 }


### PR DESCRIPTION
Possible fix for a rare bug.  Under some situations strings or other C++ operations can produce C++ exceptions that current result in an abort.  This transfers them to ``RuntimeError``.

