### PR TITLE
Support for arrays and JNI names in JClass

### DIFF
--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -18,6 +18,7 @@ package org.jpype.manager;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
@@ -159,61 +160,91 @@ public class TypeManager
    */
   public long findClassByName(String name)
   {
-    // Try it directly
-    Class<?> cls = null;
+    Class<?> cls = lookupByName(name);
+    if (cls == null)
+      return 0;
+    return this.findClass(cls);
+  }
+
+  public Class<?> lookupByName(String name)
+  {
+    // Handle arrays
+    if (name.endsWith("[]"))
+    {
+      int dims = 0;
+      while (name.endsWith("[]"))
+      {
+        dims++;
+        name = name.substring(0, name.length() - 2);
+      }
+      Class<?> cls = lookupByName(name);
+      if (cls == null)
+        return null;
+      return Array.newInstance(cls, new int[dims]).getClass();
+    }
+
     try
     {
-      cls = Class.forName(name);
+      // Attempt direct lookup
+      return Class.forName(name);
     } catch (ClassNotFoundException ex)
     {
     }
 
+    // Deal with JNI style names
+    if (name.contains("/"))
+    {
+      try
+      {
+        return Class.forName(name.replaceAll("/", "."));
+      } catch (ClassNotFoundException ex)
+      {
+      }
+    }
+
     // Special case for primitives
-    if (cls == null && !name.contains("."))
+    if (!name.contains("."))
     {
       if ("boolean".equals(name))
-        cls = Boolean.TYPE;
+        return Boolean.TYPE;
       if ("byte".equals(name))
-        cls = Byte.TYPE;
+        return Byte.TYPE;
       if ("char".equals(name))
-        cls = Character.TYPE;
+        return Character.TYPE;
       if ("short".equals(name))
-        cls = Short.TYPE;
+        return Short.TYPE;
       if ("long".equals(name))
-        cls = Long.TYPE;
+        return Long.TYPE;
       if ("int".equals(name))
-        cls = Integer.TYPE;
+        return Integer.TYPE;
       if ("float".equals(name))
-        cls = Float.TYPE;
+        return Float.TYPE;
       if ("double".equals(name))
-        cls = Double.TYPE;
+        return Double.TYPE;
     }
 
     // Attempt to find an inner class
-    if (cls == null)
+    String[] parts = name.split("\\.");
+    StringBuilder sb = new StringBuilder();
+    sb.append(parts[0]);
+    for (int i = 1; i < parts.length; ++i)
     {
-      String[] parts = name.split("\\.");
-      StringBuilder sb = new StringBuilder();
-      sb.append(parts[0]);
-      for (int i = 1; i < parts.length; ++i)
+      try
       {
-        try
+        sb.append(".");
+        sb.append(parts[i]);
+        Class<?> cls = Class.forName(sb.toString());
+        for (int j = i + 1; j < parts.length; ++j)
         {
-          sb.append(".");
-          sb.append(parts[i]);
-          cls = Class.forName(sb.toString());
-          for (int j = i + 1; j < parts.length; ++j)
-          {
-            sb.append("$");
-            sb.append(parts[j]);
-          }
-          cls = Class.forName(sb.toString());
-        } catch (ClassNotFoundException ex)
-        {
+          sb.append("$");
+          sb.append(parts[j]);
         }
+        return Class.forName(sb.toString());
+      } catch (ClassNotFoundException ex)
+      {
       }
     }
-    return this.findClass(cls);
+    return null;
   }
 
   public synchronized void populateMethod(long wrapper, Executable method)

--- a/test/jpypetest/test_jclass.py
+++ b/test/jpypetest/test_jclass.py
@@ -204,3 +204,21 @@ class JClassTestCase(common.JPypeTestCase):
         test = JClass("jpype.types.InnerTest")()
         test.test()
 
+    def testLookupGeneric(self):
+        self.assertEqual(JClass('java.util.ArrayList<>'), JClass("java.util.ArrayList"))
+
+    def testLookupJNI(self):
+        self.assertEqual(JClass('java/lang/Object'), JClass("java.lang.Object"))
+
+    def testLookupArray(self):
+        self.assertEqual(JClass('int[]'), JArray(JInt))
+        self.assertEqual(JClass('int[][]'), JArray(JInt,2))
+        self.assertEqual(JClass('int[][][]'), JArray(JInt,3))
+        self.assertEqual(JClass('java.lang.Object[][][]'), JArray(JObject,3))
+
+    def testLookupArrayJNI(self):
+        self.assertEqual(JClass('[I'), JArray(JInt))
+        self.assertEqual(JClass('[[J'), JArray(JLong,2))
+        self.assertEqual(JClass('[Ljava.lang.Object;'), JArray(JObject))
+        self.assertEqual(JClass('[Ljava/lang/Object;'), JArray(JObject))
+


### PR DESCRIPTION
Simple enhancement to JClass to handle arrays and JNI names properly.

This enhancement fixes 
https://stackoverflow.com/questions/60906495/how-do-i-build-my-java-classes-to-not-result-in-noclassdeffoundexception-from-jp/61082786#61082786
