### PR TITLE
Improvements to speed for primitive arrays

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -6,6 +6,12 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 Latest Changes:
 - **1.0.2_dev0 - 2020-07-16**
 
+  - Improved speed on transfer of lists, tuples, buffers to arrays of Java
+    primitives by a factor of 4 to 100 depending on the data type.  The
+    conversion uses optimized path for memory buffers, rather than the 
+    Sequence API.  When a Python buffer is encountered only the
+    first element is checked for conversion as Python buffers are homogeneous. 
+
 - **1.0.1 - 2020-07-16**
 
   - Workarounds for Python 3.8.4 release.  Python altered logic regarding the

--- a/native/common/include/jp_classhints.h
+++ b/native/common/include/jp_classhints.h
@@ -105,6 +105,7 @@ private:
 extern JPConversion *hintsConversion;
 extern JPConversion *charArrayConversion;
 extern JPConversion *byteArrayConversion;
+extern JPConversion *bufferConversion;
 extern JPConversion *sequenceConversion;
 extern JPConversion *nullConversion;
 extern JPConversion *classConversion;

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -39,6 +39,7 @@ JPMatch::Type JPArrayClass::findJavaConversion(JPMatch &match)
 	JP_TRACE_IN("JPArrayClass::findJavaConversion");
 	if (nullConversion->matches(this, match)
 			|| objectConversion->matches(this, match)
+			|| bufferConversion->matches(this, match)
 			|| charArrayConversion->matches(this, match)
 			|| byteArrayConversion->matches(this, match)
 			|| sequenceConversion->matches(this, match)


### PR DESCRIPTION
Identified one of the old slow paths in argument passing that we have not yet addressed and transfers it to the optimized paths.

Fixes #804 