### PR TITLE
Corrections for 3.8.4

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,13 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 - **Next version - unreleased**
 - **1.0.1_dev0 - 2020-07-14**
+
+  - Workarounds for Python 3.8.4 release.  Python altered logic regarding the
+    use of ``__setattr__`` for object and type, preventing it from being used
+    to alter derived classes.  Also the checking for errors was delegated from
+    the ``__setattr__`` method so exception types on some sanity checks 
+    needed to be updated accordingly.
+
 - **1.0.0 - 2020-07-12**
 
   - ``JChar`` is supported as a return type, thus rather than returning a

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -146,7 +146,7 @@ def _jclassPost(res, *args):
             if cls.getModifiers() & 1 == 0:
                 continue
             wrapper = _jpype.JClass(cls)
-            type.__setattr__(res, str(cls.getSimpleName()), wrapper)
+            res._customize(str(cls.getSimpleName()), wrapper)
 
 
 def _jclassDoc(cls):

--- a/jpype/_jcustomizer.py
+++ b/jpype/_jcustomizer.py
@@ -92,7 +92,7 @@ def JImplementationFor(clsname, base=False):
 
     The method ``__jclass_init__(cls)`` will be called with the constructed
     class as the argument.  This call is used to set methods for all classes
-    that derive from the specified class.  Use ``type.__setattr__()`` to
+    that derive from the specified class.  Use ``jclass._customize()`` to
     alter the class methods.
 
     Using the prototype class as a base class is used mainly to support
@@ -130,8 +130,8 @@ def _applyStickyMethods(cls, sticky):
         name = method.__name__
         if rename:
             orig = type.__getattribute__(cls, name)
-            type.__setattr__(cls, rename, orig)
-        type.__setattr__(cls, name, method)
+            cls._customize(rename, orig)
+        cls._customize(name, method)
 
 
 def _applyCustomizerImpl(members, proto, sticky, setter):
@@ -176,7 +176,7 @@ def _applyCustomizerPost(cls, proto):
     """ (internal) Customize a class after it has been created """
     sticky = []
     _applyCustomizerImpl(cls.__dict__, proto, sticky,
-                         lambda p, v: type.__setattr__(cls, p, v))
+                         lambda p, v: cls._customize(p, v))
 
     # Merge sticky into existing __jclass_init__
     if len(sticky) > 0:
@@ -186,7 +186,7 @@ def _applyCustomizerPost(cls, proto):
             if method:
                 method(cls)
             _applyStickyMethods(cls, sticky)
-        type.__setattr__(cls, '__jclass_init__', init)
+        cls._customize('__jclass_init__', init)
 
     # Apply a customizer to all derived classes
     if '__jclass_init__' in proto.__dict__:

--- a/jpype/beans.py
+++ b/jpype/beans.py
@@ -96,4 +96,4 @@ class _BeansCustomizer(object):
                 continue
 
             # Add the property
-            type.__setattr__(self, attr_name, property(getter, setter))
+            self._customize(attr_name, property(getter, setter))

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -324,7 +324,7 @@ string JPPyString::asStringUTF8(PyObject* pyobj)
 		return string(buffer, size);
 	}
 	// GCOVR_EXCL_START
-	JP_RAISE(PyExc_RuntimeError, "Failed to convert to string.");
+	JP_RAISE(PyExc_TypeError, "Failed to convert to string.");
 	return string();
 	JP_TRACE_OUT;
 	// GCOVR_EXCL_STOP

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -921,6 +921,19 @@ int PyJPClass_setDoc(PyJPClass *self, PyObject *obj, void *ctxt)
 	JP_PY_CATCH(-1);
 }
 
+PyObject* PyJPClass_customize(PyJPClass *self, PyObject *args, PyObject *kwargs)
+{
+	JP_PY_TRY("PyJPClass_customize");
+	PyObject *name = NULL;
+	PyObject *value = NULL;
+	if (!PyArg_ParseTuple(args, "OO", &name, &value))
+		return NULL;
+	if (PyType_Type.tp_setattro((PyObject*) self, name, value) == -1)
+		return NULL;
+	Py_RETURN_NONE;
+	JP_PY_CATCH(NULL);
+}
+
 static PyMethodDef classMethods[] = {
 	{"__instancecheck__", (PyCFunction) PyJPClass_instancecheck, METH_O, ""},
 	{"__subclasscheck__", (PyCFunction) PyJPClass_subclasscheck, METH_O, ""},
@@ -930,6 +943,7 @@ static PyMethodDef classMethods[] = {
 	{"_cast",             (PyCFunction) PyJPClass_cast, METH_O, ""},
 	{"_canCast",          (PyCFunction) PyJPClass_canCast, METH_O, ""},
 	{"__getitem__",       (PyCFunction) PyJPClass_array, METH_O | METH_COEXIST, ""},
+	{"_customize",        (PyCFunction) PyJPClass_customize, METH_VARARGS, ""},
 	{NULL},
 };
 

--- a/test/jpypetest/test_leak2.py
+++ b/test/jpypetest/test_leak2.py
@@ -44,7 +44,7 @@ class Tracer(object):
 
     @staticmethod
     def attach(obj):
-        obj.__setattr__("_trace", Tracer())
+        setattr(obj, "_trace", Tracer())
 
 
 # This test finds reference counting leak by attaching an

--- a/test/jpypetest/test_leak2.py
+++ b/test/jpypetest/test_leak2.py
@@ -44,7 +44,7 @@ class Tracer(object):
 
     @staticmethod
     def attach(obj):
-        object.__setattr__(obj, "_trace", Tracer())
+        obj.__setattr__("_trace", Tracer())
 
 
 # This test finds reference counting leak by attaching an


### PR DESCRIPTION
Unfortunately no sooner that getting 1.0.0 out the door, Pythons latest patch release changed a bunch of behaviors that we used.  Heaptypes can no longer be monkey patched.   So a special method is required provide a way to customize the class.  

Fixes #787