### PR TITLE
Quickfix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@
 
 pr:
   - master
+  - release
   - releases/*
 
 jobs:

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -3,10 +3,12 @@ Changelog
 
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
+- **0.7.4 - 4-28-2020**
+
   - Corrected a resource leak in arrays that affects array initialization, and variable
     argument methods.  
 
-  - Upgraded tracing and JNI checks to prevent future resource leaks.
+  - Upgraded diagnostic tracing and JNI checks to prevent future resource leaks.
 
 - **0.7.3 - 4-17-2020**
 

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog
 
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
+  - Corrected a resource leak in arrays that affects array initialization, and variable
+    argument methods.  
+
+  - Upgraded tracing and JNI checks to prevent future resource leaks.
+
 - **0.7.3 - 4-17-2020**
 
   - **Replaced type management system**, memory management for internal

--- a/docker/build_windows.sh
+++ b/docker/build_windows.sh
@@ -1,0 +1,4 @@
+~/env/python-3.5-conda/Scripts/python.exe -m pip wheel JPype1-0.7.4.tar.gz -w wheelhouse
+~/env/python-3.6-conda/Scripts/python.exe -m pip wheel JPype1-0.7.4.tar.gz -w wheelhouse
+~/env/python-3.7-conda/Scripts/python.exe -m pip wheel JPype1-0.7.4.tar.gz -w wheelhouse
+~/env/python-3.8-conda/Scripts/python.exe -m pip wheel JPype1-0.7.4.tar.gz -w wheelhouse

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -12,7 +12,7 @@
 #   cp38-cp38
 
 # Build each wheel
-VER=0.7.1
+VER=0.7.4
 for PLAT in x86_64 i686
 do
 	DOCKER_IMAGE=quay.io/pypa/manylinux1_$PLAT

--- a/jpype/__init__.py
+++ b/jpype/__init__.py
@@ -48,7 +48,7 @@ __all__.extend(_jclass.__all__)
 __all__.extend(_jcustomizer.__all__)
 __all__.extend(_gui.__all__)
 
-__version_info__ = (0, 7, 3)
+__version_info__ = (0, 7, 4)
 __version__ = ".".join(str(i) for i in __version_info__)
 
 

--- a/jpype/_classpath.py
+++ b/jpype/_classpath.py
@@ -6,6 +6,7 @@ __all__ = ['addClassPath', 'getClassPath']
 _CLASSPATHS = []
 _SEP = _os.path.pathsep
 
+
 def addClassPath(path1):
     """ Add a path to the Java class path
 

--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -182,6 +182,7 @@ class _JIterator(object):
     This customizer adds the Python iterator concept to classes
     that implement the Java Iterator interface.
     """
+
     def __next__(self):
         if self.hasNext():
             return self.next()
@@ -218,7 +219,8 @@ def _JInstantConversion(jcls, obj):
     nsec = int((utc-sec)*1e9)
     return jcls.ofEpochSecond(sec, nsec)
 
-if sys.version_info < (3,6):
+
+if sys.version_info < (3, 6):
     import pathlib
     @_jcustomizer.JConversion("java.nio.file.Path", instanceof=pathlib.PurePath)
     def _JPathConvert(jcls, obj):
@@ -228,7 +230,6 @@ if sys.version_info < (3,6):
     @_jcustomizer.JConversion("java.io.File", instanceof=pathlib.PurePath)
     def _JFileConvert(jcls, obj):
         return jcls(str(obj))
-
 
 
 @_jcustomizer.JConversion("java.nio.file.Path", attribute="__fspath__")

--- a/jpype/_jobject.py
+++ b/jpype/_jobject.py
@@ -107,7 +107,7 @@ def _JObjectFactory(v=None, tp=None):
         if not isinstance(tp, _jpype.JClass):
             import warnings
             warnings.warn("Using JObject with a Python type is deprecated.",
-                              category=DeprecationWarning, stacklevel=3)
+                          category=DeprecationWarning, stacklevel=3)
         tp = _jpype._object_classes[tp]
 
     # Given a Java class

--- a/jpype/_jstring.py
+++ b/jpype/_jstring.py
@@ -56,7 +56,7 @@ class _JStringProto(object):
         return self.contains(other)
 
     def __hash__(self):
-        if self == None: # lgtm [py/test-equals-none]
+        if self == None:  # lgtm [py/test-equals-none]
             return hash(None)
         return self.__str__().__hash__()
 

--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -401,4 +401,3 @@ class WindowsJVMFinder(JVMFinder):
             except OSError:
                 pass
         return None
-

--- a/jpype/pickle.py
+++ b/jpype/pickle.py
@@ -51,7 +51,7 @@ Example:
 Proxies and other JPype specific module resources cannot be pickled currently.
 
 Requires:
-    Python 2.7 or 3.6 or later
+    Python 3.6 or later
 
 """
 from __future__ import absolute_import

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -91,6 +91,7 @@ template <class type_t> PyObject *convertMultiArray(
 	frame.SetObjectArrayElement(contents, k++, a0);
 	jboolean isCopy;
 	void *mem = frame.getEnv()->GetPrimitiveArrayCritical(a0, &isCopy);
+	JP_TRACE_JAVA("GetPrimitiveArrayCritical", mem);
 	type_t *dest = (type_t*) mem;
 
 	Py_ssize_t step;
@@ -117,6 +118,7 @@ template <class type_t> PyObject *convertMultiArray(
 			}
 			// Commit the current section
 			indices[u] = 0;
+			JP_TRACE_JAVA("ReleasePrimitiveArrayCritical", mem);
 			frame.getEnv()->ReleasePrimitiveArrayCritical(a0, mem, JNI_COMMIT);
 			frame.DeleteLocalRef(a0);
 
@@ -127,6 +129,7 @@ template <class type_t> PyObject *convertMultiArray(
 			a0 = cls->newArrayInstance(frame, base);
 			frame.SetObjectArrayElement(contents, k++, a0);
 			mem = frame.getEnv()->GetPrimitiveArrayCritical(a0, &isCopy);
+			JP_TRACE_JAVA("GetPrimitiveArrayCritical", mem);
 			dest = (type_t*) mem;
 			src = buffer.getBufferPtr(indices);
 		}

--- a/native/common/include/jp_tracer.h
+++ b/native/common/include/jp_tracer.h
@@ -16,6 +16,8 @@
  *****************************************************************************/
 #ifndef _JP_TRACER_H__
 #define _JP_TRACER_H__
+#include <string>
+#include <sstream>
 
 // GCOVR_EXCL_START
 
@@ -33,6 +35,7 @@
 #define JP_TRACE(...) JPTracer::trace(__VA_ARGS__)
 #define JP_TRACE_LOCKS(...) JPypeTracer::traceLocks(__VA_ARGS__)
 #define JP_TRACE_PY(m, obj) JPypeTracer::tracePythonObject(m, obj)
+#define JP_TRACE_JAVA(m, obj) JPypeTracer::traceJavaObject(m, obj)
 #else
 #ifndef JP_INSTRUMENTATION
 #define JP_TRACE_IN(...) try { do {} while (0)
@@ -41,6 +44,7 @@
 #define JP_TRACE(...)
 #define JP_TRACE_LOCKS(...)
 #define JP_TRACE_PY(m, obj)
+#define JP_TRACE_JAVA(m, obj)
 #endif
 
 // Enable this option to get all the py referencing information
@@ -71,50 +75,51 @@ public:
 		}
 	}
 
+	static void traceJavaObject(const char *msg, const void* obj);
 	static void tracePythonObject(const char *msg, PyObject *ref);
 	static void traceLocks(const string& msg, void *ref);
 
-	static void trace1(const char *msg);
+	static void trace1(const char *src, const char *msg);
 	static void trace2(const char *msg1, const char *msg2);
 private:
 	static void traceIn(const char *msg, void *ref);
 	static void traceOut(const char *msg, bool error);
 } ;
 
-extern "C" bool _PyJPModule_trace;
+extern "C" int _PyJPModule_trace;
 namespace JPTracer
 {
 
 template <class T>
 inline void trace(const T& msg)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
-	stringstream str;
+	std::stringstream str;
 	str << msg;
-	JPypeTracer::trace1(str.str().c_str());
+	JPypeTracer::trace1(NULL, str.str().c_str());
 }
 
 inline void trace(const char *msg)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
-	JPypeTracer::trace1(msg);
+	JPypeTracer::trace1(NULL, msg);
 }
 
 template <class T1, class T2>
 inline void trace(const T1& msg1, const T2 & msg2)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
-	stringstream str;
+	std::stringstream str;
 	str << msg1 << " " << msg2;
-	JPypeTracer::trace1(str.str().c_str());
+	JPypeTracer::trace1(NULL, str.str().c_str());
 }
 
 inline void trace(const char *msg1, const char *msg2)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
 	JPypeTracer::trace2(msg1, msg2);
 }
@@ -122,31 +127,31 @@ inline void trace(const char *msg1, const char *msg2)
 template <class T1, class T2, class T3>
 inline void trace(const T1& msg1, const T2& msg2, const T3 & msg3)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
-	stringstream str;
+	std::stringstream str;
 	str << msg1 << " " << msg2 << " " << msg3;
-	JPypeTracer::trace1(str.str().c_str());
+	JPypeTracer::trace1(NULL, str.str().c_str());
 }
 
 template <class T1, class T2, class T3, class T4>
 inline void trace(const T1& msg1, const T2& msg2, const T3& msg3, const T4 & msg4)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
-	stringstream str;
+	std::stringstream str;
 	str << msg1 << " " << msg2 << " " << msg3 << " " << msg4;
-	JPypeTracer::trace1(str.str().c_str());
+	JPypeTracer::trace1(NULL, str.str().c_str());
 }
 
 template <class T1, class T2, class T3, class T4, class T5>
 inline void trace(const T1& msg1, const T2& msg2, const T3& msg3, const T4& msg4, const T5 & msg5)
 {
-	if (_PyJPModule_trace & 1 == 0)
+	if ((_PyJPModule_trace & 1) == 0)
 		return;
-	stringstream str;
+	std::stringstream str;
 	str << msg1 << " " << msg2 << " " << msg3 << " " << msg4 << " " << msg5;
-	JPypeTracer::trace1(str.str().c_str());
+	JPypeTracer::trace1(NULL, str.str().c_str());
 }
 }
 

--- a/native/common/include/jp_tracer.h
+++ b/native/common/include/jp_tracer.h
@@ -81,13 +81,15 @@ private:
 	static void traceOut(const char *msg, bool error);
 } ;
 
-
+extern "C" bool _PyJPModule_trace;
 namespace JPTracer
 {
 
 template <class T>
 inline void trace(const T& msg)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	stringstream str;
 	str << msg;
 	JPypeTracer::trace1(str.str().c_str());
@@ -95,12 +97,16 @@ inline void trace(const T& msg)
 
 inline void trace(const char *msg)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	JPypeTracer::trace1(msg);
 }
 
 template <class T1, class T2>
 inline void trace(const T1& msg1, const T2 & msg2)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	stringstream str;
 	str << msg1 << " " << msg2;
 	JPypeTracer::trace1(str.str().c_str());
@@ -108,12 +114,16 @@ inline void trace(const T1& msg1, const T2 & msg2)
 
 inline void trace(const char *msg1, const char *msg2)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	JPypeTracer::trace2(msg1, msg2);
 }
 
 template <class T1, class T2, class T3>
 inline void trace(const T1& msg1, const T2& msg2, const T3 & msg3)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	stringstream str;
 	str << msg1 << " " << msg2 << " " << msg3;
 	JPypeTracer::trace1(str.str().c_str());
@@ -122,6 +132,8 @@ inline void trace(const T1& msg1, const T2& msg2, const T3 & msg3)
 template <class T1, class T2, class T3, class T4>
 inline void trace(const T1& msg1, const T2& msg2, const T3& msg3, const T4 & msg4)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	stringstream str;
 	str << msg1 << " " << msg2 << " " << msg3 << " " << msg4;
 	JPypeTracer::trace1(str.str().c_str());
