### PR TITLE
Another stab at fixing Ctrl+C behavior

### DIFF
--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -77,6 +77,8 @@ class JPGarbageCollection;
 
 void assertJVMRunning(JPContext* context, const JPStackInfo& info);
 
+int hasInterrupt();
+
 /**
  * A Context encapsulates the Java virtual machine, the Java classes required
  * to function, and the JPype services created for that machine.
@@ -216,6 +218,7 @@ private:
 	JPClassLoader *m_ClassLoader;
 
 public:
+	JPClassRef m_ContextClass;
 	JPClassRef m_RuntimeException;
 	JPClassRef m_NoSuchMethodError;
 
@@ -234,6 +237,7 @@ private:
 	jmethodID m_Context_CreateExceptionID;
 	jmethodID m_Context_GetExcClassID;
 	jmethodID m_Context_GetExcValueID;
+	jmethodID m_Context_ClearInterruptID;
 	jmethodID m_CompareToID;
 	jmethodID m_Buffer_IsReadOnlyID;
 	jmethodID m_Context_OrderID;

--- a/native/common/include/jp_javaframe.h
+++ b/native/common/include/jp_javaframe.h
@@ -392,6 +392,8 @@ public:
 	void registerRef(jobject obj, PyObject* hostRef);
 	void registerRef(jobject obj, void* ref, JCleanupHook cleanup);
 
+	void clearInterrupt(bool throws);
+
 } ;
 
 #endif // _JP_JAVA_FRAME_H_

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -510,21 +510,21 @@ extern "C" JNIEXPORT void JNICALL Java_org_jpype_JPypeContext_onShutdown
  *
  */
 
