### PR TITLE
Minor bug fixes discovered during compact enhancement.

### DIFF
--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -206,9 +206,6 @@ public:
 	JPClass* _java_lang_Throwable;
 	JPStringType* _java_lang_String;
 
-	JPClassRef _java_lang_RuntimeException;
-	JPClassRef _java_lang_NoSuchMethodError;
-
 	jmethodID m_BooleanValueID;
 	jmethodID m_ByteValueID;
 	jmethodID m_CharValueID;
@@ -241,6 +238,10 @@ private:
 	JPClassLoader *m_ClassLoader;
 	JPReferenceQueue *m_ReferenceQueue;
 	JPProxyFactory *m_ProxyFactory;
+
+public:
+	JPClassRef m_RuntimeException;
+	JPClassRef m_NoSuchMethodError;
 
 private:
 	// Java Functions

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -69,17 +69,7 @@ extern int _method_not_found;
 
 // Macro to all after executing a Python command that can result in
 // a failure to convert it to an exception.
-#define JP_PY_CHECK() { if (JPPyErr::occurred()) JP_RAISE_PYTHON();  }
-
-// We need to hide sanity checks that only occur on fatal initialization
-// from the coverage tool
-#ifdef JP_INSTRUMENTATION
-#define JP_PY_CHECK_INIT() if (false)
-#else
-#define JP_PY_CHECK_INIT() { if (JPPyErr::occurred()) JP_RAISE_PYTHON();  }
-#endif
-
-
+#define JP_PY_CHECK() { if (JPPyErr::occurred()) JP_RAISE_PYTHON();  } // GCOVR_EXCL_LINE
 
 // Macro to use when hardening code
 //   Most of these will be removed after core is debugged, but

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -186,8 +186,8 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		m_Object_HashCodeID = frame.GetMethodID(cls, "hashCode", "()I");
 		m_Object_GetClassID = frame.GetMethodID(cls, "getClass", "()Ljava/lang/Class;");
 
-		_java_lang_NoSuchMethodError = JPClassRef(frame, (jclass) frame.FindClass("java/lang/NoSuchMethodError"));
-		_java_lang_RuntimeException = JPClassRef(frame, (jclass) frame.FindClass("java/lang/RuntimeException"));
+		m_NoSuchMethodError = JPClassRef(frame, (jclass) frame.FindClass("java/lang/NoSuchMethodError"));
+		m_RuntimeException = JPClassRef(frame, (jclass) frame.FindClass("java/lang/RuntimeException"));
 
 		cls = frame.FindClass("java/lang/String");
 		m_String_ToCharArrayID = frame.GetMethodID(cls, "toCharArray", "()[C");

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -410,12 +410,12 @@ void JPypeException::toJava(JPContext *context)
 
 		if (m_Type == JPError::_method_not_found)
 		{
-			frame.ThrowNew(context->_java_lang_NoSuchMethodError.get(), mesg.c_str());
+			frame.ThrowNew(context->m_NoSuchMethodError.get(), mesg.c_str());
 			return;
 		}
 		// All others are issued as RuntimeExceptions
 		JP_TRACE("String exception");
