### PR TITLE
Mutable list

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -35,7 +35,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
   - Updated the repr methods on Java classes.
 
-  - ``java.util.List`` completes the contract for ``collections.abc.Sequence``.
+  - ``java.util.List`` completes the contract for ``collections.abc.Sequence``
+    and ``collections.abc.MutableSequence``.
 
   - ``java.util.Collection`` completes the contract for ``collections.abc.Collection``.
   

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -217,7 +217,6 @@ def startJVM(*args, **kwargs):
                     jvmpath, version)) from ex
         raise
 
-
     _jpype._java_lang_Class = None
     _jpype._java_lang_Object = _jpype.JClass("java.lang.Object")
     _jpype._java_lang_Throwable = _jpype.JClass("java.lang.Throwable")
@@ -292,7 +291,9 @@ def startJVM(*args, **kwargs):
     _jpype._type_classes[_jpype.JObject] = _jpype._java_lang_Object
     _jinit.runJVMInitializers()
 
-    _jpype.JClass('org.jpype.JPypeKeywords').setKeywords(list(_pykeywords._KEYWORDS))
+    _jpype.JClass('org.jpype.JPypeKeywords').setKeywords(
+        list(_pykeywords._KEYWORDS))
+
 
 def attachToJVM(jvm):
     _jpype.attach(jvm)
@@ -421,4 +422,3 @@ class _JRuntime(object):
 
     def removeShutdownHook(self, thread):
         return _jpype.JClass("org.jpype.JPypeContext").getInstance().removeShutdownHook(thread)
-

--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -134,6 +134,26 @@ class _JList(object):
         except TypeError:
             return 0
 
+    def insert(self, idx, obj):
+        return self.add(idx, obj)
+
+    def append(self, obj):
+        return self.add(obj)
+
+    def reverse(self):
+        _jpype.JClass("java.util.Collections").reverse(self)
+
+    def extend(self, lst):
+        self.addAll(lst)
+
+    def pop(self, idx=None):
+        if idx is None:
+            idx = len(self)-1
+        return self.remove(_jtypes.JInt(idx))
+
+    def __iadd__(self, obj):
+        self.add(self, obj)
+
 
 def isPythonMapping(v):
     if isinstance(v, Mapping):

--- a/jpype/_jcustomizer.py
+++ b/jpype/_jcustomizer.py
@@ -153,7 +153,7 @@ def _applyCustomizerImpl(members, proto, sticky, setter):
                 # Apply rename
                 rename = attr.get('rename', "_"+p)
                 if p in members and isinstance(members[p], (_jpype._JField, _jpype._JMethod)):
-                   setter(rename, members[p])
+                    setter(rename, members[p])
             setter(p, v)
 
 
@@ -175,22 +175,21 @@ def _applyCustomizerPost(cls, proto):
     _applyCustomizerImpl(cls.__dict__, proto, sticky,
                          lambda p, v: type.__setattr__(cls, p, v))
 
-    # Apply a customizer to all derived classes
-    if '__jclass_init__' in proto.__dict__:
-        method = proto.__dict__['__jclass_init__']
-        _applyAll(cls, method)
-
     # Merge sticky into existing __jclass_init__
     if len(sticky) > 0:
         method = proto.__dict__.get('__jclass_init__', None)
-
         def init(cls):
             if method:
                 method(cls)
             _applyStickyMethods(cls, sticky)
         type.__setattr__(cls, '__jclass_init__', init)
-        _applyAll(cls, init)
 
+    # Apply a customizer to all derived classes
+    if '__jclass_init__' in proto.__dict__:
+        method = proto.__dict__['__jclass_init__']
+        _applyAll(cls, method)
+
+ 
 
 class JClassHints(_jpype._JClassHints):
     """ ClassHints holds class customizers and conversions.
@@ -241,7 +240,10 @@ class JClassHints(_jpype._JClassHints):
                                  lambda p, v: members.__setitem__(p, v))
 
         if len(sticky) > 0:
+            method = members.get('__jclass_init__', None)
             def init(cls):
+                if method is not None:
+                   method(cls) 
                 _applyStickyMethods(cls, sticky)
             members['__jclass_init__'] = init
 

--- a/jpype/_jcustomizer.py
+++ b/jpype/_jcustomizer.py
@@ -16,6 +16,9 @@ import _jpype
 
 __all__ = ['JImplementationFor', 'JConversion']
 
+# Member types that are copied from the prototype
+_jcopymembers = (str, property, staticmethod, classmethod)
+
 
 def JConversion(cls, exact=None, instanceof=None, attribute=None, excludes=None):
     """ Decorator to define a method as a converted a Java type.
