### PR TITLE
Fix referencing bug

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 This changelog *only* contains changes from the *first* pypi release (0.5.4.3) onwards.
 
 Latest Changes:
+
+  - Fixed reference count problem in stackframes used for exceptions.
+
 - **1.0.2_dev0 - 2020-07-16**
 
   - ^C propogates to a KeyboardInterrupt properly.

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -485,7 +485,10 @@ PyTracebackObject *tb_create(
 	PyFrameObject *frame = (PyFrameObject*) PyFrame_Type.tp_alloc(&PyFrame_Type, 0);
 	frame->f_back = NULL;
 	if (last_traceback != NULL)
+	{
 		frame->f_back = last_traceback->tb_frame;
+		Py_INCREF(frame->f_back);
+	}
 	frame->f_builtins = dict;
 	Py_INCREF(frame->f_builtins);
 	frame->f_code = (PyCodeObject*) code;


### PR DESCRIPTION
I identified the issue.  The reference counter was not being incremented on the stack trace creation.   Should be safe for a patch release.

Fixes #822