-		frame.ThrowNew(context->_java_lang_RuntimeException.get(), mesg.c_str());
+		frame.ThrowNew(context->m_RuntimeException.get(), mesg.c_str());
 		return;
 	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
 	{	// GCOVR_EXCL_START

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -76,7 +76,7 @@ JNIEXPORT jobject JNICALL JPype_InvocationHandler_hostInvoke(
 		{
 			if (hostObj == 0)
 			{
-				env->functions->ThrowNew(env, context->_java_lang_RuntimeException.get(),
+				env->functions->ThrowNew(env, context->m_RuntimeException.get(),
 						"host reference is null");
 				return NULL;
 			}
@@ -153,7 +153,7 @@ JNIEXPORT jobject JNICALL JPype_InvocationHandler_hostInvoke(
 		} catch (...)
 		{
 			JP_TRACE("Other Exception raised");
-			env->functions->ThrowNew(env, context->_java_lang_RuntimeException.get(),
+			env->functions->ThrowNew(env, context->m_RuntimeException.get(),
 					"unknown error occurred");
 		}
 		return NULL;

--- a/native/common/jp_typefactory.cpp
+++ b/native/common/jp_typefactory.cpp
@@ -48,7 +48,7 @@ void JPTypeFactory_rethrow(JPJavaFrame& frame)
 		ex.toJava(frame.getContext());
 	} catch (...)
 	{
-		frame.ThrowNew(frame.getContext()->_java_lang_RuntimeException.get(),
+		frame.ThrowNew(frame.getContext()->m_RuntimeException.get(),
 				"unknown error occurred");
 	}
 }

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -447,8 +447,7 @@ static PyType_Slot arraySlots[] = {
 	{ Py_tp_dealloc,  (void*) PyJPArray_dealloc},
 	{ Py_tp_repr,     (void*) PyJPArray_repr},
 	{ Py_tp_methods,  (void*) &arrayMethods},
-	//	{ Py_sq_ass_item, (void*) &PyJPArray_assignItem},
-	{ Py_sq_item,     (void*) &PyJPArray_getItem},
+	{ Py_mp_subscript, (void*) &PyJPArray_getItem},
 	{ Py_sq_length,   (void*) &PyJPArray_len},
 	{ Py_mp_ass_subscript, (void*) &PyJPArray_assignSubscript},
 	{0}
@@ -496,10 +495,10 @@ void PyJPArray_initType(PyObject * module)
 	JPPyTuple tuple = JPPyTuple::newTuple(1);
 	tuple.setItem(0, (PyObject*) PyJPObject_Type);
 	PyJPArray_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&arraySpec, tuple.get());
+	JP_PY_CHECK();
 	PyJPArray_Type->tp_as_buffer = &arrayBuffer;
-	JP_PY_CHECK_INIT();
 	PyModule_AddObject(module, "_JArray", (PyObject*) PyJPArray_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	tuple = JPPyTuple::newTuple(1);
 	tuple.setItem(0, (PyObject*) PyJPArray_Type);

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -124,9 +124,9 @@ void PyJPBuffer_initType(PyObject * module)
 	tuple.setItem(0, (PyObject*) PyJPObject_Type);
 	PyJPBuffer_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&bufferSpec, tuple.get());
 	PyJPBuffer_Type->tp_as_buffer = &directBuffer;
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JBuffer", (PyObject*) PyJPBuffer_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }
 
 JPPyObject PyJPBuffer_create(JPJavaFrame &frame, PyTypeObject *type, const JPValue& value)

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -25,6 +25,7 @@
 #include "jp_field.h"
 #include "jp_method.h"
 #include "jp_methoddispatch.h"
+#include "jp_primitive_accessor.h"
 
 struct PyJPClass
 {
@@ -169,6 +170,9 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 				break;
 			case Py_tp_richcompare:
 				type->tp_richcompare = (richcmpfunc) slot->pfunc;
+				break;
+			case Py_mp_subscript:
+				heap->as_mapping.mp_subscript = (binaryfunc) slot->pfunc;
 				break;
 				// GCOVR_EXCL_START
 			default:
@@ -655,7 +659,7 @@ static PyType_Slot classSlots[] = {
 
 PyTypeObject* PyJPClass_Type = NULL;
 static PyType_Spec classSpec = {
-	"_jpype.PyJPClass",
+	"_jpype._JClass",
 	sizeof (PyJPClass),
 	0,
 	Py_TPFLAGS_DEFAULT  | Py_TPFLAGS_BASETYPE,
@@ -671,9 +675,9 @@ void PyJPClass_initType(PyObject* module)
 	PyObject *bases = PyTuple_Pack(1, &PyType_Type);
 	PyJPClass_Type = (PyTypeObject*) PyType_FromSpecWithBases(&classSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JClass", (PyObject*) PyJPClass_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }
 
 JPClass* PyJPClass_getJPClass(PyObject* obj)

--- a/native/python/pyjp_classhints.cpp
+++ b/native/python/pyjp_classhints.cpp
@@ -122,7 +122,7 @@ PyType_Spec PyJPClassHintsSpec = {
 void PyJPClassHints_initType(PyObject* module)
 {
 	PyJPClassHints_Type = (PyTypeObject*) PyType_FromSpec(&PyJPClassHintsSpec);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JClassHints", (PyObject*) PyJPClassHints_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }

--- a/native/python/pyjp_field.cpp
+++ b/native/python/pyjp_field.cpp
@@ -120,9 +120,9 @@ PyType_Spec PyJPFieldSpec = {
 void PyJPField_initType(PyObject* module)
 {
 	PyJPField_Type = (PyTypeObject*) PyType_FromSpec(&PyJPFieldSpec);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JField", (PyObject*) PyJPField_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }
 
 JPPyObject PyJPField_create(JPField* m)

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -377,10 +377,10 @@ void PyJPMethod_initType(PyObject* module)
 	PyFunction_Type.tp_flags |= Py_TPFLAGS_BASETYPE;
 	PyJPMethod_Type = (PyTypeObject*) PyType_FromSpecWithBases(&methodSpec, tuple.get());
 	PyFunction_Type.tp_flags = flags;
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	PyModule_AddObject(module, "_JMethod", (PyObject*) PyJPMethod_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }
 
 JPPyObject PyJPMethod_create(JPMethodDispatch *m, PyObject *instance)

--- a/native/python/pyjp_monitor.cpp
+++ b/native/python/pyjp_monitor.cpp
@@ -132,7 +132,7 @@ PyTypeObject* PyJPMonitor_Type = NULL;
 void PyJPMonitor_initType(PyObject* module)
 {
 	PyJPMonitor_Type = (PyTypeObject*) PyType_FromSpec(&PyJPMonitorSpec);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JMonitor", (PyObject*) PyJPMonitor_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -398,30 +398,30 @@ void PyJPNumber_initType(PyObject* module)
 	bases = PyTuple_Pack(2, &PyLong_Type, PyJPObject_Type);
 	PyJPNumberLong_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberLongSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JNumberLong", (PyObject*) PyJPNumberLong_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	bases = PyTuple_Pack(2, &PyFloat_Type, PyJPObject_Type);
 	PyJPNumberFloat_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberFloatSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JNumberFloat", (PyObject*) PyJPNumberFloat_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	bases = PyTuple_Pack(1, &PyLong_Type, PyJPObject_Type);
 	PyJPNumberChar_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberCharSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JChar", (PyObject*) PyJPNumberChar_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	bases = PyTuple_Pack(1, &PyLong_Type, PyJPObject_Type);
 	PyJPNumberBool_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberBooleanSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JBoolean", (PyObject*) PyJPNumberBool_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }
 
 JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPValue& value)

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -272,21 +272,21 @@ void PyJPObject_initType(PyObject* module)
 {
 	PyObject *bases;
 	PyJPObject_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&objectSpec, NULL);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JObject", (PyObject*) PyJPObject_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	bases = PyTuple_Pack(2, PyExc_Exception, PyJPObject_Type);
 	PyJPException_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&excSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JException", (PyObject*) PyJPException_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 
 	bases = PyTuple_Pack(1, PyJPObject_Type);
 	PyJPComparable_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&comparableSpec, bases);
 	Py_DECREF(bases);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JComparable", (PyObject*) PyJPComparable_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -168,9 +168,9 @@ void PyJPProxy_initType(PyObject* module)
 	JPPyTuple tuple = JPPyTuple::newTuple(1);
 	tuple.setItem(0, (PyObject*) & PyBaseObject_Type);
 	PyJPProxy_Type = (PyTypeObject*) PyType_FromSpecWithBases(&PyJPProxySpec, tuple.get());
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JProxy", (PyObject*) PyJPProxy_Type);
-	JP_PY_CHECK_INIT();
+	JP_PY_CHECK();
 }
 
 JPProxy *PyJPProxy_getJPProxy(PyObject* obj)


### PR DESCRIPTION
This PR corrects a number of minor bugs discovered while working on the compact notation enhancement.

- Bad slot on array
- Bad macro for coverage
- Setting field before checking type return
- RuntimeException named with a different type than others

This will be merged once it completes CI.
