### PR TITLE
Iterable2

### DIFF
--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -181,17 +181,9 @@ class _JIterator(object):
     This customizer adds the Python iterator concept to classes
     that implement the Java Iterator interface.
     """
-    # Python 2 requires next to function as python next(), thus
-    # we have a conflict in behavior. Java next is renamed.
-    @JOverride(sticky=True, rename="_next")
-    def next(self):
-        if self.hasNext():
-            return self._next()
-        raise StopIteration
-
     def __next__(self):
         if self.hasNext():
-            return self._next()
+            return self.next()
         raise StopIteration
 
     def __iter__(self):

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -81,15 +81,17 @@ static PyObject *PyJPMethod_call(PyJPMethod *self, PyObject *args, PyObject *kwa
 	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame(context);
 	JP_TRACE(self->m_Method->getName());
+	PyObject *out = NULL;
 	if (self->m_Instance == NULL)
 	{
 		JPPyObjectVector vargs(args);
-		return self->m_Method->invoke(frame, vargs, false).keep();
+		out = self->m_Method->invoke(frame, vargs, false).keep();
 	} else
 	{
 		JPPyObjectVector vargs(self->m_Instance, args);
-		return self->m_Method->invoke(frame, vargs, true).keep();
+		out = self->m_Method->invoke(frame, vargs, true).keep();
 	}
+	return out;
 	JP_PY_CATCH(NULL);
 }
 

--- a/test/jpypetest/test_collection.py
+++ b/test/jpypetest/test_collection.py
@@ -188,3 +188,16 @@ class CollectionTestCase(common.JPypeTestCase):
         self.assertIsInstance(hm, Iterable)
         self.assertIsInstance(hm, Container)
         self.assertIsInstance(hm, Mapping)
+
+    def testUnmodifiableNext(self):
+        ArrayList = JClass('java.util.ArrayList')
+        Collections = JClass('java.util.Collections')
+        a = ArrayList()
+        a.add("first")
+        a.add("second")
+        a.add("third")
+        for i in a:
+            pass
+
+        for i in Collections.unmodifiableList(a):
+            pass


### PR DESCRIPTION
The old python 2 logic created an endless recursion for unmodifiable list.   This logic was outdated and thus has been removed.

We need a broader review of sticky annotation as it appears that if something is overridden multiple times it can cause issues.  But that will need to happen at a later date.