### PR TITLE
Fixed variadic method resolution

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,9 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.0.3_dev0 - unreleased**
+  
+  - Correct bug resulting in reporting ambiguous overloads when resolving
+    methods with variadic arguments.
 
   - Ctrl+C behavior is switchable with interrupt flag to startJVM.
     If True, process will halt on Ctrl-C.  If False, the process

--- a/test/harness/jpype/varargs/VarArgs.java
+++ b/test/harness/jpype/varargs/VarArgs.java
@@ -15,6 +15,8 @@
 **************************************************************************** */
 package jpype.varargs;
 
+import java.util.Map;
+
 class VarArgs
 {
 
@@ -62,5 +64,36 @@ class VarArgs
   public String[] method(String s, String... rest)
   {
     return rest;
+  }
+
+  public int conflict1(Object... j)
+  {
+  	return 1;
+  }
+
+  public int conflict1(Map j)
+  {
+  	return 2;
+  }
+
+  public int conflict2(Object... j)
+  {
+  	return 1;
+  }
+
+  public int conflict2(Map j, Map k)
+  {
+  	return 2;
+  }
+
+
+  public int conflict3(char... j)
+  {
+  	return 1;
+  }
+
+  public int conflict3(String j)
+  {
+  	return 2;
   }
 }

--- a/test/jpypetest/test_varargs.py
+++ b/test/jpypetest/test_varargs.py
@@ -39,6 +39,19 @@ class VarArgsTestCase(common.JPypeTestCase):
         self.String = jpype.JClass('java.lang.String')
         self.StringA = jpype.JArray(self.String)
 
+    def testConflict(self):
+        m = jpype.java.util.LinkedHashMap({"a":1,"b":2,"c":3})
+        test = self.VarArgs()
+        self.assertEqual(test.conflict2([1,2,3]),1)
+        self.assertEqual(test.conflict2(m,m),2)
+        self.assertEqual(test.conflict3(['h','e']),1)
+        self.assertEqual(test.conflict3('h'),2)
+        self.assertEqual(test.conflict3('hello'),2)
+        self.assertEqual(test.conflict1(1),1)
+        self.assertEqual(test.conflict1([1,2,3]),1)
+        self.assertEqual(test.conflict1({"a":1,"b":2,"c":3}),2)
+        self.assertEqual(test.conflict1(m),2)
+
     def testVarArgsCtor(self):
         va0 = self.VarArgs('1')
         va1 = self.VarArgs('1', 'a')

--- a/test/jpypetest/test_varargs.py
+++ b/test/jpypetest/test_varargs.py
@@ -40,17 +40,17 @@ class VarArgsTestCase(common.JPypeTestCase):
         self.StringA = jpype.JArray(self.String)
 
     def testConflict(self):
-        m = jpype.java.util.LinkedHashMap({"a":1,"b":2,"c":3})
+        m = jpype.java.util.LinkedHashMap({"a": 1, "b": 2, "c": 3})
         test = self.VarArgs()
-        self.assertEqual(test.conflict2([1,2,3]),1)
-        self.assertEqual(test.conflict2(m,m),2)
-        self.assertEqual(test.conflict3(['h','e']),1)
-        self.assertEqual(test.conflict3('h'),2)
-        self.assertEqual(test.conflict3('hello'),2)
-        self.assertEqual(test.conflict1(1),1)
-        self.assertEqual(test.conflict1([1,2,3]),1)
-        self.assertEqual(test.conflict1({"a":1,"b":2,"c":3}),2)
-        self.assertEqual(test.conflict1(m),2)
+        self.assertEqual(test.conflict2([1, 2, 3]), 1)
+        self.assertEqual(test.conflict2(m, m), 2)
+        self.assertEqual(test.conflict3(['h', 'e']), 1)
+        self.assertEqual(test.conflict3('h'), 2)
+        self.assertEqual(test.conflict3('hello'), 2)
+        self.assertEqual(test.conflict1(1), 1)
+        self.assertEqual(test.conflict1([1, 2, 3]), 1)
+        self.assertEqual(test.conflict1({"a": 1, "b": 2, "c": 3}), 2)
+        self.assertEqual(test.conflict1(m), 2)
 
     def testVarArgsCtor(self):
         va0 = self.VarArgs('1')


### PR DESCRIPTION
This is a last minute bug fix regarding resolution rules for variadic arguments.   This bug has been around for a while (at least 0.6.2).   Variadic methods need to be considered polymorphically when deciding if they are to be hidden with respect to other methods.   I wasn't able to handle the corner case where one variadic method was being compared to another, but the more frequent case of a specific to a variadic have been resolved.   I added a test case.   

I would like this added to the 1.1.0 release if possible.   I was going to push the release out today, but this bug is holding up some other groups so it seems like a good candidate for a rush.