### PR TITLE
Fix #856: Memory leak when casting a JString to a Python string

### DIFF
--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -195,7 +195,6 @@ PyObject* PyJPValue_str(PyObject* self)
 			str = frame.toStringUTF8(jstr);
 			cache = JPPyString::fromStringUTF8(str).keep();
 			PyDict_SetItemString(dict.get(), "_jstr", cache);
-			Py_INCREF(cache);
 			return cache;
 		}
 	}


### PR DESCRIPTION
Closes #856. Test failed before, and fixed now.