### PR TITLE
Correct bugs in hints system

### DIFF
--- a/jpype/protocol.py
+++ b/jpype/protocol.py
@@ -67,8 +67,9 @@ def _JFileConvert(jcls, obj):
     return jcls(obj.__fspath__())
 
 
-@_jcustomizer.JConversion("java.util.Collection", instanceof=Sequence,
-                          excludes=str)
+@_jcustomizer.JConversion("java.util.Iterable", instanceof=Sequence, excludes=str)
+@_jcustomizer.JConversion("java.util.List", instanceof=Sequence, excludes=str)
+@_jcustomizer.JConversion("java.util.Collection", instanceof=Sequence, excludes=str)
 def _JSequenceConvert(jcls, obj):
     return _jclass.JClass('java.util.Arrays').asList(obj)
 

--- a/jpype/protocol.py
+++ b/jpype/protocol.py
@@ -68,7 +68,6 @@ def _JFileConvert(jcls, obj):
 
 
 @_jcustomizer.JConversion("java.util.Iterable", instanceof=Sequence, excludes=str)
-@_jcustomizer.JConversion("java.util.List", instanceof=Sequence, excludes=str)
 @_jcustomizer.JConversion("java.util.Collection", instanceof=Sequence, excludes=str)
 def _JSequenceConvert(jcls, obj):
     return _jclass.JClass('java.util.Arrays').asList(obj)

--- a/native/common/jp_boxedtype.cpp
+++ b/native/common/jp_boxedtype.cpp
@@ -58,6 +58,7 @@ JPMatch::Type JPBoxedType::findJavaConversion(JPMatch &match)
 
 void JPBoxedType::getConversionInfo(JPConversionInfo &info)
 {
+	JP_TRACE_IN("JPBoxedType::getConversionInfo");
 	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
 	m_PrimitiveType->getConversionInfo(info);
 	JPPyObject::call(PyObject_CallMethod(info.expl, "extend", "O", info.implicit));
@@ -65,6 +66,7 @@ void JPBoxedType::getConversionInfo(JPConversionInfo &info)
 	JPPyObject::call(PyObject_CallMethod(info.implicit, "extend", "O", info.exact));
 	JPPyObject::call(PyObject_CallMethod(info.exact, "clear", ""));
 	JPClass::getConversionInfo(info);
+	JP_TRACE_OUT;
 }
 
 jobject JPBoxedType::box(JPJavaFrame &frame, jvalue v)

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -414,10 +414,12 @@ JPMatch::Type JPClass::findJavaConversion(JPMatch &match)
 
 void JPClass::getConversionInfo(JPConversionInfo &info)
 {
+	JP_TRACE_IN("JPClass::getConversionInfo");
 	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
 	objectConversion->getInfo(this, info);
 	hintsConversion->getInfo(this, info);
 	PyList_Append(info.ret, PyJPClass_create(frame, this).get());
+	JP_TRACE_OUT;
 }
 
 

--- a/native/common/jp_numbertype.cpp
+++ b/native/common/jp_numbertype.cpp
@@ -48,10 +48,12 @@ JPMatch::Type JPNumberType::findJavaConversion(JPMatch& match)
 
 void JPNumberType::getConversionInfo(JPConversionInfo &info)
 {
+	JP_TRACE_IN("JPNumberType::getConversionInfo");
 	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
 	javaNumberAnyConversion->getInfo(this, info);
 	boxLongConversion->getInfo(this, info);
 	boxDoubleConversion->getInfo(this, info);
 	hintsConversion->getInfo(this, info);
 	PyList_Append(info.ret, PyJPClass_create(frame, this).get());
+	JP_TRACE_OUT;
 }

--- a/native/common/jp_objecttype.cpp
+++ b/native/common/jp_objecttype.cpp
@@ -52,6 +52,7 @@ JPMatch::Type JPObjectType::findJavaConversion(JPMatch& match)
 
 void JPObjectType::getConversionInfo(JPConversionInfo &info)
 {
+	JP_TRACE_IN("JPObjectType::getConversionInfo");
 	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
 	nullConversion->getInfo(this, info);
 	objectConversion->getInfo(this, info);
@@ -63,4 +64,5 @@ void JPObjectType::getConversionInfo(JPConversionInfo &info)
 	proxyConversion->getInfo(this, info);
 	hintsConversion->getInfo(this, info);
 	PyList_Append(info.ret, PyJPClass_create(frame, this).get());
+	JP_TRACE_OUT;
 }

--- a/native/common/jp_typefactory.cpp
+++ b/native/common/jp_typefactory.cpp
@@ -202,7 +202,7 @@ JNIEXPORT jlong JNICALL JPTypeFactory_defineObjectClass(
 			(JPClass*) superClass, interfaces, modifiers));
 	if (className == "java.lang.Throwable")
 		return (jlong) (context->_java_lang_Throwable
-			= new JPObjectType(frame, cls, className,
+			= new JPClassType(frame, cls, className,
 			(JPClass*) superClass, interfaces, modifiers));
 
 	if (className == "java.lang.Number")


### PR DESCRIPTION
Deals with bugs reported in #714.  Throwable had the wrong wrapper type in the class factor.  Adds automatic conversion for List and Iterable, though they may be costly.   This is probably safe for 1.0.2 but if you want me to push it to 1.1 then just set the milestone on the review.