### PR TITLE
Fix shutdown sequence

### DIFF
--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -140,11 +140,6 @@ public:
 		return m_JavaContext.get();
 	}
 
-	bool isShutdown()
-	{
-		return m_IsShutdown;
-	}
-
 	/** Release a global reference checking for shutdown.
 	 *
 	 * This should be used in any calls to release resources from a destructor.
@@ -223,7 +218,7 @@ private:
 	jint(JNICALL * CreateJVM_Method)(JavaVM **pvm, void **penv, void *args);
 	jint(JNICALL * GetCreatedJVMs_Method)(JavaVM **pvm, jsize size, jsize * nVms);
 
-	static JNIEXPORT void JNICALL onShutdown(JNIEnv *env, jlong contextPtr);
+	static JNIEXPORT void JNICALL onShutdown(JNIEnv *env, jobject obj, jlong contextPtr);
 
 private:
 	JPContext(const JPContext& orig);
@@ -262,8 +257,7 @@ private:
 	jmethodID m_Context_OrderID;
 	jmethodID m_Object_GetClassID;
 private:
-	bool m_IsShutdown;
-	bool m_IsInitialized;
+	bool m_Running;
 	bool m_ConvertStrings;
 public:
 	JPGarbageCollection *m_GC;

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -91,6 +91,8 @@ jarray JPClass::newArrayInstance(JPJavaFrame& frame, jsize sz)
 //</editor-fold>
 //<editor-fold desc="acccessors" defaultstate="collapsed">
 
+// GCOVR_EXCL_START
+// This is currently only used in tracing
 string JPClass::toString() const
 {
 	// This sanity check will not be hit in normal operation
@@ -99,6 +101,7 @@ string JPClass::toString() const
 	JPJavaFrame frame(m_Context);
 	return frame.toString(m_Class.get());
 }
+// GCOVR_EXCL_STOP
 
 string JPClass::getName() const
 {

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -83,8 +83,7 @@ JPContext::JPContext()
 
 	m_Object_ToStringID = 0;
 	m_Object_EqualsID = 0;
-	m_IsShutdown = false;
-	m_IsInitialized = false;
+	m_Running = false;
 	m_GC = new JPGarbageCollection(this);
 }
 
@@ -99,7 +98,7 @@ JPContext::~JPContext()
 
 bool JPContext::isRunning()
 {
-	if (m_JavaVM == NULL || !m_IsInitialized)
+	if (m_JavaVM == NULL || !m_Running)
 	{
 		return false;
 	}
@@ -273,13 +272,13 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		// throw std::runtime_error("Failed");
 		// Everything is started.
 	}
-	m_IsInitialized = true;
+	m_Running = true;
 	JP_TRACE_OUT;
 }
 
-JNIEXPORT void JNICALL JPContext::onShutdown(JNIEnv *env, jlong contextPtr)
+JNIEXPORT void JNICALL JPContext::onShutdown(JNIEnv *env, jobject obj, jlong contextPtr)
 {
-	((JPContext*) contextPtr)->m_IsShutdown = true;
+	((JPContext*) contextPtr)->m_Running = false;
 }
 
 void JPContext::shutdownJVM()

--- a/native/common/jp_gc.cpp
+++ b/native/common/jp_gc.cpp
@@ -112,14 +112,21 @@ void JPGarbageCollection::shutdown()
 
 void JPGarbageCollection::onStart()
 {
+	// GCOVR_EXCL_START
+	// GC is triggered outside of user control.  Including it in
+	// coverage just creates random statistics.
 	if (!running)
 		return;
 	getWorkingSize();
 	in_python_gc = true;
+	// GCOVR_EXCL_STOP
 }
 
 void JPGarbageCollection::onEnd()
 {
+	// GCOVR_EXCL_START
+	// GC is triggered outside of user control.  Including it in
+	// coverage just creates random statistics.
 	if (!running)
 		return;
 	if (java_triggered)
@@ -188,6 +195,7 @@ void JPGarbageCollection::onEnd()
 			python_triggered++;
 		}
 	}
+	// GCOVR_EXCL_END
 }
 
 void JPGarbageCollection::getStats(JPGCStats& stats)

--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -19,11 +19,13 @@ package org.jpype;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.Buffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jpype.manager.TypeFactory;
 import org.jpype.manager.TypeFactoryNative;
@@ -110,7 +112,7 @@ public class JPypeContext
       @Override
       public void run()
       {
-        instance.watchShutdown();
+        instance.shutdown();
       }
     }));
 
@@ -128,74 +130,97 @@ public class JPypeContext
    * fashion. Inherently this is a very dangerous time as portions of Java have
    * already been deactivated.
    */