@@ -130,6 +142,8 @@ inline void trace(const T1& msg1, const T2& msg2, const T3& msg3, const T4 & msg
 template <class T1, class T2, class T3, class T4, class T5>
 inline void trace(const T1& msg1, const T2& msg2, const T3& msg3, const T4& msg4, const T5 & msg5)
 {
+	if (_PyJPModule_trace & 1 == 0)
+		return;
 	stringstream str;
 	str << msg1 << " " << msg2 << " " << msg3 << " " << msg4 << " " << msg5;
 	JPypeTracer::trace1(str.str().c_str());

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -75,8 +75,7 @@ jvalue JPArrayClass::convertToJavaVector(JPJavaFrame& frame, JPPyObjectVector& r
 	{
 		m_ComponentType->setArrayItem(frame, array, i - start, refs[i]);
 	}
-	//		res.l = array;
-	res.l = frame.keep(array); // BUGGY
+	res.l = array;
 	return res;
 	JP_TRACE_OUT;
 }
@@ -84,7 +83,6 @@ jvalue JPArrayClass::convertToJavaVector(JPJavaFrame& frame, JPPyObjectVector& r
 JPValue JPArrayClass::newInstance(JPJavaFrame& frame, int length)
 {
 	jvalue v;
-	//  	v.l = frame.keep(m_ComponentType->newArrayInstance(frame, length));
-	v.l = frame.keep(m_ComponentType->newArrayInstance(frame, length)); // BUGGY
+	v.l = m_ComponentType->newArrayInstance(frame, length);
 	return JPValue(this, v);
 }

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -75,7 +75,8 @@ jvalue JPArrayClass::convertToJavaVector(JPJavaFrame& frame, JPPyObjectVector& r
 	{
 		m_ComponentType->setArrayItem(frame, array, i - start, refs[i]);
 	}
-	res.l = frame.keep(array);
+	//		res.l = array;
+	res.l = frame.keep(array); // BUGGY
 	return res;
 	JP_TRACE_OUT;
 }
@@ -83,6 +84,7 @@ jvalue JPArrayClass::convertToJavaVector(JPJavaFrame& frame, JPPyObjectVector& r
 JPValue JPArrayClass::newInstance(JPJavaFrame& frame, int length)
 {
 	jvalue v;
-	v.l = frame.keep(m_ComponentType->newArrayInstance(frame, length));
+	//  	v.l = frame.keep(m_ComponentType->newArrayInstance(frame, length));
+	v.l = frame.keep(m_ComponentType->newArrayInstance(frame, length)); // BUGGY
 	return JPValue(this, v);
 }

--- a/native/common/jp_classloader.cpp
+++ b/native/common/jp_classloader.cpp
@@ -64,5 +64,5 @@ jclass JPClassLoader::findClass(JPJavaFrame& frame, string name)
 {
 	jvalue v;
 	v.l = frame.NewStringUTF(name.c_str());
-	return (jclass) frame.keep(frame.CallObjectMethodA(m_BootLoader.get(), m_FindClass, &v));
+	return (jclass) frame.CallObjectMethodA(m_BootLoader.get(), m_FindClass, &v);
 }

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -23,6 +23,7 @@
 //
 
 #if defined(JP_TRACING_ENABLE) || defined(JP_INSTRUMENTATION)
+
 static int jpype_frame_check(int i)
 {
 	static thread_local int depth = 0;
@@ -51,12 +52,13 @@ static int jpype_frame_check(int i)
 #else
 #define JP_FRAME_CHECK(X) if (true)
 #endif
+
 JPJavaFrame::JPJavaFrame(JPContext* context, JNIEnv* p_env, int i)
 : m_Context(context), m_Env(p_env), popped(false)
 {
 
 	// Create a memory management frame to live in
-	m_Env->functions->PushLocalFrame(m_Env, i);
+	m_Env->PushLocalFrame(i);
 	JP_TRACE_JAVA("JavaFrame", (jobject) - 1);
 	JP_FRAME_CHECK(1);
 }
@@ -67,7 +69,7 @@ JPJavaFrame::JPJavaFrame(JPContext* context, int i)
 	m_Env = context->getEnv();
 
 	// Create a memory management frame to live in
-	m_Env->functions->PushLocalFrame(m_Env, i);
+	m_Env->PushLocalFrame(i);
 	JP_TRACE_JAVA("JavaFrame", (jobject) - 1);
 	JP_FRAME_CHECK(1);
 }
@@ -76,7 +78,7 @@ JPJavaFrame::JPJavaFrame(const JPJavaFrame& frame)
 : m_Context(frame.m_Context), m_Env(frame.m_Env), popped(false)
 {
 	// Create a memory management frame to live in
-	m_Env->functions->PushLocalFrame(m_Env, LOCAL_FRAME_DEFAULT);
+	m_Env->PushLocalFrame(LOCAL_FRAME_DEFAULT);
 	JP_TRACE_JAVA("JavaFrame (copy)", (jobject) - 1);
 	JP_FRAME_CHECK(1);
 }
@@ -87,7 +89,7 @@ jobject JPJavaFrame::keep(jobject obj)
 	JP_TRACE_JAVA("Keep", obj);
 	JP_TRACE_JAVA("~JavaFrame (keep)", (jobject) - 2);
 	JP_FRAME_CHECK(-1);
-	obj = m_Env->functions->PopLocalFrame(m_Env, obj);
+	obj = m_Env->PopLocalFrame(obj);
 	JP_FRAME_CHECK(0);  // Special case we can't hold a reference after a keep
 	JP_TRACE_JAVA("Return", obj);
 	return obj;
@@ -99,7 +101,7 @@ JPJavaFrame::~JPJavaFrame()
 	if (!popped)
 	{
 		JP_TRACE_JAVA("~JavaFrame", (jobject) - 2);
-		m_Env->functions->PopLocalFrame(m_Env, NULL);
+		m_Env->PopLocalFrame(NULL);
 		JP_FRAME_CHECK(-1);
 	}
 
@@ -136,7 +138,7 @@ void JPJavaFrame::DeleteWeakGlobalRef(jweak obj)
 jobject JPJavaFrame::NewLocalRef(jobject obj)
 {
 	JP_TRACE_JAVA("New local", obj);
-	obj = m_Env->functions->NewLocalRef(m_Env, obj);
+	obj = m_Env->NewLocalRef(obj);
 	JP_TRACE_JAVA("Local", obj);
 	return obj;
 }
@@ -144,7 +146,7 @@ jobject JPJavaFrame::NewLocalRef(jobject obj)
 jobject JPJavaFrame::NewGlobalRef(jobject obj)
 {
 	JP_TRACE_JAVA("New Global", obj);
-	obj = m_Env->functions->NewGlobalRef(m_Env, obj);
+	obj = m_Env->NewGlobalRef(obj);
 	JP_TRACE_JAVA("Global", obj);
 	return obj;
 }
@@ -154,38 +156,38 @@ jobject JPJavaFrame::NewGlobalRef(jobject obj)
 
 bool JPJavaFrame::ExceptionCheck()
 {
-	return (m_Env->functions->ExceptionCheck(m_Env) ? true : false);
+	return (m_Env->ExceptionCheck() ? true : false);
 }
 
 void JPJavaFrame::ExceptionDescribe()
 {
-	m_Env->functions->ExceptionDescribe(m_Env);
+	m_Env->ExceptionDescribe();
 }
 
 void JPJavaFrame::ExceptionClear()
 {
-	m_Env->functions->ExceptionClear(m_Env);
+	m_Env->ExceptionClear();
 }
 
 jint JPJavaFrame::ThrowNew(jclass clazz, const char* msg)
 {
-	return m_Env->functions->ThrowNew(m_Env, clazz, msg);
+	return m_Env->ThrowNew(clazz, msg);
 }
 
 jint JPJavaFrame::Throw(jthrowable th)
 {
-	return m_Env->functions->Throw(m_Env, th);
+	return m_Env->Throw(th);
 }
 
 jthrowable JPJavaFrame::ExceptionOccurred()
 {
 	jthrowable obj;
 
-	obj = m_Env->functions->ExceptionOccurred(m_Env);
+	obj = m_Env->ExceptionOccurred();
 #ifdef JP_TRACING_ENABLE
 	if (obj)
 	{
-		m_Env->functions->ExceptionDescribe(m_Env);
+		m_Env->ExceptionDescribe();
 	}
 #endif
 	JP_TRACE_JAVA("Exception", obj);
@@ -229,11 +231,11 @@ jthrowable JPJavaFrame::ExceptionOccurred()
 void JPJavaFrame::check()
 {
 	JP_FRAME_CHECK(0);
-	if (m_Env && m_Env->functions->ExceptionCheck(m_Env) == JNI_TRUE)
+	if (m_Env && m_Env->ExceptionCheck() == JNI_TRUE)
 	{
-		jthrowable th = m_Env->functions->ExceptionOccurred(m_Env);
+		jthrowable th = m_Env->ExceptionOccurred();
 		JP_TRACE_JAVA("ExceptionOccurred", th);
-		m_Env->functions->ExceptionClear(m_Env);
+		m_Env->ExceptionClear();
 		JP_TRACE_JAVA("ExceptionClear", 0);
 		throw JPypeException(*this, th, JP_STACKINFO());
 	}
@@ -244,9 +246,9 @@ jobject JPJavaFrame::NewObjectA(jclass a0, jmethodID a1, jvalue* a2)
 	jobject res;
 	// Allocate the object
 	JAVA_CHECK("JPJavaFrame::JPJavaFrame::NewObjectA",
-			res = m_Env->functions->AllocObject(m_Env, a0));
+			res = m_Env->AllocObject(a0));
 	JAVA_CHECK("JPJavaFrame::NewObjectA::AllocObject",
-			m_Env->functions->CallVoidMethodA(m_Env, res, a1, a2));
+			m_Env->CallVoidMethodA(res, a1, a2));
 
 	JP_TRACE_JAVA("NewObjectA", res);
 	// Initialize the object
@@ -256,7 +258,7 @@ jobject JPJavaFrame::NewObjectA(jclass a0, jmethodID a1, jvalue* a2)
 jobject JPJavaFrame::NewDirectByteBuffer(void* address, jlong capacity)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::NewDirectByteBuffer",
-			m_Env->functions->NewDirectByteBuffer(m_Env, address, capacity));
+			m_Env->NewDirectByteBuffer(address, capacity));
 }
 
 /*****************************************************************************/
@@ -264,769 +266,769 @@ jobject JPJavaFrame::NewDirectByteBuffer(void* address, jlong capacity)
 jbyte JPJavaFrame::GetStaticByteField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::GetStaticByteField",
-			m_Env->functions->GetStaticByteField(m_Env, clazz, fid));
+			m_Env->GetStaticByteField(clazz, fid));
 }
 
 jbyte JPJavaFrame::GetByteField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::GetByteField",
-			m_Env->functions->GetByteField(m_Env, clazz, fid));
+			m_Env->GetByteField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticByteField(jclass clazz, jfieldID fid, jbyte val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticByteField",
-			m_Env->functions->SetStaticByteField(m_Env, clazz, fid, val));
+			m_Env->SetStaticByteField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetByteField(jobject clazz, jfieldID fid, jbyte val)
 {
 	JAVA_CHECK("JPJavaFrame::SetByteField",
-			m_Env->functions->SetByteField(m_Env, clazz, fid, val));
+			m_Env->SetByteField(clazz, fid, val));
 }
 
 jbyte JPJavaFrame::CallStaticByteMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::CallStaticByteMethodA",
-			m_Env->functions->CallStaticByteMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticByteMethodA(clazz, mid, val));
 }
 
 jbyte JPJavaFrame::CallByteMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::CallByteMethodA",
-			m_Env->functions->CallByteMethodA(m_Env, obj, mid, val));
+			m_Env->CallByteMethodA(obj, mid, val));
 }
 
 jbyte JPJavaFrame::CallNonvirtualByteMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::CallNonvirtualByteMethodA",
-			m_Env->functions->CallNonvirtualByteMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualByteMethodA(obj, claz, mid, val));
 }
 
 jshort JPJavaFrame::GetStaticShortField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::GetStaticShortField",
-			m_Env->functions->GetStaticShortField(m_Env, clazz, fid));
+			m_Env->GetStaticShortField(clazz, fid));
 }
 
 jshort JPJavaFrame::GetShortField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::GetShortField",
-			m_Env->functions->GetShortField(m_Env, clazz, fid));
+			m_Env->GetShortField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticShortField(jclass clazz, jfieldID fid, jshort val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticShortField",
-			m_Env->functions->SetStaticShortField(m_Env, clazz, fid, val));
+			m_Env->SetStaticShortField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetShortField(jobject clazz, jfieldID fid, jshort val)
 {
 	JAVA_CHECK("JPJavaFrame::SetShortField",
-			m_Env->functions->SetShortField(m_Env, clazz, fid, val));
+			m_Env->SetShortField(clazz, fid, val));
 }
 
 jshort JPJavaFrame::CallStaticShortMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::CallStaticShortMethodA",
-			m_Env->functions->CallStaticShortMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticShortMethodA(clazz, mid, val));
 }
 
 jshort JPJavaFrame::CallShortMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::CallShortMethodA",
-			m_Env->functions->CallShortMethodA(m_Env, obj, mid, val));
+			m_Env->CallShortMethodA(obj, mid, val));
 }
 
 jshort JPJavaFrame::CallNonvirtualShortMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::CallNonvirtualShortMethodA",
-			m_Env->functions->CallNonvirtualShortMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualShortMethodA(obj, claz, mid, val));
 }
 
 jint JPJavaFrame::GetStaticIntField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::GetStaticIntField",
-			m_Env->functions->GetStaticIntField(m_Env, clazz, fid));
+			m_Env->GetStaticIntField(clazz, fid));
 }
 
 jint JPJavaFrame::GetIntField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::GetIntField",
-			m_Env->functions->GetIntField(m_Env, clazz, fid));
+			m_Env->GetIntField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticIntField(jclass clazz, jfieldID fid, jint val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticIntField",
-			m_Env->functions->SetStaticIntField(m_Env, clazz, fid, val));
+			m_Env->SetStaticIntField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetIntField(jobject clazz, jfieldID fid, jint val)
 {
 	JAVA_CHECK("JPJavaFrame::SetIntField",
-			m_Env->functions->SetIntField(m_Env, clazz, fid, val));
+			m_Env->SetIntField(clazz, fid, val));
 }
 
 jint JPJavaFrame::CallStaticIntMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::CallStaticIntMethodA",
-			m_Env->functions->CallStaticIntMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticIntMethodA(clazz, mid, val));
 }
 
 jint JPJavaFrame::CallIntMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::CallIntMethodA",
-			m_Env->functions->CallIntMethodA(m_Env, obj, mid, val));
+			m_Env->CallIntMethodA(obj, mid, val));
 }
 
 jint JPJavaFrame::CallNonvirtualIntMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::CallNonvirtualIntMethodA",
-			m_Env->functions->CallNonvirtualIntMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualIntMethodA(obj, claz, mid, val));
 }
 
 jlong JPJavaFrame::GetStaticLongField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::GetStaticLongField",
-			m_Env->functions->GetStaticLongField(m_Env, clazz, fid));
+			m_Env->GetStaticLongField(clazz, fid));
 }
 
 jlong JPJavaFrame::GetLongField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::GetLongField",
-			m_Env->functions->GetLongField(m_Env, clazz, fid));
+			m_Env->GetLongField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticLongField(jclass clazz, jfieldID fid, jlong val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticLongField",
-			m_Env->functions->SetStaticLongField(m_Env, clazz, fid, val));
+			m_Env->SetStaticLongField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetLongField(jobject clazz, jfieldID fid, jlong val)
 {
 	JAVA_CHECK("JPJavaFrame::SetLongField",
-			m_Env->functions->SetLongField(m_Env, clazz, fid, val));
+			m_Env->SetLongField(clazz, fid, val));
 }
 
 jlong JPJavaFrame::CallStaticLongMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::CallStaticLongMethodA",
-			m_Env->functions->CallStaticLongMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticLongMethodA(clazz, mid, val));
 }
 
 jlong JPJavaFrame::CallLongMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::CallLongMethodA",
-			m_Env->functions->CallLongMethodA(m_Env, obj, mid, val));
+			m_Env->CallLongMethodA(obj, mid, val));
 }
 
 jlong JPJavaFrame::CallNonvirtualLongMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::CallNonvirtualLongMethodA",
-			m_Env->functions->CallNonvirtualLongMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualLongMethodA(obj, claz, mid, val));
 }
 
 jfloat JPJavaFrame::GetStaticFloatField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::GetStaticFloatField",
-			m_Env->functions->GetStaticFloatField(m_Env, clazz, fid));
+			m_Env->GetStaticFloatField(clazz, fid));
 }
 
 jfloat JPJavaFrame::GetFloatField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::GetFloatField",
-			m_Env->functions->GetFloatField(m_Env, clazz, fid));
+			m_Env->GetFloatField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticFloatField(jclass clazz, jfieldID fid, jfloat val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticFloatField",
-			m_Env->functions->SetStaticFloatField(m_Env, clazz, fid, val));
+			m_Env->SetStaticFloatField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetFloatField(jobject clazz, jfieldID fid, jfloat val)
 {
 	JAVA_CHECK("JPJavaFrame::SetFloatField",
-			m_Env->functions->SetFloatField(m_Env, clazz, fid, val));
+			m_Env->SetFloatField(clazz, fid, val));
 }
 
 jfloat JPJavaFrame::CallStaticFloatMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::CallStaticFloatMethodA",