@@ -121,10 +124,11 @@ def _applyStickyMethods(cls, sticky):
     for method in sticky:
         attr = getattr(method, '__joverride__')
         rename = attr.get('rename', None)
+        name = method.__name__
         if rename:
-            type.__setattr__(
-                cls, rename, type.__getattribute__(cls, method.__name__))
-        type.__setattr__(cls, method.__name__, method)
+            orig = type.__getattribute__(cls, name)
+            type.__setattr__(cls, rename, orig)
+        type.__setattr__(cls, name, method)
 
 
 def _applyCustomizerImpl(members, proto, sticky, setter):
@@ -139,20 +143,17 @@ def _applyCustomizerImpl(members, proto, sticky, setter):
 
     """
     for p, v in proto.__dict__.items():
-        if callable(v) or isinstance(v, (str, property, staticmethod, classmethod)):
-            rename = "_"+p
-
+        if callable(v) or isinstance(v, _jcopymembers):
             # Apply JOverride annotation
             attr = getattr(v, '__joverride__', None)
             if attr is not None:
                 if attr.get('sticky', False):
                     sticky.append(v)
-                rename = attr.get('rename', rename)
-
-            # Apply rename
-            if p in members and isinstance(members[p], (_jpype._JField, _jpype._JMethod)):
-                setter(rename, members[p])
-
+                    continue
+                # Apply rename
+                rename = attr.get('rename', "_"+p)
+                if p in members and isinstance(members[p], (_jpype._JField, _jpype._JMethod)):
+                   setter(rename, members[p])
             setter(p, v)
 
 

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -81,6 +81,7 @@ _java_lang_NoClassDefFoundError = None
 _java_lang_ClassNotFoundException = None
 _java_lang_UnsupportedClassVersionError = None
 
+
 def _getJavaClass(javaname):
     """ This produces diagnostics on failing to find a Java class """
     global _java_lang_Class
@@ -182,6 +183,7 @@ def unwrap(name):
         return name
     return ".".join([_keywordUnwrap(i) for i in name.split('.')])
 
+
 class _JImportLoader:
     """ (internal) Finder hook for importlib. """
 
@@ -210,10 +212,10 @@ class _JImportLoader:
         for customizer in _CUSTOMIZERS:
             if customizer.canCustomize(name):
                 return customizer.getSpec(name)
-  
+
         # Using isPackage eliminates need for registering tlds
         if not hasattr(base, parts[2]):
-            # If the base is a Java package and it wasn't found in the 
+            # If the base is a Java package and it wasn't found in the
             # package using getAttr, then we need to emit an error
             # so we produce a meaningful diagnositic.
             _getJavaClass(name)
@@ -263,4 +265,3 @@ registerDomain('org')
 registerDomain('mil')
 registerDomain('edu')
 registerDomain('net')
-

--- a/jpype/protocol.py
+++ b/jpype/protocol.py
@@ -19,8 +19,8 @@ _JBuffer = _jpype._JBuffer
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol, runtime_checkable
-    from typing import Sequence, Mapping # lgtm [py/unused-import]
-    from typing import SupportsFloat, Callable # lgtm [py/unused-import]
+    from typing import Sequence, Mapping  # lgtm [py/unused-import]
+    from typing import SupportsFloat, Callable  # lgtm [py/unused-import]
 
     @runtime_checkable
     class SupportsIndex(Protocol):
@@ -30,13 +30,14 @@ if sys.version_info < (3, 8):
 else:
     # 3.8 onward
     from typing import Protocol, runtime_checkable
-    from typing import SupportsIndex, SupportsFloat # lgtm [py/unused-import]
-    from typing import Sequence, Mapping, Callable # lgtm [py/unused-import]
+    from typing import SupportsIndex, SupportsFloat  # lgtm [py/unused-import]
+    from typing import Sequence, Mapping, Callable  # lgtm [py/unused-import]
 
 # Types we need
 @runtime_checkable
 class SupportsPath(Protocol):
     def __fspath__(self) -> str: ...
+
 
 @_jcustomizer.JConversion("java.nio.file.Path", instanceof=SupportsPath)
 def _JPathConvert(jcls, obj):
@@ -50,7 +51,7 @@ def _JFileConvert(jcls, obj):
 
 
 @_jcustomizer.JConversion("java.util.Collection", instanceof=Sequence,
-        excludes=str)
+                          excludes=str)
 def _JSequenceConvert(jcls, obj):
     return _jclass.JClass('java.util.Arrays').asList(obj)
 

--- a/test/harness/jpype/override/A.java
+++ b/test/harness/jpype/override/A.java
@@ -1,0 +1,10 @@
+package jpype.override;
+
+public class A
+{
+   public int remove(Object o)
+   {
+       return 1;
+   }
+}
+       

--- a/test/harness/jpype/override/B.java
+++ b/test/harness/jpype/override/B.java
@@ -1,0 +1,10 @@
+package jpype.override;
+
+public class B extends A
+{
+   public int remove(Object o)
+   {
+       return 2;
+   }
+}
+ 

--- a/test/jpypetest/test_conversion.py
+++ b/test/jpypetest/test_conversion.py
@@ -13,11 +13,13 @@ class ConversionTestCase(common.JPypeTestCase):
 
     def testList(self):
         cls = JClass('jpype.collection.CollectionTest')
-        self.assertIsInstance(cls.testList([1,2,3]), JClass('java.util.List'))
+        self.assertIsInstance(cls.testList(
+            [1, 2, 3]), JClass('java.util.List'))
 
     def testMap(self):
         cls = JClass('jpype.collection.CollectionTest')
-        self.assertIsInstance(cls.testMap({'a':1, 'b':2}), JClass('java.util.Map'))
+        self.assertIsInstance(cls.testMap(
+            {'a': 1, 'b': 2}), JClass('java.util.Map'))
 
     def testCanConvertExact(self):
         self.assertEqual(self.jc1._canConvertToJava("a"), "exact")

--- a/test/jpypetest/test_customizer.py
+++ b/test/jpypetest/test_customizer.py
@@ -1,0 +1,29 @@
+import _jpype
+import jpype
+from jpype.types import *
+from jpype import java
+import common
+try:
+    import numpy as np
+except ImportError:
+    pass
+
+
+class CustomizerTestCase(common.JPypeTestCase):
+    def setUp(self):
+        common.JPypeTestCase.setUp(self)
+        self.fixture = JClass('jpype.common.Fixture')()
+
+    def testSticky(self):
+        @jpype.JImplementationFor("jpype.override.A")
+        class _A:
+            @jpype.JOverride(sticky=True, rename="remove_")
+            def remove(self, obj):
+                pass
+
+        A = jpype.JClass("jpype.override.A")
+        B = jpype.JClass("jpype.override.B")
+        self.assertEqual(A.remove, _A.remove)
+        self.assertEqual(B.remove, _A.remove)
+        self.assertEqual(str(A.remove_), "jpype.override.A.remove")
+        self.assertEqual(str(B.remove_), "jpype.override.B.remove")

--- a/test/jpypetest/test_fault.py
+++ b/test/jpypetest/test_fault.py
@@ -252,7 +252,7 @@ class FaultTestCase(common.JPypeTestCase):
 
         def f():
             pass
-        #with self.assertRaises(TypeError):
+        # with self.assertRaises(TypeError):
         #    _jpype._JClassHints()._addTypeConversion(None, f, 1)
         with self.assertRaises(TypeError):
             _jpype._JClassHints()._addTypeConversion(str, None, 1)

--- a/test/jpypetest/test_hints.py
+++ b/test/jpypetest/test_hints.py
@@ -34,8 +34,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.implicit)
         self.assertTrue(proto._JClass in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testNumber(self):
         cls = JClass('java.lang.Number')
@@ -45,8 +45,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(proto._JNumberFloat in hints.implicit)
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testString(self):
         cls = JClass('java.lang.String')
@@ -54,8 +54,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(str in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testClass(self):
         cls = JClass('java.lang.Class')
@@ -63,8 +63,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto._JClass in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testCollection(self):
         cls = JClass('java.util.Collection')
@@ -72,7 +72,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testList(self):
@@ -80,9 +80,9 @@ class HintsTestCase(common.JPypeTestCase):
         hints = cls._hints
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
-        self.assertTrue(len(hints.implicit)==0)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.implicit) == 0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJBoolean(self):
         cls = JBoolean
@@ -93,7 +93,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JClass("java.lang.Boolean") in hints.implicit)
         self.assertTrue(proto.SupportsIndex in hints.explicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJChar(self):
         cls = JChar
@@ -102,8 +102,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.exact)
         self.assertTrue(JClass("java.lang.Character") in hints.implicit)
         self.assertTrue(str in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJShort(self):
         cls = JShort
@@ -115,7 +115,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JClass("java.lang.Short") in hints.implicit)
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJInt(self):
         cls = JInt
@@ -128,7 +128,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JClass('java.lang.Integer') in hints.implicit)
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJLong(self):
         cls = JLong
@@ -142,7 +142,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JClass('java.lang.Long') in hints.implicit)
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJFloat(self):
         cls = JFloat
@@ -158,8 +158,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(int in hints.implicit)
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testJDouble(self):
         cls = JDouble
@@ -176,8 +176,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(proto.SupportsIndex in hints.implicit)
         self.assertTrue(proto.SupportsFloat in hints.implicit)
         self.assertTrue(int in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedByte(self):
         cls = JClass('java.lang.Byte')
@@ -188,7 +188,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(proto.SupportsFloat in hints.explicit)
         self.assertTrue(JClass('java.lang.Byte') in hints.explicit)
         self.assertTrue(proto.SupportsIndex in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedBoolean(self):
         cls = JClass('java.lang.Boolean')
@@ -200,7 +200,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(proto.SupportsIndex in hints.explicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
         self.assertTrue(JClass('java.lang.Boolean') in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedCharacter(self):
         cls = JClass('java.lang.Character')
@@ -210,7 +210,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JChar in hints.implicit)
         self.assertTrue(JClass('java.lang.Character') in hints.explicit)
         self.assertTrue(str in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedShort(self):
         cls = JClass('java.lang.Short')
@@ -223,7 +223,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JChar in hints.explicit)
         self.assertTrue(JClass('java.lang.Short') in hints.explicit)
         self.assertTrue(proto.SupportsIndex in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedInteger(self):
         cls = JClass('java.lang.Integer')
@@ -237,7 +237,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JShort in hints.explicit)
         self.assertTrue(JClass('java.lang.Integer') in hints.explicit)
         self.assertTrue(proto.SupportsIndex in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedLong(self):
         cls = JClass('java.lang.Long')
@@ -252,7 +252,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(JInt in hints.explicit)
         self.assertTrue(JClass('java.lang.Long') in hints.explicit)
         self.assertTrue(proto.SupportsIndex in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedFloat(self):
         cls = JClass('java.lang.Float')
@@ -269,7 +269,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(int in hints.explicit)
         self.assertTrue(proto.SupportsIndex in hints.explicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testBoxedDouble(self):
         cls = JClass('java.lang.Double')
@@ -287,7 +287,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(proto.SupportsIndex in hints.explicit)
         self.assertTrue(proto.SupportsFloat in hints.explicit)
         self.assertTrue(int in hints.explicit)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testObjectArray(self):
         cls = JClass('java.lang.Object[]')
@@ -295,7 +295,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testBooleanArray(self):
@@ -304,7 +304,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testCharArray(self):
@@ -314,8 +314,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.exact)
         self.assertTrue(str in hints.implicit)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testShortArray(self):
         cls = JClass('short[]')
@@ -323,7 +323,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testIntArray(self):
@@ -332,7 +332,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testLongArray(self):
@@ -341,7 +341,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testFloatArray(self):
@@ -350,7 +350,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testDoubleArray(self):
@@ -359,7 +359,7 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.Sequence in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
+        self.assertTrue(len(hints.explicit) == 0)
         self.assertTrue(str in hints.none)
 
     def testPath(self):
@@ -368,8 +368,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.SupportsPath in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testFile(self):
         cls = JClass('java.io.File')
@@ -377,8 +377,8 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(proto.SupportsPath in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)
 
     def testInstant(self):
         import datetime
@@ -387,6 +387,5 @@ class HintsTestCase(common.JPypeTestCase):
         self.assertTrue(cls in hints.returns)
         self.assertTrue(cls in hints.exact)
         self.assertTrue(datetime.datetime in hints.implicit)
-        self.assertTrue(len(hints.explicit)==0)
-        self.assertTrue(len(hints.none)==0)
-
+        self.assertTrue(len(hints.explicit) == 0)
+        self.assertTrue(len(hints.none) == 0)

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -207,5 +207,3 @@ class JByteTestCase(common.JPypeTestCase):
             ja[0:1] = [java.lang.Double(321)]
         with self.assertRaises(TypeError):
             ja[0:1] = [object()]
-
-

--- a/test/jpypetest/test_jshort.py
+++ b/test/jpypetest/test_jshort.py
@@ -376,7 +376,6 @@ class JShortTestCase(common.JPypeTestCase):
         with self.assertRaises(TypeError):
             ja[0:1] = [object()]
 
-
     def testArrayConversionFail(self):
         jarr = JArray(JShort)(VALUES)
         with self.assertRaises(TypeError):

--- a/test/jpypetest/test_list.py
+++ b/test/jpypetest/test_list.py
@@ -127,13 +127,16 @@ class JListTestCase(common.JPypeTestCase):
         obj.add("b")
         obj.add("c")
         del obj[1]
-        self.assertEqual(tuple(i for i in obj), ('a', 'c'))
+        self.assertElementsEqual(obj, ('a', 'c'))
         obj.add("a")
         obj.add("b")
         obj.add("c")
         del obj[1:3]
+        self.assertElementsEqual(obj, ('a', 'b', 'c'))
         with self.assertRaises(TypeError):
             del obj[1.0]
+        del obj[-1]
+        self.assertElementsEqual(obj, ('a', 'b'))
 
     def testAddAll(self):
         obj = self.cls()
@@ -244,6 +247,8 @@ class JListTestCase(common.JPypeTestCase):
             obj.remove(1)
         with self.assertRaises(ValueError):
             obj.remove('1')
+        with self.assertRaises(ValueError):
+            obj.remove(object())
         self.assertElementsEqual(obj, lst)
         
 

--- a/test/jpypetest/test_list.py
+++ b/test/jpypetest/test_list.py
@@ -171,10 +171,12 @@ class JListTestCase(common.JPypeTestCase):
         lst = ['A', 'B', 'C']
         cls = jpype.JClass('java.util.ArrayList')
         obj = cls(lst)
-        obj.insert(0,'1')
-        obj.insert(3,'2')
-        lst.insert(0,'1')
-        lst.insert(3,'2')
+        lst.insert(0, '1')
+        obj.insert(0, '1')
+        lst.insert(3, '2')
+        obj.insert(3, '2')
+        lst.insert(-1, '3')
+        obj.insert(-1, '3')
         self.assertElementsEqual(obj, lst)
 
     def testAppend(self):
@@ -199,8 +201,8 @@ class JListTestCase(common.JPypeTestCase):
         lst = ['A', 'B', 'C']
         cls = jpype.JClass('java.util.ArrayList')
         obj = cls(lst)
-        obj.extend(range(0,3))
-        lst.extend(range(0,3))
+        obj.extend(range(0, 3))
+        lst.extend(range(0, 3))
         self.assertElementsEqual(obj, lst)
 
     def testPop(self):
@@ -210,6 +212,7 @@ class JListTestCase(common.JPypeTestCase):
         self.assertEqual(obj.pop(), lst.pop())
         self.assertEqual(obj.pop(0), lst.pop(0))
         self.assertEqual(obj.pop(2), lst.pop(2))
+        self.assertEqual(obj.pop(-1), lst.pop(-1))
         self.assertElementsEqual(obj, lst)
 
     def testIAdd(self):
@@ -220,3 +223,38 @@ class JListTestCase(common.JPypeTestCase):
         lst += 'D'
         self.assertElementsEqual(obj, lst)
 
+    def testAdd(self):
+        lst = ['A', 'B', 'C']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        lst2 = lst + ['D']
+        obj2 = obj + ['D']
+        self.assertElementsEqual(obj, lst)
+        self.assertElementsEqual(obj2, lst2)
+
+    def testRemove(self):
+        lst = ['A', 'B', 'C', 'D', 'E']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        lst.remove('C')
+        obj.remove('C')
+        with self.assertRaises(ValueError):
+            lst.remove('C')
+        with self.assertRaises(ValueError):
+            obj.remove(1)
+        with self.assertRaises(ValueError):
+            obj.remove('1')
+        self.assertElementsEqual(obj, lst)
+        
+
+    def testProtocol(self):
+        from collections.abc import Sequence, MutableSequence
+        List = jpype.JClass('java.util.List')
+        ArrayList = jpype.JClass('java.util.ArrayList')
+        LinkedList = jpype.JClass('java.util.LinkedList')
+        self.assertTrue(issubclass(List, Sequence))
+        self.assertTrue(issubclass(List, MutableSequence))
+        self.assertTrue(issubclass(ArrayList, Sequence))
+        self.assertTrue(issubclass(ArrayList, MutableSequence))
+        self.assertTrue(issubclass(LinkedList, Sequence))
+        self.assertTrue(issubclass(LinkedList, MutableSequence))

--- a/test/jpypetest/test_list.py
+++ b/test/jpypetest/test_list.py
@@ -166,3 +166,57 @@ class JListTestCase(common.JPypeTestCase):
         cls = jpype.JClass('java.util.ArrayList')
         obj = cls(self.Arrays.asList(['a', 'b', 'c']))
         self.assertEqual(tuple(i for i in obj), ('a', 'b', 'c'))
+
+    def testInsert(self):
+        lst = ['A', 'B', 'C']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        obj.insert(0,'1')
+        obj.insert(3,'2')
+        lst.insert(0,'1')
+        lst.insert(3,'2')
+        self.assertElementsEqual(obj, lst)
+
+    def testAppend(self):
+        lst = ['A', 'B', 'C']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        obj.append('2')
+        lst.append('2')
+        lst[len(lst):] = ['3']
+        obj[len(obj):] = ['3']
+        self.assertElementsEqual(obj, lst)
+
+    def testReverse(self):
+        lst = ['A', 'B', 'C']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        obj.reverse()
+        lst.reverse()
+        self.assertElementsEqual(obj, lst)
+
+    def testExtend(self):
+        lst = ['A', 'B', 'C']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        obj.extend(range(0,3))
+        lst.extend(range(0,3))
+        self.assertElementsEqual(obj, lst)
+
+    def testPop(self):
+        lst = ['A', 'B', 'C', 'D', 'E']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        self.assertEqual(obj.pop(), lst.pop())
+        self.assertEqual(obj.pop(0), lst.pop(0))
+        self.assertEqual(obj.pop(2), lst.pop(2))
+        self.assertElementsEqual(obj, lst)
+
+    def testIAdd(self):
+        lst = ['A', 'B', 'C']
+        cls = jpype.JClass('java.util.ArrayList')
+        obj = cls(lst)
+        obj += 'D'
+        lst += 'D'
+        self.assertElementsEqual(obj, lst)
+

--- a/test/jpypetest/test_reflect.py
+++ b/test/jpypetest/test_reflect.py
@@ -73,4 +73,3 @@ class ReflectCase(common.JPypeTestCase):
         self.assertIsNotNone(obj)
         self.assertIsNotNone(field)
         self.assertEqual('private', field.get(obj))
-


### PR DESCRIPTION
This completes the MutableSequence contract on ``java.util.List``. 

In addition, it fixes the following bugs:
- sticky methods were being applied twice causing endless recursion in some cases.
- sticky methods removed ``__jclass_init__`` on a base class.
- delitem on negative indices failed.
