### PR TITLE
fix typo: ImportException -> ImportError

### DIFF
--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -91,7 +91,7 @@ def _JExceptionHandler(pkg, name, ex):
         missing = str(ex).replace('/', '.')
         raise ImportError("Unable to import '%s' due to missing dependency '%s'" % (
             javaname, missing)) from ex
-    raise ImportException("Unable to import '%s'" % javaname) from ex
+    raise ImportError("Unable to import '%s'" % javaname) from ex
 
 
 def registerImportCustomizer(customizer):


### PR DESCRIPTION
In the java exception handler of imports.py, there is a little typo - if none of the cases match, it tries to create `ImportException` (which does not exist) instead of `ImportError`.