-			m_Env->functions->CallStaticFloatMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticFloatMethodA(clazz, mid, val));
 }
 
 jfloat JPJavaFrame::CallFloatMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::CallFloatMethodA",
-			m_Env->functions->CallFloatMethodA(m_Env, obj, mid, val));
+			m_Env->CallFloatMethodA(obj, mid, val));
 }
 
 jfloat JPJavaFrame::CallNonvirtualFloatMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::CallNonvirtualFloatMethodA",
-			m_Env->functions->CallNonvirtualFloatMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualFloatMethodA(obj, claz, mid, val));
 }
 
 jdouble JPJavaFrame::GetStaticDoubleField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::GetStaticDoubleField",
-			m_Env->functions->GetStaticDoubleField(m_Env, clazz, fid));
+			m_Env->GetStaticDoubleField(clazz, fid));
 }
 
 jdouble JPJavaFrame::GetDoubleField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::GetDoubleField",
-			m_Env->functions->GetDoubleField(m_Env, clazz, fid));
+			m_Env->GetDoubleField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticDoubleField(jclass clazz, jfieldID fid, jdouble val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticDoubleField",
-			m_Env->functions->SetStaticDoubleField(m_Env, clazz, fid, val));
+			m_Env->SetStaticDoubleField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetDoubleField(jobject clazz, jfieldID fid, jdouble val)
 {
 	JAVA_CHECK("JPJavaFrame::SetDoubleField",
-			m_Env->functions->SetDoubleField(m_Env, clazz, fid, val));
+			m_Env->SetDoubleField(clazz, fid, val));
 }
 
 jdouble JPJavaFrame::CallStaticDoubleMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::CallStaticDoubleMethodA",
-			m_Env->functions->CallStaticDoubleMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticDoubleMethodA(clazz, mid, val));
 }
 
 jdouble JPJavaFrame::CallDoubleMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::CallDoubleMethodA",
-			m_Env->functions->CallDoubleMethodA(m_Env, obj, mid, val));
+			m_Env->CallDoubleMethodA(obj, mid, val));
 }
 
 jdouble JPJavaFrame::CallNonvirtualDoubleMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::CallNonvirtualDoubleMethodA",
-			m_Env->functions->CallNonvirtualDoubleMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualDoubleMethodA(obj, claz, mid, val));
 }
 
 jchar JPJavaFrame::GetStaticCharField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::GetStaticCharField",
-			m_Env->functions->GetStaticCharField(m_Env, clazz, fid));
+			m_Env->GetStaticCharField(clazz, fid));
 }
 
 jchar JPJavaFrame::GetCharField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::GetCharField",
-			m_Env->functions->GetCharField(m_Env, clazz, fid));
+			m_Env->GetCharField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticCharField(jclass clazz, jfieldID fid, jchar val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticCharField",
-			m_Env->functions->SetStaticCharField(m_Env, clazz, fid, val));
+			m_Env->SetStaticCharField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetCharField(jobject clazz, jfieldID fid, jchar val)
 {
 	JAVA_CHECK("JPJavaFrame::SetCharField",
-			m_Env->functions->SetCharField(m_Env, clazz, fid, val));
+			m_Env->SetCharField(clazz, fid, val));
 }
 
 jchar JPJavaFrame::CallStaticCharMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::CallStaticCharMethodA",
-			m_Env->functions->CallStaticCharMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticCharMethodA(clazz, mid, val));
 }
 
 jchar JPJavaFrame::CallCharMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::CallCharMethodA",
-			m_Env->functions->CallCharMethodA(m_Env, obj, mid, val));
+			m_Env->CallCharMethodA(obj, mid, val));
 }
 
 jchar JPJavaFrame::CallNonvirtualCharMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::CallNonvirtualCharMethodA",
-			m_Env->functions->CallNonvirtualCharMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualCharMethodA(obj, claz, mid, val));
 }
 
 jboolean JPJavaFrame::GetStaticBooleanField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::GetStaticBooleanField",
-			m_Env->functions->GetStaticBooleanField(m_Env, clazz, fid));
+			m_Env->GetStaticBooleanField(clazz, fid));
 }
 
 jboolean JPJavaFrame::GetBooleanField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::GetBooleanField",
-			m_Env->functions->GetBooleanField(m_Env, clazz, fid));
+			m_Env->GetBooleanField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticBooleanField(jclass clazz, jfieldID fid, jboolean val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticBooleanField",
-			m_Env->functions->SetStaticBooleanField(m_Env, clazz, fid, val));
+			m_Env->SetStaticBooleanField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetBooleanField(jobject clazz, jfieldID fid, jboolean val)
 {
 	JAVA_CHECK("JPJavaFrame::SetBooleanField",
-			m_Env->functions->SetBooleanField(m_Env, clazz, fid, val));
+			m_Env->SetBooleanField(clazz, fid, val));
 }
 
 jboolean JPJavaFrame::CallStaticBooleanMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::CallStaticBooleanMethodA",
-			m_Env->functions->CallStaticBooleanMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticBooleanMethodA(clazz, mid, val));
 }
 
 jboolean JPJavaFrame::CallBooleanMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::CallBooleanMethodA",
-			m_Env->functions->CallBooleanMethodA(m_Env, obj, mid, val));
+			m_Env->CallBooleanMethodA(obj, mid, val));
 }
 
 jboolean JPJavaFrame::CallNonvirtualBooleanMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::CallNonvirtualBooleanMethodA",
-			m_Env->functions->CallNonvirtualBooleanMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualBooleanMethodA(obj, claz, mid, val));
 }
 
 jobject JPJavaFrame::GetStaticObjectField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::GetStaticObjectField",
-			m_Env->functions->GetStaticObjectField(m_Env, clazz, fid));
+			m_Env->GetStaticObjectField(clazz, fid));
 }
 
 jobject JPJavaFrame::GetObjectField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::GetObjectField",
-			m_Env->functions->GetObjectField(m_Env, clazz, fid));
+			m_Env->GetObjectField(clazz, fid));
 }
 
 void JPJavaFrame::SetStaticObjectField(jclass clazz, jfieldID fid, jobject val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticObjectField",
-			m_Env->functions->SetStaticObjectField(m_Env, clazz, fid, val));
+			m_Env->SetStaticObjectField(clazz, fid, val));
 }
 
 void JPJavaFrame::SetObjectField(jobject clazz, jfieldID fid, jobject val)
 {
 	JAVA_CHECK("JPJavaFrame::SetObjectField",
-			m_Env->functions->SetObjectField(m_Env, clazz, fid, val));
+			m_Env->SetObjectField(clazz, fid, val));
 }
 
 jobject JPJavaFrame::CallStaticObjectMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::CallStaticObjectMethodA",
-			m_Env->functions->CallStaticObjectMethodA(m_Env, clazz, mid, val));
+			m_Env->CallStaticObjectMethodA(clazz, mid, val));
 }
 
 jobject JPJavaFrame::CallObjectMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::CallObjectMethodA",
-			m_Env->functions->CallObjectMethodA(m_Env, obj, mid, val));
+			m_Env->CallObjectMethodA(obj, mid, val));
 }
 
 jobject JPJavaFrame::CallNonvirtualObjectMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::CallNonvirtualObjectMethodA",
-			m_Env->functions->CallNonvirtualObjectMethodA(m_Env, obj, claz, mid, val));
+			m_Env->CallNonvirtualObjectMethodA(obj, claz, mid, val));
 }
 
 jbyteArray JPJavaFrame::NewByteArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jbyteArray, "JPJavaFrame::NewByteArray",
-			m_Env->functions->NewByteArray(m_Env, len));
+			m_Env->NewByteArray(len));
 }
 
 void JPJavaFrame::SetByteArrayRegion(jbyteArray array, jsize start, jsize len, jbyte* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetByteArrayRegion",
-			m_Env->functions->SetByteArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetByteArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetByteArrayRegion(jbyteArray array, jsize start, jsize len, jbyte* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetByteArrayRegion",
-			m_Env->functions->GetByteArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetByteArrayRegion(array, start, len, vals));
 }
 
 jbyte* JPJavaFrame::GetByteArrayElements(jbyteArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jbyte*, "JPJavaFrame::GetByteArrayElements",
-			m_Env->functions->GetByteArrayElements(m_Env, array, isCopy));
+			m_Env->GetByteArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseByteArrayElements(jbyteArray array, jbyte* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseByteArrayElements",
-			m_Env->functions->ReleaseByteArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseByteArrayElements(array, v, mode));
 }
 
 jshortArray JPJavaFrame::NewShortArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jshortArray, "JPJavaFrame::NewShortArray",
-			m_Env->functions->NewShortArray(m_Env, len));
+			m_Env->NewShortArray(len));
 }
 
 void JPJavaFrame::SetShortArrayRegion(jshortArray array, jsize start, jsize len, jshort* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetShortArrayRegion",
-			m_Env->functions->SetShortArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetShortArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetShortArrayRegion(jshortArray array, jsize start, jsize len, jshort* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetShortArrayRegion",
-			m_Env->functions->GetShortArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetShortArrayRegion(array, start, len, vals));
 }
 
 jshort* JPJavaFrame::GetShortArrayElements(jshortArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jshort*, "JPJavaFrame::GetShortArrayElements",
-			m_Env->functions->GetShortArrayElements(m_Env, array, isCopy));
+			m_Env->GetShortArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseShortArrayElements(jshortArray array, jshort* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseShortArrayElements",
-			m_Env->functions->ReleaseShortArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseShortArrayElements(array, v, mode));
 }
 
 jintArray JPJavaFrame::NewIntArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jintArray, "JPJavaFrame::NewIntArray",
-			m_Env->functions->NewIntArray(m_Env, len));
+			m_Env->NewIntArray(len));
 }
 
 void JPJavaFrame::SetIntArrayRegion(jintArray array, jsize start, jsize len, jint* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetIntArrayRegion",
-			m_Env->functions->SetIntArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetIntArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetIntArrayRegion(jintArray array, jsize start, jsize len, jint* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetIntArrayRegion",
-			m_Env->functions->GetIntArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetIntArrayRegion(array, start, len, vals));
 }
 
 jint* JPJavaFrame::GetIntArrayElements(jintArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jint*, "JPJavaFrame::GetIntArrayElements",
-			m_Env->functions->GetIntArrayElements(m_Env, array, isCopy));
+			m_Env->GetIntArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseIntArrayElements(jintArray array, jint* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseIntArrayElements",
-			m_Env->functions->ReleaseIntArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseIntArrayElements(array, v, mode));
 }
 
 jlongArray JPJavaFrame::NewLongArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jlongArray, "JPJavaFrame::NewLongArray",
-			m_Env->functions->NewLongArray(m_Env, len));
+			m_Env->NewLongArray(len));
 }
 
 void JPJavaFrame::SetLongArrayRegion(jlongArray array, jsize start, jsize len, jlong* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetLongArrayRegion",
-			m_Env->functions->SetLongArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetLongArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetLongArrayRegion(jlongArray array, jsize start, jsize len, jlong* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetLongArrayRegion",
-			m_Env->functions->GetLongArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetLongArrayRegion(array, start, len, vals));
 }
 
 jlong* JPJavaFrame::GetLongArrayElements(jlongArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jlong*, "JPJavaFrame::GetLongArrayElements",
-			m_Env->functions->GetLongArrayElements(m_Env, array, isCopy));
+			m_Env->GetLongArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseLongArrayElements(jlongArray array, jlong* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseLongArrayElements",
-			m_Env->functions->ReleaseLongArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseLongArrayElements(array, v, mode));
 }
 
 jfloatArray JPJavaFrame::NewFloatArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jfloatArray, "JPJavaFrame::NewFloatArray",
-			m_Env->functions->NewFloatArray(m_Env, len));
+			m_Env->NewFloatArray(len));
 }
 
 void JPJavaFrame::SetFloatArrayRegion(jfloatArray array, jsize start, jsize len, jfloat* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetFloatArrayRegion",
-			m_Env->functions->SetFloatArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetFloatArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetFloatArrayRegion(jfloatArray array, jsize start, jsize len, jfloat* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetFloatArrayRegion",
-			m_Env->functions->GetFloatArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetFloatArrayRegion(array, start, len, vals));
 }
 
 jfloat* JPJavaFrame::GetFloatArrayElements(jfloatArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jfloat*, "JPJavaFrame::GetFloatArrayElements",
-			m_Env->functions->GetFloatArrayElements(m_Env, array, isCopy));
+			m_Env->GetFloatArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseFloatArrayElements(jfloatArray array, jfloat* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseFloatArrayElements",
-			m_Env->functions->ReleaseFloatArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseFloatArrayElements(array, v, mode));
 }
 
 jdoubleArray JPJavaFrame::NewDoubleArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jdoubleArray, "JPJavaFrame::NewDoubleArray",
-			m_Env->functions->NewDoubleArray(m_Env, len));
+			m_Env->NewDoubleArray(len));
 }
 
 void JPJavaFrame::SetDoubleArrayRegion(jdoubleArray array, jsize start, jsize len, jdouble* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetDoubleArrayRegion",
-			m_Env->functions->SetDoubleArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetDoubleArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetDoubleArrayRegion(jdoubleArray array, jsize start, jsize len, jdouble* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetDoubleArrayRegion",
-			m_Env->functions->GetDoubleArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetDoubleArrayRegion(array, start, len, vals));
 }
 
 jdouble* JPJavaFrame::GetDoubleArrayElements(jdoubleArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jdouble*, "JPJavaFrame::GetDoubleArrayElements",
-			m_Env->functions->GetDoubleArrayElements(m_Env, array, isCopy));
+			m_Env->GetDoubleArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseDoubleArrayElements(jdoubleArray array, jdouble* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseDoubleArrayElements",
-			m_Env->functions->ReleaseDoubleArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseDoubleArrayElements(array, v, mode));
 }
 
 jcharArray JPJavaFrame::NewCharArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jcharArray, "JPJavaFrame::NewCharArray",
-			m_Env->functions->NewCharArray(m_Env, len));
+			m_Env->NewCharArray(len));
 }
 
 void JPJavaFrame::SetCharArrayRegion(jcharArray array, jsize start, jsize len, jchar* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetCharArrayRegion",
-			m_Env->functions->SetCharArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetCharArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetCharArrayRegion(jcharArray array, jsize start, jsize len, jchar* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetCharArrayRegion",
-			m_Env->functions->GetCharArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetCharArrayRegion(array, start, len, vals));
 }
 
 jchar* JPJavaFrame::GetCharArrayElements(jcharArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jchar*, "JPJavaFrame::GetCharArrayElements",
-			m_Env->functions->GetCharArrayElements(m_Env, array, isCopy));
+			m_Env->GetCharArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseCharArrayElements(jcharArray array, jchar* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseCharArrayElements",
-			m_Env->functions->ReleaseCharArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseCharArrayElements(array, v, mode));
 }
 
 jbooleanArray JPJavaFrame::NewBooleanArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jbooleanArray, "JPJavaFrame::NewBooleanArray",
