### PR TITLE
Do not fail on non-present folders

### DIFF
--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -145,6 +145,10 @@ class JVMFinder(object):
         java_names = ('jre', 'jdk', 'java')
 
         for parent in parents:
+            # Fast exit if folder does not exist
+            if not os.path.exists(parent):
+                continue
+
             for childname in sorted(os.listdir(parent)):
                 # Compute the real path
                 path = os.path.realpath(os.path.join(parent, childname))


### PR DESCRIPTION
The function `find_possible_homes` tests a given list of locations.
On very minimal systems (e.g. docker images), some of the folders might not be present (e.g. the `/usr/lib/jvm`). This however leads to a `FileNotFoundError` when calling `os.listdir`.

This PR fixes this problem.