### PR TITLE
Fixing read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+#   formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+    version: 3.8
+    install:
+      - requirements: docs/requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,18 @@
 # https://aka.ms/yaml
 
 pr:
-  - master
-  - release
-  - releases/*
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    include:
+    - doc/*
+    - setup.py
+    - setupext/*
+    - jpype/*
+    - native/*
+    - test/*
 
 jobs:
 - job: Documentation


### PR DESCRIPTION
Attempt to get rtd to use 3.8 to avoid typing_extensions requirement.