-			m_Env->functions->NewBooleanArray(m_Env, len));
+			m_Env->NewBooleanArray(len));
 }
 
 void JPJavaFrame::SetBooleanArrayRegion(jbooleanArray array, jsize start, jsize len, jboolean* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetBooleanArrayRegion",
-			m_Env->functions->SetBooleanArrayRegion(m_Env, array, start, len, vals));
+			m_Env->SetBooleanArrayRegion(array, start, len, vals));
 }
 
 void JPJavaFrame::GetBooleanArrayRegion(jbooleanArray array, jsize start, jsize len, jboolean* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetBooleanArrayRegion",
-			m_Env->functions->GetBooleanArrayRegion(m_Env, array, start, len, vals));
+			m_Env->GetBooleanArrayRegion(array, start, len, vals));
 }
 
 jboolean* JPJavaFrame::GetBooleanArrayElements(jbooleanArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jboolean*, "JPJavaFrame::GetBooleanArrayElements",
-			m_Env->functions->GetBooleanArrayElements(m_Env, array, isCopy));
+			m_Env->GetBooleanArrayElements(array, isCopy));
 }
 
 void JPJavaFrame::ReleaseBooleanArrayElements(jbooleanArray array, jboolean* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseBooleanArrayElements",
-			m_Env->functions->ReleaseBooleanArrayElements(m_Env, array, v, mode));
+			m_Env->ReleaseBooleanArrayElements(array, v, mode));
 }
 
 int JPJavaFrame::MonitorEnter(jobject a0)
 {
 	JAVA_RETURN(int, "JPJavaFrame::MonitorEnter",
-			m_Env->functions->MonitorEnter(m_Env, a0));
+			m_Env->MonitorEnter(a0));
 }
 
 int JPJavaFrame::MonitorExit(jobject a0)
 {
 	JAVA_RETURN(int, "JPJavaFrame::MonitorExit",
-			m_Env->functions->MonitorExit(m_Env, a0));
+			m_Env->MonitorExit(a0));
 }
 
 jmethodID JPJavaFrame::FromReflectedMethod(jobject a0)
 {
 	JAVA_RETURN(jmethodID, "JPJavaFrame::FromReflectedMethod",
-			m_Env->functions->FromReflectedMethod(m_Env, a0));
+			m_Env->FromReflectedMethod(a0));
 }
 
 jfieldID JPJavaFrame::FromReflectedField(jobject a0)
 {
 	JAVA_RETURN(jfieldID, "JPJavaFrame::FromReflectedField",
-			m_Env->functions->FromReflectedField(m_Env, a0));
+			m_Env->FromReflectedField(a0));
 }
 
 jclass JPJavaFrame::FindClass(const string& a0)
 {
 	JAVA_RETURN(jclass, "JPJavaFrame::FindClass",
-			m_Env->functions->FindClass(m_Env, a0.c_str()));
+			m_Env->FindClass(a0.c_str()));
 }
 
 jobjectArray JPJavaFrame::NewObjectArray(jsize a0, jclass a1, jobject a2)
 {
 	JAVA_RETURN_OBJ(jobjectArray, "JPJavaFrame::NewObjectArray",
-			m_Env->functions->NewObjectArray(m_Env, a0, a1, a2));
+			m_Env->NewObjectArray(a0, a1, a2));
 }
 
 void JPJavaFrame::SetObjectArrayElement(jobjectArray a0, jsize a1, jobject a2)
 {
 	JAVA_CHECK("JPJavaFrame::SetObjectArrayElement",
-			m_Env->functions->SetObjectArrayElement(m_Env, a0, a1, a2));
+			m_Env->SetObjectArrayElement(a0, a1, a2));
 }
 
 void JPJavaFrame::CallStaticVoidMethodA(jclass a0, jmethodID a1, jvalue* a2)
 {
 	JAVA_CHECK("JPJavaFrame::CallStaticVoidMethodA",
-			m_Env->functions->CallStaticVoidMethodA(m_Env, a0, a1, a2));
+			m_Env->CallStaticVoidMethodA(a0, a1, a2));
 }
 
 void JPJavaFrame::CallVoidMethodA(jobject a0, jmethodID a1, jvalue* a2)
 {
 	JAVA_CHECK("JPJavaFrame::CallVoidMethodA",
-			m_Env->functions->CallVoidMethodA(m_Env, a0, a1, a2));
+			m_Env->CallVoidMethodA(a0, a1, a2));
 }
 
 void JPJavaFrame::CallNonvirtualVoidMethodA(jobject a0, jclass a1, jmethodID a2, jvalue* a3)
 {
 	JAVA_CHECK("JPJavaFrame::CallVoidMethodA",
-			m_Env->functions->CallNonvirtualVoidMethodA(m_Env, a0, a1, a2, a3));
+			m_Env->CallNonvirtualVoidMethodA(a0, a1, a2, a3));
 }
 
 jboolean JPJavaFrame::IsAssignableFrom(jclass a0, jclass a1)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::IsAssignableFrom",
-			m_Env->functions->IsAssignableFrom(m_Env, a0, a1));
+			m_Env->IsAssignableFrom(a0, a1));
 }
 
 jstring JPJavaFrame::NewStringUTF(const char* a0)
 {
 	JAVA_RETURN_OBJ(jstring, "JPJavaFrame::NewString",
-			m_Env->functions->NewStringUTF(m_Env, a0));
+			m_Env->NewStringUTF(a0));
 }
 
 const char* JPJavaFrame::GetStringUTFChars(jstring a0, jboolean* a1)
 {
 	JAVA_RETURN(const char*, "JPJavaFrame::GetStringUTFChars",
-			m_Env->functions->GetStringUTFChars(m_Env, a0, a1));
+			m_Env->GetStringUTFChars(a0, a1));
 }
 
 void JPJavaFrame::ReleaseStringUTFChars(jstring a0, const char* a1)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseStringUTFChars",
-			m_Env->functions->ReleaseStringUTFChars(m_Env, a0, a1));
+			m_Env->ReleaseStringUTFChars(a0, a1));
 }
 
 jsize JPJavaFrame::GetArrayLength(jarray a0)
 {
 	JAVA_RETURN(jsize, "JPJavaFrame::GetArrayLength",
-			m_Env->functions->GetArrayLength(m_Env, a0));
+			m_Env->GetArrayLength(a0));
 }
 
 jobject JPJavaFrame::GetObjectArrayElement(jobjectArray a0, jsize a1)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::GetObjectArrayElement",
-			m_Env->functions->GetObjectArrayElement(m_Env, a0, a1));
+			m_Env->GetObjectArrayElement(a0, a1));
 }
 
 jmethodID JPJavaFrame::GetMethodID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jmethodID, "JPJavaFrame::GetMethodID",
-			m_Env->functions->GetMethodID(m_Env, a0, a1, a2));
+			m_Env->GetMethodID(a0, a1, a2));
 }
 
 jmethodID JPJavaFrame::GetStaticMethodID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jmethodID, "JPJavaFrame::GetStaticMethodID",
-			m_Env->functions->GetStaticMethodID(m_Env, a0, a1, a2));
+			m_Env->GetStaticMethodID(a0, a1, a2));
 }
 
 jfieldID JPJavaFrame::GetFieldID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jfieldID, "JPJavaFrame::GetFieldID",
-			m_Env->functions->GetFieldID(m_Env, a0, a1, a2));
+			m_Env->GetFieldID(a0, a1, a2));
 }
 
 jfieldID JPJavaFrame::GetStaticFieldID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jfieldID, "JPJavaFrame::GetStaticFieldID",
-			m_Env->functions->GetStaticFieldID(m_Env, a0, a1, a2));
+			m_Env->GetStaticFieldID(a0, a1, a2));
 }
 
 jsize JPJavaFrame::GetStringUTFLength(jstring a0)
 {
 	JAVA_RETURN(jsize, "JPJavaFrame::GetStringUTFLength",
-			m_Env->functions->GetStringUTFLength(m_Env, a0));
+			m_Env->GetStringUTFLength(a0));
 }
 
 jclass JPJavaFrame::DefineClass(const char* a0, jobject a1, const jbyte* a2, jsize a3)
 {
 	JAVA_RETURN(jclass, "JPJavaFrame::DefineClass",
-			m_Env->functions->DefineClass(m_Env, a0, a1, a2, a3));
+			m_Env->DefineClass(a0, a1, a2, a3));
 }
 
 jint JPJavaFrame::RegisterNatives(jclass a0, const JNINativeMethod* a1, jint a2)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::RegisterNatives",
-			m_Env->functions->RegisterNatives(m_Env, a0, a1, a2));
+			m_Env->RegisterNatives(a0, a1, a2));
 }
 
 void* JPJavaFrame::GetDirectBufferAddress(jobject obj)
 {
 	JAVA_RETURN(void*, "JPJavaFrame::GetDirectBufferAddress",
-			m_Env->functions->GetDirectBufferAddress(m_Env, obj));
+			m_Env->GetDirectBufferAddress(obj));
 }
 
 jlong JPJavaFrame::GetDirectBufferCapacity(jobject obj)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::GetDirectBufferAddress",
-			m_Env->functions->GetDirectBufferCapacity(m_Env, obj));
+			m_Env->GetDirectBufferCapacity(obj));
 }
 
 jboolean JPJavaFrame::isBufferReadOnly(jobject obj)

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -22,6 +22,35 @@
 // resources should be created within them.
 //
 
+#if defined(JP_TRACING_ENABLE) || defined(JP_INSTRUMENTATION)
+static int jpype_frame_check(int i)
+{
+	static thread_local int depth = 0;
+	if (i > 0)
+	{
+		depth += i;
+		return depth;
+	}
+	if (i < 0)
+	{
+		depth += i;
+		return depth;
+	}
+
+	// GCOVR_EXCL_START
+	if (depth <= 0)
+	{
+		// Enable C++ traces so we can see
+		_jp_cpp_exceptions = true;
+		JP_RAISE(PyExc_SystemError, "Local reference outside of frame");
+	}
+	// GCOVR_EXCL_END
+	return depth;
+}
+#define JP_FRAME_CHECK(X) jpype_frame_check(X)
+#else
+#define JP_FRAME_CHECK(X) if (true)
+#endif
 JPJavaFrame::JPJavaFrame(JPContext* context, JNIEnv* p_env, int i)
 : m_Context(context), m_Env(p_env), popped(false)
 {
@@ -29,6 +58,7 @@ JPJavaFrame::JPJavaFrame(JPContext* context, JNIEnv* p_env, int i)
 	// Create a memory management frame to live in
 	m_Env->functions->PushLocalFrame(m_Env, i);
 	JP_TRACE_JAVA("JavaFrame", (jobject) - 1);
+	JP_FRAME_CHECK(1);
 }
 
 JPJavaFrame::JPJavaFrame(JPContext* context, int i)
@@ -39,6 +69,7 @@ JPJavaFrame::JPJavaFrame(JPContext* context, int i)
 	// Create a memory management frame to live in
 	m_Env->functions->PushLocalFrame(m_Env, i);
 	JP_TRACE_JAVA("JavaFrame", (jobject) - 1);
+	JP_FRAME_CHECK(1);
 }
 
 JPJavaFrame::JPJavaFrame(const JPJavaFrame& frame)
@@ -47,6 +78,7 @@ JPJavaFrame::JPJavaFrame(const JPJavaFrame& frame)
 	// Create a memory management frame to live in
 	m_Env->functions->PushLocalFrame(m_Env, LOCAL_FRAME_DEFAULT);
 	JP_TRACE_JAVA("JavaFrame (copy)", (jobject) - 1);
+	JP_FRAME_CHECK(1);
 }
 
 jobject JPJavaFrame::keep(jobject obj)
@@ -54,7 +86,9 @@ jobject JPJavaFrame::keep(jobject obj)
 	popped = true;
 	JP_TRACE_JAVA("Keep", obj);
 	JP_TRACE_JAVA("~JavaFrame (keep)", (jobject) - 2);
+	JP_FRAME_CHECK(-1);
 	obj = m_Env->functions->PopLocalFrame(m_Env, obj);
+	JP_FRAME_CHECK(0);  // Special case we can't hold a reference after a keep
 	JP_TRACE_JAVA("Return", obj);
 	return obj;
 }
@@ -66,6 +100,7 @@ JPJavaFrame::~JPJavaFrame()
 	{
 		JP_TRACE_JAVA("~JavaFrame", (jobject) - 2);
 		m_Env->functions->PopLocalFrame(m_Env, NULL);
+		JP_FRAME_CHECK(-1);
 	}
 
 	// It is not safe to detach as we would loss all local references including
@@ -177,24 +212,29 @@ jthrowable JPJavaFrame::ExceptionOccurred()
 #else
 #define JAVA_RETURN(X,Y,Z) \
   X ret = Z; \
+  JP_TRACE_JAVA(Y, 0); \
   check(); \
   return ret;
 #define JAVA_RETURN_OBJ(X,Y,Z) \
   X ret = Z; \
-  JP_TRACE_JAVA("ret", Y); \
+  JP_TRACE_JAVA(Y, ret); \
   check(); \
   return ret;
 #define JAVA_CHECK(Y,Z) \
   Z; \
+  JP_TRACE_JAVA(Y, 0); \
   check();
 #endif
 
 void JPJavaFrame::check()
 {
+	JP_FRAME_CHECK(0);
 	if (m_Env && m_Env->functions->ExceptionCheck(m_Env) == JNI_TRUE)
 	{
 		jthrowable th = m_Env->functions->ExceptionOccurred(m_Env);
+		JP_TRACE_JAVA("ExceptionOccurred", th);
 		m_Env->functions->ExceptionClear(m_Env);
+		JP_TRACE_JAVA("ExceptionClear", 0);
 		throw JPypeException(*this, th, JP_STACKINFO());
 	}
 }
@@ -216,7 +256,7 @@ jobject JPJavaFrame::NewObjectA(jclass a0, jmethodID a1, jvalue* a2)
 jobject JPJavaFrame::NewDirectByteBuffer(void* address, jlong capacity)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::NewDirectByteBuffer",
-		m_Env->functions->NewDirectByteBuffer(m_Env, address, capacity));
+			m_Env->functions->NewDirectByteBuffer(m_Env, address, capacity));
 }
 
 /*****************************************************************************/
@@ -224,769 +264,769 @@ jobject JPJavaFrame::NewDirectByteBuffer(void* address, jlong capacity)
 jbyte JPJavaFrame::GetStaticByteField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::GetStaticByteField",
