### PR TITLE
One line fix to avoid distrubing daemon threads during shutdown.

### DIFF
--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -190,7 +190,7 @@ public class JPypeContext
 
       for (Thread t : threads.keySet())
       {
-        if (t1 == t)
+        if (t1 == t || t.isDaemon())
           continue;
 //      if (t.getState() == Thread.State.RUNNABLE)
         t.interrupt();


### PR DESCRIPTION
A bug in the new shutdown routine caused the Java native reference queue to get pinged with an InterruptedException.   This PR corrects the issue removing the warning message.  It was not clear if the warning was harmful, but better to fix it.