### PR TITLE
fix typo in import system: "jname" -> "name"

### DIFF
--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -174,7 +174,7 @@ class _JImportLoader:
         # Use the parent module to simplify name mangling
         if not parts[1] and _jpype.isPackage(parts[2]):
             ms = _ModuleSpec(name, self)
-            ms._jname = jname
+            ms._jname = name
             return ms
 
         if not parts[1] and not _jpype.isPackage(parts[0]):


### PR DESCRIPTION
In the import system, if a TLD is not registered (and therefore the check in line 163 fails), when trying to create the parent module in it is tried to access an undefined variable "jname" instead of using "name".