-		m_Env->functions->GetStaticByteField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticByteField(m_Env, clazz, fid));
 }
 
 jbyte JPJavaFrame::GetByteField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::GetByteField",
-		m_Env->functions->GetByteField(m_Env, clazz, fid));
+			m_Env->functions->GetByteField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticByteField(jclass clazz, jfieldID fid, jbyte val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticByteField",
-		m_Env->functions->SetStaticByteField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticByteField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetByteField(jobject clazz, jfieldID fid, jbyte val)
 {
 	JAVA_CHECK("JPJavaFrame::SetByteField",
-		m_Env->functions->SetByteField(m_Env, clazz, fid, val));
+			m_Env->functions->SetByteField(m_Env, clazz, fid, val));
 }
 
 jbyte JPJavaFrame::CallStaticByteMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::CallStaticByteMethodA",
-		m_Env->functions->CallStaticByteMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticByteMethodA(m_Env, clazz, mid, val));
 }
 
 jbyte JPJavaFrame::CallByteMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::CallByteMethodA",
-		m_Env->functions->CallByteMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallByteMethodA(m_Env, obj, mid, val));
 }
 
 jbyte JPJavaFrame::CallNonvirtualByteMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jbyte, "JPJavaFrame::CallNonvirtualByteMethodA",
-		m_Env->functions->CallNonvirtualByteMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualByteMethodA(m_Env, obj, claz, mid, val));
 }
 
 jshort JPJavaFrame::GetStaticShortField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::GetStaticShortField",
-		m_Env->functions->GetStaticShortField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticShortField(m_Env, clazz, fid));
 }
 
 jshort JPJavaFrame::GetShortField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::GetShortField",
-		m_Env->functions->GetShortField(m_Env, clazz, fid));
+			m_Env->functions->GetShortField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticShortField(jclass clazz, jfieldID fid, jshort val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticShortField",
-		m_Env->functions->SetStaticShortField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticShortField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetShortField(jobject clazz, jfieldID fid, jshort val)
 {
 	JAVA_CHECK("JPJavaFrame::SetShortField",
-		m_Env->functions->SetShortField(m_Env, clazz, fid, val));
+			m_Env->functions->SetShortField(m_Env, clazz, fid, val));
 }
 
 jshort JPJavaFrame::CallStaticShortMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::CallStaticShortMethodA",
-		m_Env->functions->CallStaticShortMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticShortMethodA(m_Env, clazz, mid, val));
 }
 
 jshort JPJavaFrame::CallShortMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::CallShortMethodA",
-		m_Env->functions->CallShortMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallShortMethodA(m_Env, obj, mid, val));
 }
 
 jshort JPJavaFrame::CallNonvirtualShortMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jshort, "JPJavaFrame::CallNonvirtualShortMethodA",
-		m_Env->functions->CallNonvirtualShortMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualShortMethodA(m_Env, obj, claz, mid, val));
 }
 
 jint JPJavaFrame::GetStaticIntField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::GetStaticIntField",
-		m_Env->functions->GetStaticIntField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticIntField(m_Env, clazz, fid));
 }
 
 jint JPJavaFrame::GetIntField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::GetIntField",
-		m_Env->functions->GetIntField(m_Env, clazz, fid));
+			m_Env->functions->GetIntField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticIntField(jclass clazz, jfieldID fid, jint val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticIntField",
-		m_Env->functions->SetStaticIntField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticIntField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetIntField(jobject clazz, jfieldID fid, jint val)
 {
 	JAVA_CHECK("JPJavaFrame::SetIntField",
-		m_Env->functions->SetIntField(m_Env, clazz, fid, val));
+			m_Env->functions->SetIntField(m_Env, clazz, fid, val));
 }
 
 jint JPJavaFrame::CallStaticIntMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::CallStaticIntMethodA",
-		m_Env->functions->CallStaticIntMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticIntMethodA(m_Env, clazz, mid, val));
 }
 
 jint JPJavaFrame::CallIntMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::CallIntMethodA",
-		m_Env->functions->CallIntMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallIntMethodA(m_Env, obj, mid, val));
 }
 
 jint JPJavaFrame::CallNonvirtualIntMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::CallNonvirtualIntMethodA",
-		m_Env->functions->CallNonvirtualIntMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualIntMethodA(m_Env, obj, claz, mid, val));
 }
 
 jlong JPJavaFrame::GetStaticLongField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::GetStaticLongField",
-		m_Env->functions->GetStaticLongField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticLongField(m_Env, clazz, fid));
 }
 
 jlong JPJavaFrame::GetLongField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::GetLongField",
-		m_Env->functions->GetLongField(m_Env, clazz, fid));
+			m_Env->functions->GetLongField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticLongField(jclass clazz, jfieldID fid, jlong val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticLongField",
-		m_Env->functions->SetStaticLongField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticLongField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetLongField(jobject clazz, jfieldID fid, jlong val)
 {
 	JAVA_CHECK("JPJavaFrame::SetLongField",
-		m_Env->functions->SetLongField(m_Env, clazz, fid, val));
+			m_Env->functions->SetLongField(m_Env, clazz, fid, val));
 }
 
 jlong JPJavaFrame::CallStaticLongMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::CallStaticLongMethodA",
-		m_Env->functions->CallStaticLongMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticLongMethodA(m_Env, clazz, mid, val));
 }
 
 jlong JPJavaFrame::CallLongMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::CallLongMethodA",
-		m_Env->functions->CallLongMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallLongMethodA(m_Env, obj, mid, val));
 }
 
 jlong JPJavaFrame::CallNonvirtualLongMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::CallNonvirtualLongMethodA",
-		m_Env->functions->CallNonvirtualLongMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualLongMethodA(m_Env, obj, claz, mid, val));
 }
 
 jfloat JPJavaFrame::GetStaticFloatField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::GetStaticFloatField",
-		m_Env->functions->GetStaticFloatField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticFloatField(m_Env, clazz, fid));
 }
 
 jfloat JPJavaFrame::GetFloatField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::GetFloatField",
-		m_Env->functions->GetFloatField(m_Env, clazz, fid));
+			m_Env->functions->GetFloatField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticFloatField(jclass clazz, jfieldID fid, jfloat val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticFloatField",
-		m_Env->functions->SetStaticFloatField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticFloatField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetFloatField(jobject clazz, jfieldID fid, jfloat val)
 {
 	JAVA_CHECK("JPJavaFrame::SetFloatField",
-		m_Env->functions->SetFloatField(m_Env, clazz, fid, val));
+			m_Env->functions->SetFloatField(m_Env, clazz, fid, val));
 }
 
 jfloat JPJavaFrame::CallStaticFloatMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::CallStaticFloatMethodA",
-		m_Env->functions->CallStaticFloatMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticFloatMethodA(m_Env, clazz, mid, val));
 }
 
 jfloat JPJavaFrame::CallFloatMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::CallFloatMethodA",
-		m_Env->functions->CallFloatMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallFloatMethodA(m_Env, obj, mid, val));
 }
 
 jfloat JPJavaFrame::CallNonvirtualFloatMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jfloat, "JPJavaFrame::CallNonvirtualFloatMethodA",
-		m_Env->functions->CallNonvirtualFloatMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualFloatMethodA(m_Env, obj, claz, mid, val));
 }
 
 jdouble JPJavaFrame::GetStaticDoubleField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::GetStaticDoubleField",
-		m_Env->functions->GetStaticDoubleField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticDoubleField(m_Env, clazz, fid));
 }
 
 jdouble JPJavaFrame::GetDoubleField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::GetDoubleField",
-		m_Env->functions->GetDoubleField(m_Env, clazz, fid));
+			m_Env->functions->GetDoubleField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticDoubleField(jclass clazz, jfieldID fid, jdouble val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticDoubleField",
-		m_Env->functions->SetStaticDoubleField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticDoubleField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetDoubleField(jobject clazz, jfieldID fid, jdouble val)
 {
 	JAVA_CHECK("JPJavaFrame::SetDoubleField",
-		m_Env->functions->SetDoubleField(m_Env, clazz, fid, val));
+			m_Env->functions->SetDoubleField(m_Env, clazz, fid, val));
 }
 
 jdouble JPJavaFrame::CallStaticDoubleMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::CallStaticDoubleMethodA",
-		m_Env->functions->CallStaticDoubleMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticDoubleMethodA(m_Env, clazz, mid, val));
 }
 
 jdouble JPJavaFrame::CallDoubleMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::CallDoubleMethodA",
-		m_Env->functions->CallDoubleMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallDoubleMethodA(m_Env, obj, mid, val));
 }
 
 jdouble JPJavaFrame::CallNonvirtualDoubleMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jdouble, "JPJavaFrame::CallNonvirtualDoubleMethodA",
-		m_Env->functions->CallNonvirtualDoubleMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualDoubleMethodA(m_Env, obj, claz, mid, val));
 }
 
 jchar JPJavaFrame::GetStaticCharField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::GetStaticCharField",
-		m_Env->functions->GetStaticCharField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticCharField(m_Env, clazz, fid));
 }
 
 jchar JPJavaFrame::GetCharField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::GetCharField",
-		m_Env->functions->GetCharField(m_Env, clazz, fid));
+			m_Env->functions->GetCharField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticCharField(jclass clazz, jfieldID fid, jchar val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticCharField",
-		m_Env->functions->SetStaticCharField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticCharField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetCharField(jobject clazz, jfieldID fid, jchar val)
 {
 	JAVA_CHECK("JPJavaFrame::SetCharField",
-		m_Env->functions->SetCharField(m_Env, clazz, fid, val));
+			m_Env->functions->SetCharField(m_Env, clazz, fid, val));
 }
 
 jchar JPJavaFrame::CallStaticCharMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::CallStaticCharMethodA",
-		m_Env->functions->CallStaticCharMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticCharMethodA(m_Env, clazz, mid, val));
 }
 
 jchar JPJavaFrame::CallCharMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::CallCharMethodA",
-		m_Env->functions->CallCharMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallCharMethodA(m_Env, obj, mid, val));
 }
 
 jchar JPJavaFrame::CallNonvirtualCharMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jchar, "JPJavaFrame::CallNonvirtualCharMethodA",
-		m_Env->functions->CallNonvirtualCharMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualCharMethodA(m_Env, obj, claz, mid, val));
 }
 
 jboolean JPJavaFrame::GetStaticBooleanField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::GetStaticBooleanField",
-		m_Env->functions->GetStaticBooleanField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticBooleanField(m_Env, clazz, fid));
 }
 
 jboolean JPJavaFrame::GetBooleanField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::GetBooleanField",
-		m_Env->functions->GetBooleanField(m_Env, clazz, fid));
+			m_Env->functions->GetBooleanField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticBooleanField(jclass clazz, jfieldID fid, jboolean val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticBooleanField",
-		m_Env->functions->SetStaticBooleanField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticBooleanField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetBooleanField(jobject clazz, jfieldID fid, jboolean val)
 {
 	JAVA_CHECK("JPJavaFrame::SetBooleanField",
-		m_Env->functions->SetBooleanField(m_Env, clazz, fid, val));
+			m_Env->functions->SetBooleanField(m_Env, clazz, fid, val));
 }
 
 jboolean JPJavaFrame::CallStaticBooleanMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::CallStaticBooleanMethodA",
-		m_Env->functions->CallStaticBooleanMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticBooleanMethodA(m_Env, clazz, mid, val));
 }
 
 jboolean JPJavaFrame::CallBooleanMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::CallBooleanMethodA",
-		m_Env->functions->CallBooleanMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallBooleanMethodA(m_Env, obj, mid, val));
 }
 
 jboolean JPJavaFrame::CallNonvirtualBooleanMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::CallNonvirtualBooleanMethodA",
-		m_Env->functions->CallNonvirtualBooleanMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualBooleanMethodA(m_Env, obj, claz, mid, val));
 }
 
 jobject JPJavaFrame::GetStaticObjectField(jclass clazz, jfieldID fid)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::GetStaticObjectField",
-		m_Env->functions->GetStaticObjectField(m_Env, clazz, fid));
+			m_Env->functions->GetStaticObjectField(m_Env, clazz, fid));
 }
 
 jobject JPJavaFrame::GetObjectField(jobject clazz, jfieldID fid)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::GetObjectField",
-		m_Env->functions->GetObjectField(m_Env, clazz, fid));
+			m_Env->functions->GetObjectField(m_Env, clazz, fid));
 }
 
 void JPJavaFrame::SetStaticObjectField(jclass clazz, jfieldID fid, jobject val)
 {
 	JAVA_CHECK("JPJavaFrame::SetStaticObjectField",
-		m_Env->functions->SetStaticObjectField(m_Env, clazz, fid, val));
+			m_Env->functions->SetStaticObjectField(m_Env, clazz, fid, val));
 }
 
 void JPJavaFrame::SetObjectField(jobject clazz, jfieldID fid, jobject val)
 {
 	JAVA_CHECK("JPJavaFrame::SetObjectField",
-		m_Env->functions->SetObjectField(m_Env, clazz, fid, val));
+			m_Env->functions->SetObjectField(m_Env, clazz, fid, val));
 }
 
 jobject JPJavaFrame::CallStaticObjectMethodA(jclass clazz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::CallStaticObjectMethodA",
-		m_Env->functions->CallStaticObjectMethodA(m_Env, clazz, mid, val));
+			m_Env->functions->CallStaticObjectMethodA(m_Env, clazz, mid, val));
 }
 
 jobject JPJavaFrame::CallObjectMethodA(jobject obj, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::CallObjectMethodA",
-		m_Env->functions->CallObjectMethodA(m_Env, obj, mid, val));
+			m_Env->functions->CallObjectMethodA(m_Env, obj, mid, val));
 }
 
 jobject JPJavaFrame::CallNonvirtualObjectMethodA(jobject obj, jclass claz, jmethodID mid, jvalue* val)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::CallNonvirtualObjectMethodA",
-		m_Env->functions->CallNonvirtualObjectMethodA(m_Env, obj, claz, mid, val));
+			m_Env->functions->CallNonvirtualObjectMethodA(m_Env, obj, claz, mid, val));
 }
 
 jbyteArray JPJavaFrame::NewByteArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jbyteArray, "JPJavaFrame::NewByteArray",
-		m_Env->functions->NewByteArray(m_Env, len));
+			m_Env->functions->NewByteArray(m_Env, len));
 }
 
 void JPJavaFrame::SetByteArrayRegion(jbyteArray array, jsize start, jsize len, jbyte* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetByteArrayRegion",
-		m_Env->functions->SetByteArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetByteArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetByteArrayRegion(jbyteArray array, jsize start, jsize len, jbyte* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetByteArrayRegion",
-		m_Env->functions->GetByteArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetByteArrayRegion(m_Env, array, start, len, vals));
 }
 
 jbyte* JPJavaFrame::GetByteArrayElements(jbyteArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jbyte*, "JPJavaFrame::GetByteArrayElements",
-		m_Env->functions->GetByteArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetByteArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseByteArrayElements(jbyteArray array, jbyte* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseByteArrayElements",
-		m_Env->functions->ReleaseByteArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseByteArrayElements(m_Env, array, v, mode));
 }
 
 jshortArray JPJavaFrame::NewShortArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jshortArray, "JPJavaFrame::NewShortArray",
