### PR TITLE
Add pyjnius to the alternatives

### DIFF
--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -408,6 +408,18 @@ of the use of Python many be hard to realize.  In addition, the documentation
 is a bit underwhelming thus it is difficult to see how capable it is from the
 limited examples.
 
+`PyJnius <https://github.com/kivy/pyjnius>`_
+--------------------------------------------
+
+PyJnius is another Python to Java only bridge.  Syntax is somewhat similar to
+JPype in that classes can be loaded in and then have mostly Java native syntax.
+Like JPype, it provides an ability to customize Java classes so that they
+appear more like native classes.  PyJnius seems to be focused on Android.  It
+is written using Cython .pxi files for speed.  It does not include a method to
+represent primitive arrays, thus Python list must be converted whenever an
+array needs to be passed as an argument or a return.  This seems pretty
+prohibitive for scientific code.  PyJnius to still be in active development.
+
 `Javabridge <https://github.com/CellProfiler/python-javabridge/>`_
 ------------------------------------------------------------------
 

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -418,7 +418,7 @@ appear more like native classes.  PyJnius seems to be focused on Android.  It
 is written using Cython .pxi files for speed.  It does not include a method to
 represent primitive arrays, thus Python list must be converted whenever an
 array needs to be passed as an argument or a return.  This seems pretty
-prohibitive for scientific code.  PyJnius to still be in active development.
+prohibitive for scientific code.  PyJnius appears is still in active development.
 
 `Javabridge <https://github.com/CellProfiler/python-javabridge/>`_
 ------------------------------------------------------------------


### PR DESCRIPTION
Another alternative for the guide.  Not really sure what this offers other that being targeted towards Android.   A cursory test found it was not very suited for scientific use as they have hidden the Java array types and therefore can't do the same level of buffer exchanges that we achieve.   There may be a good idea or two in there, but I was not able to tease it out with my investigation.

Fixes #786 