-  private void watchShutdown()
+  @SuppressWarnings(
+          {
+            "CallToThreadYield", "SleepWhileInLoop"
+          })
+  private void shutdown()
   {
-    // Try to yield in case there is a race condition.  The user
-    // may have installed a shutdown hook, but we cannot verify
-    // the order that shutdown hook threads are executed.  Thus we will
-    // try to intentionally lose the race.
-    //
-    // This will only occur if something registered a shutdown hook through
-    // a Java API.  Those registered though the JPype API will be joined
-    // manually.
-    for (int i = 0; i < 5; i++)
+    try
     {
-      try
-      {
-        Thread.sleep(1);
-        Thread.yield();
-      } catch (InterruptedException ex)
-      {
-      }
-    }
-
-    // Execute any used defined shutdown hooks registered with JPype.
-    if (!this.shutdownHooks.isEmpty())
-    {
-      for (Thread thread : this.shutdownHooks)
-      {
-        thread.start();
-      }
-      for (Thread thread : this.shutdownHooks)
+      // Try to yield in case there is a race condition.  The user
+      // may have installed a shutdown hook, but we cannot verify
+      // the order that shutdown hook threads are executed.  Thus we will
+      // try to intentionally lose the race.
+      //
+      // This will only occur if something registered a shutdown hook through
+      // a Java API.  Those registered though the JPype API will be joined
+      // manually.
+      for (int i = 0; i < 5; i++)
       {
         try
         {
-          thread.join();
+          Thread.sleep(1);
+          Thread.yield();
         } catch (InterruptedException ex)
         {
         }
       }
-    }
 
-    // Disable all future calls to proxies
-    this.shutdownFlag.incrementAndGet();
-
-    // Wait for any unregistered proxies to finish so that we don't yank
-    // the rug out from under them result in a segfault.
-    while (this.proxyCount.get() > 0)
-    {
-      try
+      // Execute any used defined shutdown hooks registered with JPype.
+      if (!this.shutdownHooks.isEmpty())
       {
-        Thread.sleep(100);
-      } catch (InterruptedException ex)
-      {
+        for (Thread thread : this.shutdownHooks)
+        {
+          thread.start();
+        }
+        for (Thread thread : this.shutdownHooks)
+        {
+          try
+          {
+            thread.join();
+          } catch (InterruptedException ex)
+          {
+          }
+        }
       }
+
+      // Disable all future calls to proxies
+      this.shutdownFlag.incrementAndGet();
+
+      // Past this point any further execution of a Python proxy would
+      // be fatal.
+      Thread t1 = Thread.currentThread();
+      Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
+
+      for (Thread t : threads.keySet())
+      {
+        if (t1 == t)
+          continue;
+//      if (t.getState() == Thread.State.RUNNABLE)
+        t.interrupt();
+      }
+
+      // Inform Python no more calls are permitted
+      onShutdown(this.context);
+      Thread.yield();
+
+      // Wait for any unregistered proxies to finish so that we don't yank
+      // the rug out from under them result in a segfault.
+      while (this.proxyCount.get() > 0)
+      {
+        try
+        {
+          Thread.sleep(10);
+        } catch (InterruptedException ex)
+        {
+        }
+      }
+
+//    // Check to see if who is alive
+//    threads = Thread.getAllStackTraces();
+//    System.out.println("Check for remaining");
+//    for (Thread t : threads.keySet())
+//    {
+//      System.out.println("  " + t.getName() + " " + t.getState());
+//      for (StackTraceElement e : t.getValue())
+//      {
+//        System.out.println("    " + e.getClassName());
+//      }
+//    }
+    } catch (Throwable th)
+    {
     }
-
-    // Kill all remaining Python resources
-    shutdown();
-  }
-
-  /**
-   * Stop all JPype resources.
-   *
-   * This code is part of a shutdown hook so it should be bomb proof.
-   *
-   */
-  void shutdown()
-  {
-    // Inform Python no more calls are permitted
-    onShutdown(this.context);
 
     // Release all Python references
     try
@@ -457,6 +482,38 @@ public class JPypeContext
     if (b instanceof java.nio.DoubleBuffer)
       return ((java.nio.DoubleBuffer) b).order() == ByteOrder.LITTLE_ENDIAN;
     return true;
+  }
+
+  /**
+   * Utility to probe functional interfaces.
+   *
+   * @param cls
+   * @return
+   */
+  public String getFunctional(Class cls)
+  {
+    // If we don't find it to be a functional interface, then we won't return
+    // the SAM.
+    if (cls.getDeclaredAnnotation(FunctionalInterface.class) == null)
+      return null;
+    for (Method m : cls.getMethods())
+    {
+      if (Modifier.isAbstract(m.getModifiers()))
+      {
+        // This is a very odd construct.  Java allows for java.lang.Object
+        // methods to declared in FunctionalInterfaces and they don't count
+        // towards the single abstract method. So we have to probe the class
+        // until we find something that fails.
+        try
+        {
+          Object.class.getMethod(m.getName(), m.getParameterTypes());
+        } catch (NoSuchMethodException | SecurityException ex)
+        {
+          return m.getName();
+        }
+      }
+    }
+    return null;
   }
 
 }