-		m_Env->functions->NewShortArray(m_Env, len));
+			m_Env->functions->NewShortArray(m_Env, len));
 }
 
 void JPJavaFrame::SetShortArrayRegion(jshortArray array, jsize start, jsize len, jshort* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetShortArrayRegion",
-		m_Env->functions->SetShortArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetShortArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetShortArrayRegion(jshortArray array, jsize start, jsize len, jshort* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetShortArrayRegion",
-		m_Env->functions->GetShortArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetShortArrayRegion(m_Env, array, start, len, vals));
 }
 
 jshort* JPJavaFrame::GetShortArrayElements(jshortArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jshort*, "JPJavaFrame::GetShortArrayElements",
-		m_Env->functions->GetShortArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetShortArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseShortArrayElements(jshortArray array, jshort* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseShortArrayElements",
-		m_Env->functions->ReleaseShortArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseShortArrayElements(m_Env, array, v, mode));
 }
 
 jintArray JPJavaFrame::NewIntArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jintArray, "JPJavaFrame::NewIntArray",
-		m_Env->functions->NewIntArray(m_Env, len));
+			m_Env->functions->NewIntArray(m_Env, len));
 }
 
 void JPJavaFrame::SetIntArrayRegion(jintArray array, jsize start, jsize len, jint* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetIntArrayRegion",
-		m_Env->functions->SetIntArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetIntArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetIntArrayRegion(jintArray array, jsize start, jsize len, jint* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetIntArrayRegion",
-		m_Env->functions->GetIntArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetIntArrayRegion(m_Env, array, start, len, vals));
 }
 
 jint* JPJavaFrame::GetIntArrayElements(jintArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jint*, "JPJavaFrame::GetIntArrayElements",
-		m_Env->functions->GetIntArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetIntArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseIntArrayElements(jintArray array, jint* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseIntArrayElements",
-		m_Env->functions->ReleaseIntArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseIntArrayElements(m_Env, array, v, mode));
 }
 
 jlongArray JPJavaFrame::NewLongArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jlongArray, "JPJavaFrame::NewLongArray",
-		m_Env->functions->NewLongArray(m_Env, len));
+			m_Env->functions->NewLongArray(m_Env, len));
 }
 
 void JPJavaFrame::SetLongArrayRegion(jlongArray array, jsize start, jsize len, jlong* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetLongArrayRegion",
-		m_Env->functions->SetLongArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetLongArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetLongArrayRegion(jlongArray array, jsize start, jsize len, jlong* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetLongArrayRegion",
-		m_Env->functions->GetLongArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetLongArrayRegion(m_Env, array, start, len, vals));
 }
 
 jlong* JPJavaFrame::GetLongArrayElements(jlongArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jlong*, "JPJavaFrame::GetLongArrayElements",
-		m_Env->functions->GetLongArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetLongArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseLongArrayElements(jlongArray array, jlong* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseLongArrayElements",
-		m_Env->functions->ReleaseLongArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseLongArrayElements(m_Env, array, v, mode));
 }
 
 jfloatArray JPJavaFrame::NewFloatArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jfloatArray, "JPJavaFrame::NewFloatArray",
-		m_Env->functions->NewFloatArray(m_Env, len));
+			m_Env->functions->NewFloatArray(m_Env, len));
 }
 
 void JPJavaFrame::SetFloatArrayRegion(jfloatArray array, jsize start, jsize len, jfloat* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetFloatArrayRegion",
-		m_Env->functions->SetFloatArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetFloatArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetFloatArrayRegion(jfloatArray array, jsize start, jsize len, jfloat* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetFloatArrayRegion",
-		m_Env->functions->GetFloatArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetFloatArrayRegion(m_Env, array, start, len, vals));
 }
 
 jfloat* JPJavaFrame::GetFloatArrayElements(jfloatArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jfloat*, "JPJavaFrame::GetFloatArrayElements",
-		m_Env->functions->GetFloatArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetFloatArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseFloatArrayElements(jfloatArray array, jfloat* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseFloatArrayElements",
-		m_Env->functions->ReleaseFloatArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseFloatArrayElements(m_Env, array, v, mode));
 }
 
 jdoubleArray JPJavaFrame::NewDoubleArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jdoubleArray, "JPJavaFrame::NewDoubleArray",
-		m_Env->functions->NewDoubleArray(m_Env, len));
+			m_Env->functions->NewDoubleArray(m_Env, len));
 }
 
 void JPJavaFrame::SetDoubleArrayRegion(jdoubleArray array, jsize start, jsize len, jdouble* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetDoubleArrayRegion",
-		m_Env->functions->SetDoubleArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetDoubleArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetDoubleArrayRegion(jdoubleArray array, jsize start, jsize len, jdouble* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetDoubleArrayRegion",
-		m_Env->functions->GetDoubleArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetDoubleArrayRegion(m_Env, array, start, len, vals));
 }
 
 jdouble* JPJavaFrame::GetDoubleArrayElements(jdoubleArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jdouble*, "JPJavaFrame::GetDoubleArrayElements",
-		m_Env->functions->GetDoubleArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetDoubleArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseDoubleArrayElements(jdoubleArray array, jdouble* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseDoubleArrayElements",
-		m_Env->functions->ReleaseDoubleArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseDoubleArrayElements(m_Env, array, v, mode));
 }
 
 jcharArray JPJavaFrame::NewCharArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jcharArray, "JPJavaFrame::NewCharArray",
-		m_Env->functions->NewCharArray(m_Env, len));
+			m_Env->functions->NewCharArray(m_Env, len));
 }
 
 void JPJavaFrame::SetCharArrayRegion(jcharArray array, jsize start, jsize len, jchar* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetCharArrayRegion",
-		m_Env->functions->SetCharArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetCharArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetCharArrayRegion(jcharArray array, jsize start, jsize len, jchar* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetCharArrayRegion",
-		m_Env->functions->GetCharArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetCharArrayRegion(m_Env, array, start, len, vals));
 }
 
 jchar* JPJavaFrame::GetCharArrayElements(jcharArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jchar*, "JPJavaFrame::GetCharArrayElements",
-		m_Env->functions->GetCharArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetCharArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseCharArrayElements(jcharArray array, jchar* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseCharArrayElements",
-		m_Env->functions->ReleaseCharArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseCharArrayElements(m_Env, array, v, mode));
 }
 
 jbooleanArray JPJavaFrame::NewBooleanArray(jsize len)
 {
 	JAVA_RETURN_OBJ(jbooleanArray, "JPJavaFrame::NewBooleanArray",
-		m_Env->functions->NewBooleanArray(m_Env, len));
+			m_Env->functions->NewBooleanArray(m_Env, len));
 }
 
 void JPJavaFrame::SetBooleanArrayRegion(jbooleanArray array, jsize start, jsize len, jboolean* vals)
 {
 	JAVA_CHECK("JPJavaFrame::SetBooleanArrayRegion",
-		m_Env->functions->SetBooleanArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->SetBooleanArrayRegion(m_Env, array, start, len, vals));
 }
 
 void JPJavaFrame::GetBooleanArrayRegion(jbooleanArray array, jsize start, jsize len, jboolean* vals)
 {
 	JAVA_CHECK("JPJavaFrame::GetBooleanArrayRegion",
-		m_Env->functions->GetBooleanArrayRegion(m_Env, array, start, len, vals));
+			m_Env->functions->GetBooleanArrayRegion(m_Env, array, start, len, vals));
 }
 
 jboolean* JPJavaFrame::GetBooleanArrayElements(jbooleanArray array, jboolean* isCopy)
 {
 	JAVA_RETURN(jboolean*, "JPJavaFrame::GetBooleanArrayElements",
-		m_Env->functions->GetBooleanArrayElements(m_Env, array, isCopy));
+			m_Env->functions->GetBooleanArrayElements(m_Env, array, isCopy));
 }
 
 void JPJavaFrame::ReleaseBooleanArrayElements(jbooleanArray array, jboolean* v, jint mode)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseBooleanArrayElements",
-		m_Env->functions->ReleaseBooleanArrayElements(m_Env, array, v, mode));
+			m_Env->functions->ReleaseBooleanArrayElements(m_Env, array, v, mode));
 }
 
 int JPJavaFrame::MonitorEnter(jobject a0)
 {
 	JAVA_RETURN(int, "JPJavaFrame::MonitorEnter",
-		m_Env->functions->MonitorEnter(m_Env, a0));
+			m_Env->functions->MonitorEnter(m_Env, a0));
 }
 
 int JPJavaFrame::MonitorExit(jobject a0)
 {
 	JAVA_RETURN(int, "JPJavaFrame::MonitorExit",
-		m_Env->functions->MonitorExit(m_Env, a0));
+			m_Env->functions->MonitorExit(m_Env, a0));
 }
 
 jmethodID JPJavaFrame::FromReflectedMethod(jobject a0)
 {
 	JAVA_RETURN(jmethodID, "JPJavaFrame::FromReflectedMethod",
-		m_Env->functions->FromReflectedMethod(m_Env, a0));
+			m_Env->functions->FromReflectedMethod(m_Env, a0));
 }
 
 jfieldID JPJavaFrame::FromReflectedField(jobject a0)
 {
 	JAVA_RETURN(jfieldID, "JPJavaFrame::FromReflectedField",
-		m_Env->functions->FromReflectedField(m_Env, a0));
+			m_Env->functions->FromReflectedField(m_Env, a0));
 }
 
 jclass JPJavaFrame::FindClass(const string& a0)
 {
 	JAVA_RETURN(jclass, "JPJavaFrame::FindClass",
-		m_Env->functions->FindClass(m_Env, a0.c_str()));
+			m_Env->functions->FindClass(m_Env, a0.c_str()));
 }
 
 jobjectArray JPJavaFrame::NewObjectArray(jsize a0, jclass a1, jobject a2)
 {
 	JAVA_RETURN_OBJ(jobjectArray, "JPJavaFrame::NewObjectArray",
-		m_Env->functions->NewObjectArray(m_Env, a0, a1, a2));
+			m_Env->functions->NewObjectArray(m_Env, a0, a1, a2));
 }
 
 void JPJavaFrame::SetObjectArrayElement(jobjectArray a0, jsize a1, jobject a2)
 {
 	JAVA_CHECK("JPJavaFrame::SetObjectArrayElement",
-		m_Env->functions->SetObjectArrayElement(m_Env, a0, a1, a2));
+			m_Env->functions->SetObjectArrayElement(m_Env, a0, a1, a2));
 }
 
 void JPJavaFrame::CallStaticVoidMethodA(jclass a0, jmethodID a1, jvalue* a2)
 {
 	JAVA_CHECK("JPJavaFrame::CallStaticVoidMethodA",
-		m_Env->functions->CallStaticVoidMethodA(m_Env, a0, a1, a2));
+			m_Env->functions->CallStaticVoidMethodA(m_Env, a0, a1, a2));
 }
 
 void JPJavaFrame::CallVoidMethodA(jobject a0, jmethodID a1, jvalue* a2)
 {
 	JAVA_CHECK("JPJavaFrame::CallVoidMethodA",
-		m_Env->functions->CallVoidMethodA(m_Env, a0, a1, a2));
+			m_Env->functions->CallVoidMethodA(m_Env, a0, a1, a2));
 }
 
 void JPJavaFrame::CallNonvirtualVoidMethodA(jobject a0, jclass a1, jmethodID a2, jvalue* a3)
 {
 	JAVA_CHECK("JPJavaFrame::CallVoidMethodA",
-		m_Env->functions->CallNonvirtualVoidMethodA(m_Env, a0, a1, a2, a3));
+			m_Env->functions->CallNonvirtualVoidMethodA(m_Env, a0, a1, a2, a3));
 }
 
 jboolean JPJavaFrame::IsAssignableFrom(jclass a0, jclass a1)
 {
 	JAVA_RETURN(jboolean, "JPJavaFrame::IsAssignableFrom",
-		m_Env->functions->IsAssignableFrom(m_Env, a0, a1));
+			m_Env->functions->IsAssignableFrom(m_Env, a0, a1));
 }
 
 jstring JPJavaFrame::NewStringUTF(const char* a0)
 {
 	JAVA_RETURN_OBJ(jstring, "JPJavaFrame::NewString",
-		m_Env->functions->NewStringUTF(m_Env, a0));
+			m_Env->functions->NewStringUTF(m_Env, a0));
 }
 
 const char* JPJavaFrame::GetStringUTFChars(jstring a0, jboolean* a1)
 {
 	JAVA_RETURN(const char*, "JPJavaFrame::GetStringUTFChars",
-		m_Env->functions->GetStringUTFChars(m_Env, a0, a1));
+			m_Env->functions->GetStringUTFChars(m_Env, a0, a1));
 }
 
 void JPJavaFrame::ReleaseStringUTFChars(jstring a0, const char* a1)
 {
 	JAVA_CHECK("JPJavaFrame::ReleaseStringUTFChars",
-		m_Env->functions->ReleaseStringUTFChars(m_Env, a0, a1));
+			m_Env->functions->ReleaseStringUTFChars(m_Env, a0, a1));
 }
 
 jsize JPJavaFrame::GetArrayLength(jarray a0)
 {
 	JAVA_RETURN(jsize, "JPJavaFrame::GetArrayLength",
-		m_Env->functions->GetArrayLength(m_Env, a0));
+			m_Env->functions->GetArrayLength(m_Env, a0));
 }
 
 jobject JPJavaFrame::GetObjectArrayElement(jobjectArray a0, jsize a1)
 {
 	JAVA_RETURN_OBJ(jobject, "JPJavaFrame::GetObjectArrayElement",
-		m_Env->functions->GetObjectArrayElement(m_Env, a0, a1));
+			m_Env->functions->GetObjectArrayElement(m_Env, a0, a1));
 }
 
 jmethodID JPJavaFrame::GetMethodID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jmethodID, "JPJavaFrame::GetMethodID",
-		m_Env->functions->GetMethodID(m_Env, a0, a1, a2));
+			m_Env->functions->GetMethodID(m_Env, a0, a1, a2));
 }
 
 jmethodID JPJavaFrame::GetStaticMethodID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jmethodID, "JPJavaFrame::GetStaticMethodID",
