### PR TITLE
Propagate interrupt to KeyboardInterrupt

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -6,6 +6,7 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 Latest Changes:
 - **1.0.2_dev0 - 2020-07-16**
 
+  - ^C propogates to a KeyboardInterrupt properly.
 
   - Added cache to the method dispatch to bypass resolution of overloads.
     This reduces the cost of method resolution significantly especially if

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -165,6 +165,11 @@ void JPContext::loadEntryPoints(const string& path)
 	JP_TRACE_OUT;
 }
 
+static void interruptPy()
+{
+	PyErr_SetInterrupt();
+}
+
 void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		bool ignoreUnrecognized, bool convertStrings)
 {
@@ -344,6 +349,14 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		jclass comparableClass = frame.FindClass("java/lang/Comparable");
 		m_CompareToID = frame.GetMethodID(comparableClass, "compareTo",
 				"(Ljava/lang/Object;)I");
+
+		jclass signalClass = getClassLoader()->findClass(frame, "org.jpype.JPypeSignal");
+
+		method[0].name = (char*) "interruptPy";
+		method[0].signature = (char*) "()V";
+		method[0].fnPtr = (void*) interruptPy;
+		frame.GetMethodID(signalClass, "<init>", "()V");
+		frame.RegisterNatives(signalClass, method, 1);
 
 		jclass proxyClass = getClassLoader()->findClass(frame, "org.jpype.proxy.JPypeProxy");
 

--- a/native/java/org/jpype/JPypeSignal.java
+++ b/native/java/org/jpype/JPypeSignal.java
@@ -10,7 +10,7 @@
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-  
+
   See NOTICE file for details.
 **************************************************************************** */
 package org.jpype;
@@ -49,6 +49,7 @@ public class JPypeSignal
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable
         {
           main.interrupt();
+          interruptPy();
           return null;
         }
       });
@@ -59,4 +60,6 @@ public class JPypeSignal
       throw new RuntimeException(ex);
     }
   }
+
+  native static void interruptPy();
 }


### PR DESCRIPTION
If Java catches an interrupt it currently passes it on to the main Java thread, but it was not getting forwarded to Python.  The PR fixes that so that both get informed.   This still leaves a hole that if Python gets the interrupt it does not clear the Java one and vise versa.   So still more to do, but this should correct one issue.

Fixes #813 