-static int interrupt = 0;
+static int interruptState = 0;
 extern "C" JNIEXPORT void JNICALL Java_org_jpype_JPypeSignal_interruptPy
 (JNIEnv *env, jclass cls)
 {
-	interrupt = 1;
+	interruptState = 1;
 	PyErr_SetInterrupt();
 }
 
 extern "C" JNIEXPORT void JNICALL Java_org_jpype_JPypeSignal_acknowledgePy
 (JNIEnv *env, jclass cls)
 {
-	interrupt = 0;
+	interruptState = 0;
 }
 
 int hasInterrupt()
 {
-	return interrupt!=0;
+	return interruptState != 0;
 }

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -288,6 +288,12 @@ void JPypeException::toPython()
 	JP_TRACE_IN("JPypeException::toPython");
 	try
 	{
+		// Check the signals before processing the exception
+		// It may be a signal when interrupted Java in which case
+		// the signal takes precedence.
+		if (PyErr_CheckSignals()!=0)
+			return;
+
 		mesg = getMessage();
 		JP_TRACE(m_Error.l);
 		JP_TRACE(mesg.c_str());

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -1256,3 +1256,12 @@ void JPJavaFrame::registerRef(jobject obj, void* ref, JCleanupHook cleanup)
 {
 	JPReferenceQueue::registerRef(*this, obj, ref, cleanup);
 }
+
+void JPJavaFrame::clearInterrupt(bool throws)
+{
+	JPPyCallRelease call;
+	jvalue jv;
+	jv.z = throws;
+	CallVoidMethodA(m_Context->m_ContextClass.get(),
+			m_Context->m_Context_ClearInterruptID, &jv);
+}

--- a/native/common/jp_reference_queue.cpp
+++ b/native/common/jp_reference_queue.cpp
@@ -82,6 +82,12 @@ JNIEXPORT void JNICALL Java_org_jpype_ref_JPypeReferenceNative_wake
 
 void JPReferenceQueue::registerRef(JPJavaFrame &frame, jobject obj, PyObject* hostRef)
 {
+	// There are certain calls such as exception handling in which the 
+	// Python object is null.  In those cases, we don't need to bind the Java
+	// object lifespan and can just ignore it.
+	if (hostRef == 0)
+		return;
+
 	// MATCH TO DECREF IN releasePython
 	Py_INCREF(hostRef);
 	registerRef(frame, obj, hostRef, &releasePython);

--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -71,7 +71,7 @@ public class JPypeContext
 
   public final String VERSION = "1.0.3_dev0";
 
-  private static JPypeContext INSTANCE =  new JPypeContext();
+  private static JPypeContext INSTANCE = new JPypeContext();
   // This is the C++ portion of the context.
   private long context;
   private TypeFactory typeFactory;
@@ -217,7 +217,6 @@ public class JPypeContext
 //        {
 //        }
 //      }
-
 //      // Check to see if who is alive
 //      threads = Thread.getAllStackTraces();
 //      System.out.println("Check for remaining");
@@ -461,6 +460,43 @@ public class JPypeContext
 //  {
 //    proxyCount.decrementAndGet();
 //  }
+  /**
+   * Clear the current interrupt.
+   *
+   * @param x is true if an exception should be thrown.
+   * @throws InterruptedException
+   */
+  public static void clearInterrupt(boolean x) throws InterruptedException
+  {
+    try
+    {
+      Thread th = Thread.currentThread();
+
+      // Only relevant if this is the main thread for signal handling
+      if (th != JPypeSignal.main)
+        return;
+
+      // Unconditionally clear the interrupt flag if we are called from 
+      // C++.  This happens when a field get() or method call() is 
+      // invoked.
+      if (!x)
+        JPypeSignal.acknowledgePy();
+
+      // Check if this thread is interrupted
+      if (th.isInterrupted())
+      {
+        // Clear the flag in C++
+        JPypeSignal.acknowledgePy();
+        
+        // Clear the flag in Java
+        Thread.sleep(1);
+      }
+    } catch (InterruptedException ex)
+    {
+      if (x)
+        throw ex;
+    }
+  }
 
   public long getExcClass(Throwable th)
   {

--- a/native/java/org/jpype/JPypeSignal.java
+++ b/native/java/org/jpype/JPypeSignal.java
@@ -62,4 +62,5 @@ public class JPypeSignal
   }
 
   native static void interruptPy();
+  native static void acknowledgePy();
 }

--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -32,6 +32,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
+import org.jpype.JPypeContext;
+import org.jpype.JPypeSignal;
 import org.jpype.proxy.JPypeProxy;
 
 /**
@@ -306,11 +308,7 @@ public class TypeManager
    */
   public long findClassForObject(Object object) throws InterruptedException
   {
-    Thread th = Thread.currentThread();
-    if (th.isInterrupted())
-    {
-      Thread.sleep(1);
-    }
+    JPypeContext.clearInterrupt(true);
     if (object == null)
       return 0;
 

--- a/native/python/pyjp_field.cpp
+++ b/native/python/pyjp_field.cpp
@@ -39,6 +39,9 @@ static PyObject *PyJPField_get(PyJPField *self, PyObject *obj, PyObject *type)
 	JP_PY_TRY("PyJPField_get");
 	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame = JPJavaFrame::outer(context);
+	// Clear any pending interrupts if we are on the main thread.
+	if (hasInterrupt())
+		frame.clearInterrupt(false);
 	if (self->m_Field->isStatic())
 		return self->m_Field->getStaticField().keep();
 	if (obj == NULL)

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -91,6 +91,9 @@ static PyObject *PyJPMethod_call(PyJPMethod *self, PyObject *args, PyObject *kwa
 	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame = JPJavaFrame::outer(context);
 	JP_TRACE(self->m_Method->getName());
+	// Clear any pending interrupts if we are on the main thread
+	if (hasInterrupt())
+		frame.clearInterrupt(false);
 	PyObject *out = NULL;
 	if (self->m_Instance == NULL)
 	{


### PR DESCRIPTION
This deals with a segfault in the Ctrl+C path.  There was a race condition that was leading to two exceptions on the stack.  I added addition interlocks and set up pattern which if a Ctrl+C is issued prior to calling Java the interrupt is cleared so that we don't get a sleep interrupted after a Ctrl+C in certain cases. 

This seems like a pretty important PR for 1.1 release.   It does not deal with the non-interactive case which still segfaults in the stack unwinds poorly.  That will need to be a followup, but it is less important.

Fixes #556 again