-		m_Env->functions->GetStaticMethodID(m_Env, a0, a1, a2));
+			m_Env->functions->GetStaticMethodID(m_Env, a0, a1, a2));
 }
 
 jfieldID JPJavaFrame::GetFieldID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jfieldID, "JPJavaFrame::GetFieldID",
-		m_Env->functions->GetFieldID(m_Env, a0, a1, a2));
+			m_Env->functions->GetFieldID(m_Env, a0, a1, a2));
 }
 
 jfieldID JPJavaFrame::GetStaticFieldID(jclass a0, const char* a1, const char* a2)
 {
 	JAVA_RETURN(jfieldID, "JPJavaFrame::GetStaticFieldID",
-		m_Env->functions->GetStaticFieldID(m_Env, a0, a1, a2));
+			m_Env->functions->GetStaticFieldID(m_Env, a0, a1, a2));
 }
 
 jsize JPJavaFrame::GetStringUTFLength(jstring a0)
 {
 	JAVA_RETURN(jsize, "JPJavaFrame::GetStringUTFLength",
-		m_Env->functions->GetStringUTFLength(m_Env, a0));
+			m_Env->functions->GetStringUTFLength(m_Env, a0));
 }
 
 jclass JPJavaFrame::DefineClass(const char* a0, jobject a1, const jbyte* a2, jsize a3)
 {
 	JAVA_RETURN(jclass, "JPJavaFrame::DefineClass",
-		m_Env->functions->DefineClass(m_Env, a0, a1, a2, a3));
+			m_Env->functions->DefineClass(m_Env, a0, a1, a2, a3));
 }
 
 jint JPJavaFrame::RegisterNatives(jclass a0, const JNINativeMethod* a1, jint a2)
 {
 	JAVA_RETURN(jint, "JPJavaFrame::RegisterNatives",
-		m_Env->functions->RegisterNatives(m_Env, a0, a1, a2));
+			m_Env->functions->RegisterNatives(m_Env, a0, a1, a2));
 }
 
 void* JPJavaFrame::GetDirectBufferAddress(jobject obj)
 {
 	JAVA_RETURN(void*, "JPJavaFrame::GetDirectBufferAddress",
-		m_Env->functions->GetDirectBufferAddress(m_Env, obj));
+			m_Env->functions->GetDirectBufferAddress(m_Env, obj));
 }
 
 jlong JPJavaFrame::GetDirectBufferCapacity(jobject obj)
 {
 	JAVA_RETURN(jlong, "JPJavaFrame::GetDirectBufferAddress",
-		m_Env->functions->GetDirectBufferCapacity(m_Env, obj));
+			m_Env->functions->GetDirectBufferCapacity(m_Env, obj));
 }
 
 jboolean JPJavaFrame::isBufferReadOnly(jobject obj)
@@ -1004,6 +1044,7 @@ jboolean JPJavaFrame::orderBuffer(jobject obj)
 
 // GCOVR_EXCL_START
 // This is used when debugging reference counting problems.
+
 jclass JPJavaFrame::getClass(jobject obj)
 {
 	return (jclass) CallObjectMethodA(obj, m_Context->m_Object_GetClassID, 0);
@@ -1134,5 +1175,5 @@ jint JPJavaFrame::compareTo(jobject obj, jobject obj2)
 {
 	jvalue v;
 	v.l = obj2;
-	return this->CallIntMethodA(obj, m_Context->m_CompareToID, &v);
+	return CallIntMethodA(obj, m_Context->m_CompareToID, &v);
 }

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -161,7 +161,7 @@ JPMatch::Type JPMethod::matches(JPJavaFrame &frame, JPMethodMatch& methodMatch, 
 	{
 		size_t j = i + methodMatch.offset;
 		JPClass *type = m_ParameterTypes[i];
-		JP_TRACE("Compare", i, j, type->toString(), JPPyObject::getTypeName(arg[j]));
+		JP_TRACE("Compare", i, j, type->getCanonicalName(), JPPyObject::getTypeName(arg[j]));
 		JPMatch::Type ematch = type->findJavaConversion(methodMatch.argument[j]);
 		JP_TRACE("Result", ematch);
 		if (ematch < methodMatch.type)

--- a/native/common/jp_tracer.cpp
+++ b/native/common/jp_tracer.cpp
@@ -50,6 +50,20 @@ static JPypeTracer* jpype_tracer_last = NULL;
 std::mutex trace_lock;
 
 #define JPYPE_TRACING_OUTPUT cerr
+static int INDENT_WIDTH = 2;
+static const char *INDENT =
+		"                                                                                ";
+
+static void jpype_indent(int space)
+{
+	space *= INDENT_WIDTH;
+	while (space > 80)
+	{
+		JPYPE_TRACING_OUTPUT << INDENT;
+		space -= 80;
+	}
+	JPYPE_TRACING_OUTPUT << &INDENT[80 - space];
+}
 
 //This code is not thread safe, thus tracing a multithreaded code is likely
 // to result in crashes.
@@ -77,14 +91,11 @@ void JPypeTracer::traceIn(const char* msg, void* ref)
 		jpype_traceLevel = 0;
 
 	std::lock_guard<std::mutex> guard(trace_lock);
-	for (int i = 0; i < jpype_traceLevel; i++)
-	{
-		JPYPE_TRACING_OUTPUT << "  ";
-	}
-	JPYPE_TRACING_OUTPUT << "<B msg=\"" << msg << "\"";
+	jpype_indent(jpype_traceLevel);
+	JPYPE_TRACING_OUTPUT << "> " << msg ;
 	if (ref != NULL)
 		JPYPE_TRACING_OUTPUT << " id=\"" << ref << "\"";
-	JPYPE_TRACING_OUTPUT << " >" << endl;
+	JPYPE_TRACING_OUTPUT << endl;
 	JPYPE_TRACING_OUTPUT.flush();
 	jpype_traceLevel++;
 }
@@ -96,39 +107,63 @@ void JPypeTracer::traceOut(const char* msg, bool error)
 
 	std::lock_guard<std::mutex> guard(trace_lock);
 	jpype_traceLevel--;
-	for (int i = 0; i < jpype_traceLevel; i++)
-	{
-		JPYPE_TRACING_OUTPUT << "  ";
-	}
+	jpype_indent(jpype_traceLevel);
 	if (error)
 	{
-		JPYPE_TRACING_OUTPUT << "</B> <!-- !!!!!!!! EXCEPTION !!!!!! " << msg << " -->" << endl;
+		JPYPE_TRACING_OUTPUT << "EXCEPTION! " << msg << endl;
 	} else
 	{
-		JPYPE_TRACING_OUTPUT << "</B> <!-- " << msg << " -->" << endl;
+		JPYPE_TRACING_OUTPUT << "< " << msg << endl;
 	}
 	JPYPE_TRACING_OUTPUT.flush();
 }
 
+void JPypeTracer::traceJavaObject(const char* msg, const void* ref)
+{
+	if ((_PyJPModule_trace & 4) == 0)
+		return;
+	if (ref == (void*) 0)
+	{
+		JPypeTracer::trace1("JNI", msg);
+		jpype_traceLevel++;
+		return;
+	}
+	if (ref == (void*) - 1)
+	{
+		JPypeTracer::trace1("+ JNI", msg);
+		jpype_traceLevel++;
+		return;
+	}
+	if (ref == (void*) - 2)
+	{
+		jpype_traceLevel--;
+		JPypeTracer::trace1("- JNI", msg);
+		return;
+	}
+	stringstream str;
+	str << msg << " " << (void*) ref ;
+	JPypeTracer::trace1("JNI", str.str().c_str());
+}
+
 void JPypeTracer::tracePythonObject(const char* msg, PyObject* ref)
 {
-	if (_PyJPModule_trace & 2 == 0)
+	if ((_PyJPModule_trace & 2) == 0)
 		return;
 	if (ref != NULL)
 	{
 		stringstream str;
 		str << msg << " " << (void*) ref << " " << ref->ob_refcnt << " " << Py_TYPE(ref)->tp_name;
-		JPypeTracer::trace1(str.str().c_str());
+		JPypeTracer::trace1("PY", str.str().c_str());
 
 	} else
 	{
 		stringstream str;
 		str << msg << " " << (void*) ref;
-		JPypeTracer::trace1(str.str().c_str());
+		JPypeTracer::trace1("PY", str.str().c_str());
 	}
 }
 
-void JPypeTracer::trace1(const char* msg)
+void JPypeTracer::trace1(const char* source, const char* msg)
 {
 	if (_PyJPModule_trace == 0)
 		return;
@@ -139,11 +174,12 @@ void JPypeTracer::trace1(const char* msg)
 	if (jpype_tracer_last != NULL)
 		name = jpype_tracer_last->m_Name;
 
-	for (int i = 0; i < jpype_traceLevel; i++)
-	{
-		JPYPE_TRACING_OUTPUT << "  ";
-	}
-	JPYPE_TRACING_OUTPUT << "<M>" << name << " : " << msg << "</M>" << endl;
+	jpype_indent(jpype_traceLevel);
+	if (source != NULL)
+		JPYPE_TRACING_OUTPUT << source << ": ";
+	if (source == NULL || (_PyJPModule_trace & 16) != 0)
+		JPYPE_TRACING_OUTPUT << name << ": ";
+	JPYPE_TRACING_OUTPUT << msg << endl;
 	JPYPE_TRACING_OUTPUT.flush();
 }
 
@@ -158,18 +194,15 @@ void JPypeTracer::trace2(const char* msg1, const char* msg2)
 	if (jpype_tracer_last != NULL)
 		name = jpype_tracer_last->m_Name;
 
-	for (int i = 0; i < jpype_traceLevel; i++)
-	{
-		JPYPE_TRACING_OUTPUT << "  ";
-	}
-	JPYPE_TRACING_OUTPUT << "<M>" << name << " : " << msg1 << " " << msg2 << "</M>" << endl;
+	jpype_indent(jpype_traceLevel);
+	JPYPE_TRACING_OUTPUT << name << ": " << msg1 << " " << msg2 << endl;
 	JPYPE_TRACING_OUTPUT.flush();
 }
 
 void JPypeTracer::traceLocks(const string& msg, void* ref)
 {
 	std::lock_guard<std::mutex> guard(trace_lock);
-	JPYPE_TRACING_OUTPUT << "<M>" << msg << ": " << ref << "</M>" << endl;
+	JPYPE_TRACING_OUTPUT << msg << ": " << ref  << endl;
 	JPYPE_TRACING_OUTPUT.flush();
 }
 