--- a/native/java/org/jpype/proxy/JPypeProxy.java
+++ b/native/java/org/jpype/proxy/JPypeProxy.java
@@ -68,28 +68,28 @@ public class JPypeProxy implements InvocationHandler
   public Object invoke(Object proxy, Method method, Object[] args)
           throws Throwable
   {
-    if (context.isShutdown())
-      throw new RuntimeException("Proxy called during shutdown");
-
-    // We can save a lot of effort on the C++ side by doing all the
-    // type lookup work here.
-    TypeManager typeManager = context.getTypeManager();
-    long returnType;
-    long[] parameterTypes;
-    synchronized (typeManager)
-    {
-      returnType = typeManager.findClass(method.getReturnType());
-      Class<?>[] types = method.getParameterTypes();
-      parameterTypes = new long[types.length];
-      for (int i = 0; i < types.length; ++i)
-      {
-        parameterTypes[i] = typeManager.findClass(types[i]);
-      }
-    }
-
     try
     {
       context.incrementProxy();
+      if (context.isShutdown())
+        throw new RuntimeException("Proxy called during shutdown");
+
+      // We can save a lot of effort on the C++ side by doing all the
+      // type lookup work here.
+      TypeManager typeManager = context.getTypeManager();
+      long returnType;
+      long[] parameterTypes;
+      synchronized (typeManager)
+      {
+        returnType = typeManager.findClass(method.getReturnType());
+        Class<?>[] types = method.getParameterTypes();
+        parameterTypes = new long[types.length];
+        for (int i = 0; i < types.length; ++i)
+        {
+          parameterTypes[i] = typeManager.findClass(types[i]);
+        }
+      }
+
       return hostInvoke(context.getContext(), method.getName(), instance, returnType, parameterTypes, args);
     } finally
     {

--- a/native/java/org/jpype/ref/JPypeReferenceQueue.java
+++ b/native/java/org/jpype/ref/JPypeReferenceQueue.java
@@ -68,7 +68,7 @@ final public class JPypeReferenceQueue extends ReferenceQueue
   public void start()
   {
     isStopped = false;
-    queueThread = new Thread(new Worker());
+    queueThread = new Thread(new Worker(), "Python Reference Queue");
     queueThread.setDaemon(true);
     queueThread.start();
   }

--- a/native/java/org/jpype/ref/JPypeReferenceSet.java
+++ b/native/java/org/jpype/ref/JPypeReferenceSet.java
@@ -1,7 +1,6 @@
 package org.jpype.ref;
 
 import java.util.ArrayList;
-import static org.jpype.ref.JPypeReferenceQueue.removeHostReference;
 
 /**
  *

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -128,7 +128,7 @@ static Py_ssize_t PyJPArray_len(PyJPArray *self)
 	JP_PY_TRY("PyJPArray_len");
 	PyJPModule_getContext();
 	if (self->m_Array == NULL)
-		JP_RAISE(PyExc_ValueError, "Null array");
+		JP_RAISE(PyExc_ValueError, "Null array"); // GCOVR_EXCL_LINE
 	return self->m_Array->getLength();
 	JP_PY_CATCH(-1);
 }

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -16,17 +16,10 @@ static void PyJPBuffer_dealloc(PyJPBuffer *self)
 	JP_PY_CATCH();
 }
 
-static PyObject *PyJPBuffer_repr(PyJPBuffer *self)
+static PyObject *PyJPBuffer_repr(PyJPArray *self)
 {
 	JP_PY_TRY("PyJPBuffer_repr");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame(context);
-	if (self->m_Buffer == NULL)
-		JP_RAISE(PyExc_ValueError, "Null array");
-	stringstream sout;
-
-	sout << "<java beffer " << self->m_Buffer->getClass()->toString() << ">";
-	return JPPyString::fromStringUTF8(sout.str()).keep();
+	return PyUnicode_FromFormat("<java buffer '%s'>", Py_TYPE(self)->tp_name);
 	JP_PY_CATCH(0);
 }
 

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -35,7 +35,7 @@ int PyJPBuffer_getBuffer(PyJPBuffer *self, Py_buffer *view, int flags)
 	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame(context);
 	if (self->m_Buffer == NULL)
-		JP_RAISE(PyExc_ValueError, "Null buffer");
+		JP_RAISE(PyExc_ValueError, "Null buffer"); // GCOVR_EXCL_LINE
 	try
 	{
 		JPBuffer *buffer = self->m_Buffer;

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -619,11 +619,7 @@ static PyObject *PyJPClass_convertToJava(PyJPClass *self, PyObject *other)
 static PyObject *PyJPClass_repr(PyJPClass *self)
 {
 	JP_PY_TRY("PyJPClass_repr");
-	string name;
-	if (self->m_Class == NULL)
-		name = ((PyTypeObject*) self)->tp_name;
-	else
-		name = self->m_Class->getCanonicalName();
+	string name = ((PyTypeObject*) self)->tp_name;
 	return PyUnicode_FromFormat("<java class '%s'>", name.c_str());
 	JP_PY_CATCH(0);
 }

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -474,7 +474,7 @@ static PyObject *PyJPModule_arrayFromBuffer(PyObject *module, PyObject *args, Py
 PyObject *PyJPModule_collect(PyObject* module, PyObject *obj)
 {
 	JPContext* context = JPContext_global;
-	if (context->isShutdown())
+	if (!context->isRunning())
 		Py_RETURN_NONE;
 	PyObject *a1 = PyTuple_GetItem(obj, 0);
 	if (!PyUnicode_Check(a1))


### PR DESCRIPTION
This addresses two bugs in the shutdown sequence:

- Daemon threads were still running and could execute during resource cleanup
- The shutdown flag was not being respected due to a bug in the parameter list in onShutdown

To improve this 
- Make before break was added to JProxy to prevent a race condition
- JPype attempts to send interrupt to all threads so that they may be serviced.
- disabling all Java calls was moved up in the sequence

This was tested against a series of sleep/call loops.   Python does not respect any sort of interrupt code as signals all divert to the main thread and they didn't plan for interruptions of blocking calls like sleep.  Therefore, it is impossible to make it so that Python code can't stall the process.  Further, there are always going to be edge cases (monitor held during interruption, exception thrown in exception handling).   But those are really user errors for failing to plan an orderly shutdown, and not really the sole responsibility of library.