--- a/native/common/jp_tracer.cpp
+++ b/native/common/jp_tracer.cpp
@@ -125,7 +125,6 @@ void JPypeTracer::traceJavaObject(const char* msg, const void* ref)
 	if (ref == (void*) 0)
 	{
 		JPypeTracer::trace1("JNI", msg);
-		jpype_traceLevel++;
 		return;
 	}
 	if (ref == (void*) - 1)

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -68,7 +68,6 @@ static int PyJPArray_init(PyObject *self, PyObject *args, PyObject *kwargs)
 	JPValue *value = PyJPValue_getJavaSlot(v);
 	if (value != NULL)
 	{
-		JPJavaFrame frame(context);
 		JPArrayClass* arrayClass2 = dynamic_cast<JPArrayClass*> (value->getClass());
 		if (arrayClass2 == NULL)
 			JP_RAISE(PyExc_TypeError, "Class must be array type");
@@ -81,7 +80,7 @@ static int PyJPArray_init(PyObject *self, PyObject *args, PyObject *kwargs)
 
 	if (PySequence_Check(v))
 	{
-		JPJavaFrame frame(context);
+		JP_TRACE("Sequence");
 		jlong length =  PySequence_Size(v);
 		if (length < 0 || length > 2147483647)
 			JP_RAISE(PyExc_ValueError, "Array size invalid");
@@ -94,6 +93,8 @@ static int PyJPArray_init(PyObject *self, PyObject *args, PyObject *kwargs)
 
 	if (PyIndex_Check(v))
 	{
+		//		JPJavaFrame frame(context);
+		JP_TRACE("Index");
 		long long length = PyLong_AsLongLong(v);
 		if (length < 0 || length > 2147483647)
 			JP_RAISE(PyExc_ValueError, "Array size invalid");

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -637,7 +637,7 @@ PyMODINIT_FUNC PyInit__jpype()
 	// PyJPModule = module;
 	Py_INCREF(module);
 	PyJPModule = module;
-	PyModule_AddStringConstant(module, "__version__", "0.7.3");
+	PyModule_AddStringConstant(module, "__version__", "0.7.4");
 
 	// Initialize each of the python extension types
 	PyJPClass_initType(module);

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -142,6 +142,7 @@ void PyJPValue_finalize(void* obj)
 	JPContext *context = JPContext_global;
 	if (context == NULL || !context->isRunning())
 		return;
+	JPJavaFrame frame(context);
 	JPClass* cls = value->getClass();
 	// This one can't check for initialized because we may need to delete a stale
 	// resource after shutdown.
@@ -219,6 +220,9 @@ PyObject *PyJPValue_getattro(PyObject *obj, PyObject *name)
 	// Private members go regardless
 	if (PyUnicode_GetLength(name) && PyUnicode_ReadChar(name, 0) == '_')
 		return attr.keep();
+
+	JPContext *context = PyJPModule_getContext();
+	JPJavaFrame frame(context);
 
 	// Methods
 	if (Py_TYPE(attr.get()) == (PyTypeObject*) PyJPMethod_Type)

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -221,9 +221,6 @@ PyObject *PyJPValue_getattro(PyObject *obj, PyObject *name)
 	if (PyUnicode_GetLength(name) && PyUnicode_ReadChar(name, 0) == '_')
 		return attr.keep();
 
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame(context);
-
 	// Methods
 	if (Py_TYPE(attr.get()) == (PyTypeObject*) PyJPMethod_Type)
 		return attr.keep();

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ jpypeLib = Extension(name='_jpype', **setupext.platform.platform_specific)
 
 setup(
     name='JPype1',
-    version='0.7.2',
+    version='0.7.4',
     description='A Python to Java bridge.',
     long_description=open('README.rst').read(),
     license='License :: OSI Approved :: Apache Software License',
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development',
         'Topic :: Scientific/Engineering',
     ],

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -547,19 +547,18 @@ class ArrayTestCase(common.JPypeTestCase):
     def testZeroArray(self):
         ls = []
         ja = JArray(JInt)(ls)
-        self.assertEqual(len(ja),0)
+        self.assertEqual(len(ja), 0)
         na = np.array(ja)
-        self.assertEqual(len(ja),0)
+        self.assertEqual(len(ja), 0)
         ja = JArray(JString)(ls)
         with self.assertRaisesRegex(BufferError, "not primitive array"):
             memoryview(ja)
-        self.assertEqual(len(ja),0)
+        self.assertEqual(len(ja), 0)
         na = np.array(ja)
-        self.assertEqual(len(ja),0)
-        ja = JArray(JInt,2)([[],[1]])
+        self.assertEqual(len(ja), 0)
+        ja = JArray(JInt, 2)([[], [1]])
         with self.assertRaisesRegex(BufferError, "not rectangular"):
             memoryview(ja)
-        ja = JArray(JInt,2)([[1],[]])
+        ja = JArray(JInt, 2)([[1], []])
         with self.assertRaisesRegex(BufferError, "not rectangular"):
             memoryview(ja)
-

--- a/test/jpypetest/test_comparable.py
+++ b/test/jpypetest/test_comparable.py
@@ -33,17 +33,16 @@ class ComparableTestCase(common.JPypeTestCase):
         i1 = Instant.parse("1970-01-01T00:00:00Z")
         i3 = jpype.JObject(None, Instant)
 
-        self.assertTrue(i1==i1)
-        self.assertFalse(i1==i3)
-        self.assertFalse(i3==i1)
-        self.assertTrue(i1!=i3)
-        self.assertTrue(i3!=i1)
+        self.assertTrue(i1 == i1)
+        self.assertFalse(i1 == i3)
+        self.assertFalse(i3 == i1)
+        self.assertTrue(i1 != i3)
+        self.assertTrue(i3 != i1)
         with self.assertRaises(ValueError):
-            print(i1<i3)
+            print(i1 < i3)
         with self.assertRaises(ValueError):
-            print(i1<=i3)
+            print(i1 <= i3)
         with self.assertRaises(ValueError):
-            print(i1>i3)
+            print(i1 > i3)
         with self.assertRaises(ValueError):
-            print(i1>=i3)
-
+            print(i1 >= i3)

--- a/test/jpypetest/test_directbuffer.py
+++ b/test/jpypetest/test_directbuffer.py
@@ -117,16 +117,16 @@ class JBufferTestCase(common.JPypeTestCase):
         bf = method(obj)
         mv = np.asarray(memoryview(bf))
         ja = JArray(dtype)(5)
-        mv[:] = [1,2,3,4,5]
+        mv[:] = [1, 2, 3, 4, 5]
         bf.get(ja)
-        self.assertEqual(list(ja), [1,2,3,4,5])
+        self.assertEqual(list(ja), [1, 2, 3, 4, 5])
         obj.order(self.bo.LITTLE_ENDIAN)
         bf = method(obj)
         mv = np.asarray(memoryview(bf))
         ja = JArray(dtype)(5)
-        mv[:] = [1,2,3,4,5]
+        mv[:] = [1, 2, 3, 4, 5]
         bf.get(ja)
-        self.assertEqual(list(ja), [1,2,3,4,5])
+        self.assertEqual(list(ja), [1, 2, 3, 4, 5])
 
     @common.requireNumpy
     def testMemoryViewShortNP(self):
@@ -147,6 +147,3 @@ class JBufferTestCase(common.JPypeTestCase):
     @common.requireNumpy
     def testMemoryViewDoubleNP(self):
         self.checkNP(self.cls.asDoubleBuffer, JDouble, 8)
-
- 
-

--- a/test/jpypetest/test_exc.py
+++ b/test/jpypetest/test_exc.py
@@ -123,4 +123,3 @@ class ExceptionTestCase(common.JPypeTestCase):
         WE = jpype.JClass("jpype.exc.WierdException")
         with self.assertRaises(WE):
             WE.testThrow()
-

--- a/test/jpypetest/test_fault.py
+++ b/test/jpypetest/test_fault.py
@@ -3,6 +3,7 @@ import jpype
 from jpype import *
 import common
 
+
 class FaultTestCase(common.JPypeTestCase):
     """ Test for fault paths in JPype
 
@@ -1118,6 +1119,7 @@ class FaultTestCase(common.JPypeTestCase):
     def testClassHintsFaults(self):
         class CTest(object):
             pass
+
         @JConversion("java.lang.Number", exact=CTest)
         def _CTestConversion(jcls, obj):
             return java.lang.Integer(123)
@@ -1125,6 +1127,7 @@ class FaultTestCase(common.JPypeTestCase):
         class ATest(object):
             def __foo__(self):
                 pass
+
         @JConversion("java.lang.Number", attribute="__foo__")
         def _ATestConversion(jcls, obj):
             return java.lang.Integer(123)

--- a/test/jpypetest/test_javacoverage.py
+++ b/test/jpypetest/test_javacoverage.py
@@ -19,8 +19,10 @@ class JavaCoverageTestCase(common.JPypeTestCase):
     def testContext(self):
         self.assertEqual(self.inst.collectRectangular(None), None)
         self.assertEqual(self.inst.collectRectangular(JString('hello')), None)
-        self.assertEqual(self.inst.collectRectangular(JArray(JObject,2)([JArray(JObject)(0)])), None)
-        self.assertEqual(self.inst.collectRectangular(JArray(JObject)([None,None])), None)
+        self.assertEqual(self.inst.collectRectangular(
+            JArray(JObject, 2)([JArray(JObject)(0)])), None)
+        self.assertEqual(self.inst.collectRectangular(
+            JArray(JObject)([None, None])), None)
         self.assertEqual(self.inst.getExcValue(None), 0)
 
     def testRefQueue(self):
@@ -36,7 +38,7 @@ class JavaCoverageTestCase(common.JPypeTestCase):
         u2 = JPypeReference(None, None, 1, 0)
         self.assertTrue(u.equals(u))
         self.assertFalse(u.equals(u2))
-        self.assertFalse(u.equals(JString("a"))) 
+        self.assertFalse(u.equals(JString("a")))
 
     def testModifiers(self):
         cls = JClass('org.jpype.manager.ModifierCode')
@@ -71,7 +73,7 @@ class JavaCoverageTestCase(common.JPypeTestCase):
 
             @JOverride
             def assignMembers(self, context, cls, ctorMethod, methodList, fieldList):
-                return 
+                return
 
             @JOverride
             def defineField(self, context, cls, name, field, fieldType, modifiers):
@@ -102,26 +104,36 @@ class JavaCoverageTestCase(common.JPypeTestCase):
         with self.assertRaises(JException):
             manager.init()
 
-        self.assertEqual(factory.entities[manager.findClassByName('boolean')], 'boolean')
-        self.assertEqual(factory.entities[manager.findClassByName('byte')], 'byte')
-        self.assertEqual(factory.entities[manager.findClassByName('char')], 'char')
-        self.assertEqual(factory.entities[manager.findClassByName('short')], 'short')
-        self.assertEqual(factory.entities[manager.findClassByName('int')], 'int')
-        self.assertEqual(factory.entities[manager.findClassByName('long')], 'long')
-        self.assertEqual(factory.entities[manager.findClassByName('float')], 'float')
-        self.assertEqual(factory.entities[manager.findClassByName('double')], 'double')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('boolean')], 'boolean')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('byte')], 'byte')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('char')], 'char')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('short')], 'short')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('int')], 'int')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('long')], 'long')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('float')], 'float')
+        self.assertEqual(
+            factory.entities[manager.findClassByName('double')], 'double')
 
-        self.assertEqual(factory.entities[manager.findClass(JBoolean)], "boolean")
+        self.assertEqual(
+            factory.entities[manager.findClass(JBoolean)], "boolean")
         self.assertEqual(factory.entities[manager.findClass(JChar)], "char")
         self.assertEqual(factory.entities[manager.findClass(JByte)], "byte")
         self.assertEqual(factory.entities[manager.findClass(JShort)], "short")
         self.assertEqual(factory.entities[manager.findClass(JInt)], "int")
         self.assertEqual(factory.entities[manager.findClass(JLong)], "long")
         self.assertEqual(factory.entities[manager.findClass(JFloat)], "float")
-        self.assertEqual(factory.entities[manager.findClass(JDouble)], "double")
+        self.assertEqual(
+            factory.entities[manager.findClass(JDouble)], "double")
 
         self.assertEqual(manager.populateMethod(0, None), None)
-        
+
         sb = JClass("java.lang.StringBuilder")
         with self.assertRaises(JException):
             manager.populateMembers(sb)
@@ -129,11 +141,3 @@ class JavaCoverageTestCase(common.JPypeTestCase):
 
         # See if we leaked any entities
         self.assertEqual(len(factory.entities), 0)
-
-
-
-
-
-
-
-

--- a/test/jpypetest/test_jclass.py
+++ b/test/jpypetest/test_jclass.py
@@ -196,11 +196,9 @@ class JClassTestCase(common.JPypeTestCase):
         self.assertEqual(
             jpype.java.lang.Class._canConvertToJava(JString), "exact")
 
-
     def testInnerClass(self):
         # This tests for problems when the inner class implements the
-        # outer interface which creates a race condition.  Success is 
+        # outer interface which creates a race condition.  Success is
         # not throwing an exception
         test = JClass("jpype.types.InnerTest")()
         test.test()
-

--- a/test/jpypetest/test_jobject.py
+++ b/test/jpypetest/test_jobject.py
@@ -225,7 +225,7 @@ class JClassTestCase(common.JPypeTestCase):
     def testSetAttrFail2(self):
         fixture = JClass("jpype.common.Fixture")()
         with self.assertRaisesRegex(AttributeError, "is not settable"):
-            setattr(fixture,"callObject",4)
+            setattr(fixture, "callObject", 4)
 
     def testJavaPrimitives(self):
         self.assertIsInstance(
@@ -247,21 +247,26 @@ class JClassTestCase(common.JPypeTestCase):
 
     @common.requireNumpy
     def testNumpyPrimitives(self):
-        self.assertIsInstance(self.fixture.callObject(np.int8(1)), java.lang.Byte)
-        self.assertIsInstance(self.fixture.callObject(np.int16(1)), java.lang.Short)
-        self.assertIsInstance(self.fixture.callObject(np.int32(1)), java.lang.Integer)
-        self.assertIsInstance(self.fixture.callObject(np.int64(1)), java.lang.Long)
-        self.assertIsInstance(self.fixture.callObject(np.float32(1)), java.lang.Float)
-        self.assertIsInstance(self.fixture.callObject(np.float64(1)), java.lang.Double)
+        self.assertIsInstance(
+            self.fixture.callObject(np.int8(1)), java.lang.Byte)
+        self.assertIsInstance(self.fixture.callObject(
+            np.int16(1)), java.lang.Short)
+        self.assertIsInstance(self.fixture.callObject(
+            np.int32(1)), java.lang.Integer)
+        self.assertIsInstance(self.fixture.callObject(
+            np.int64(1)), java.lang.Long)
+        self.assertIsInstance(self.fixture.callObject(
+            np.float32(1)), java.lang.Float)
+        self.assertIsInstance(self.fixture.callObject(
+            np.float64(1)), java.lang.Double)
 
     def testCompare(self):
         jo = JClass("java.lang.Object")()
         with self.assertRaisesRegex(TypeError, 'not supported'):
-            jo<0
+            jo < 0
         with self.assertRaisesRegex(TypeError, 'not supported'):
-            jo<=0
+            jo <= 0
         with self.assertRaisesRegex(TypeError, 'not supported'):
-            jo>0
+            jo > 0
         with self.assertRaisesRegex(TypeError, 'not supported'):
-            jo>=0
-
+            jo >= 0

--- a/test/jpypetest/test_leak2.py
+++ b/test/jpypetest/test_leak2.py
@@ -6,13 +6,16 @@ import logging
 import time
 import common
 
+
 class Tracer(object):
     ctor = 0
     dtor = 0
+
     def __init__(self):
-        Tracer.ctor +=1 
+        Tracer.ctor += 1
+
     def __del__(self):
-        Tracer.dtor +=1 
+        Tracer.dtor += 1
 
     @staticmethod
     def reset():
@@ -26,10 +29,10 @@ class Tracer(object):
     @staticmethod
     def attach(obj):
         object.__setattr__(obj, "_trace", Tracer())
-    
 
-# This test finds reference counting leak by attaching an 
-# object that lives as long as the wrapper is alive.  
+
+# This test finds reference counting leak by attaching an
+# object that lives as long as the wrapper is alive.
 # It can't detect Java reference counter leaks.
 class Leak2TestCase(common.JPypeTestCase):
 
@@ -40,6 +43,7 @@ class Leak2TestCase(common.JPypeTestCase):
 
     def testArrayCall(self):
         JA = JArray(JInt)
+
         def call():
             inst = JA(100)
             Tracer.attach(inst)
@@ -50,6 +54,7 @@ class Leak2TestCase(common.JPypeTestCase):
 
     def testArrayMemoryView(self):
         JA = JArray(JInt)
+
         def call():
             inst = JA(100)
             Tracer.attach(inst)
@@ -60,6 +65,7 @@ class Leak2TestCase(common.JPypeTestCase):
 
     def testBufferCall(self):
         byte_buffer = jpype.JClass('java.nio.ByteBuffer')
+
         def call():
             inst = byte_buffer.allocateDirect(10)
             Tracer.attach(inst)
@@ -70,6 +76,7 @@ class Leak2TestCase(common.JPypeTestCase):
 
     def testBufferMemoryView(self):
         byte_buffer = jpype.JClass('java.nio.ByteBuffer')
+
         def call():
             inst = byte_buffer.allocateDirect(10)
             Tracer.attach(inst)
@@ -77,4 +84,3 @@ class Leak2TestCase(common.JPypeTestCase):
         for i in range(100):
             call()
         self.assertEqual(Tracer.leaked(), 0)
-

--- a/test/jpypetest/test_zzz.py
+++ b/test/jpypetest/test_zzz.py
@@ -18,4 +18,3 @@ class ZZZTestCase(common.JPypeTestCase):
 
     def testShutdown(self):
         jpype.shutdownJVM()
-


### PR DESCRIPTION
While tracing through another bug report I found to my horror that there was a problem with local referencing which causes arrays to leak references both when used directly and when used as part of argument handling which is a major problem.   I recommend that we do a 0.7.4 release to deal with this significant issue. 

Fixes #712 

The fix for the issue was to remove two incorrect keep statements.   Finding it was much more challenging.  The resource in this case was being lost during the middle of a call to variable arguments.  The result was the Java frame was now the root frame and pushing all the local references that were after the bad call to global scope.   I am not sure why Java doesn't flag this type of problem directly.  There is no case in which creating local references without a frame is acceptable so ``-Xcheck:jni`` should have caught it.  To identify this hairy issue I had to upgrade the trace utilities to report python, java and trace events and allow them to be selectively controlled.  Once it was clear the source, I developed an internal consistency check which is evaluated whenever instrumentation or tracing is enabled.  Creating a local reference outside of Java frame will now trigger an exception.   The only case where this does not happen is on the exception paths where throwing an exception is likely to be fatal and thus lead to a lack of diagnostics.   This modification ensures that the current test bench will fail if this issue ever reappears.

I backported this from the head so it excludes all of the other changes on master.
