### PR TITLE
Fix cflags for unix

### DIFF
--- a/setupext/build_ext.py
+++ b/setupext/build_ext.py
@@ -211,7 +211,7 @@ class BuildExtCommand(build_ext):
     def _set_cflags(self):
         # set compiler flags
         c = self.compiler.compiler_type
-        jpypeLib = self.extensions[1]
+        jpypeLib = [i for i in self.extensions if i.name == '_jpype'][0]
         if c == 'unix' and self.distribution.enable_coverage:
             jpypeLib.extra_compile_args.extend(
                 ['-ggdb', '--coverage', '-ftest-coverage'])
@@ -225,7 +225,7 @@ class BuildExtCommand(build_ext):
             self.compiler = Makefile(self.compiler)
             self.force = True
 
-        jpypeLib = self.extensions[1]
+        jpypeLib = [i for i in self.extensions if i.name == '_jpype'][0]
         tracing = self.distribution.enable_tracing
         self._set_cflags()
         if tracing:

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -77,19 +77,19 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
         distutils.log.info("Add darwin settings")
         platform_specific['libraries'] = ['dl']
         platform_specific['define_macros'] = [('MACOSX', 1)]
-        platform_specific['extra_compile_args'] = ['-g0', '-std=c++11']
+        platform_specific['extra_compile_args'] = ['-g0', '-std=c++11', '-O2']
         jni_md_platform = 'darwin'
 
     elif platform.startswith('linux'):
         distutils.log.info("Add linux settings")
         platform_specific['libraries'] = ['dl']
-        platform_specific['extra_compile_args'] = ['-g0', '-std=c++11']
+        platform_specific['extra_compile_args'] = ['-g0', '-std=c++11', '-O2']
         jni_md_platform = 'linux'
 
     elif platform.startswith('aix7'):
         distutils.log.info("Add aix settings")
         platform_specific['libraries'] = ['dl']
-        platform_specific['extra_compile_args'] = ['-g3', '-std=c++11']
+        platform_specific['extra_compile_args'] = ['-g3', '-std=c++11', '-O2']
         jni_md_platform = 'aix7'
 
     elif platform.startswith('freebsd'):
@@ -99,7 +99,7 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
     elif platform.startswith('android'):
         distutils.log.info("Add android settings")
         platform_specific['libraries'] = ['dl', 'c++_shared', 'SDL2']
-        platform_specific['extra_compile_args'] = ['-g0', '-std=c++11', '-fexceptions', '-frtti']
+        platform_specific['extra_compile_args'] = ['-g0', '-std=c++11', '-fexceptions', '-frtti', '-O2']
 
         print("PLATFORM_SPECIFIC:", platform_specific)
         jni_md_platform = 'linux'
@@ -110,8 +110,8 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
         distutils.log.warn("Your platform '%s' is not being handled explicitly."
                            " It may work or not!", platform)
 
-## This code is used to include python library in the build when starting Python from 
-## within Java.  It will be used in the future, but is not currently required.
+# This code is used to include python library in the build when starting Python from
+# within Java.  It will be used in the future, but is not currently required.
 #    if static and sysconfig.get_config_var('BLDLIBRARY') is not None:
 #        platform_specific['extra_link_args'].append(sysconfig.get_config_var('BLDLIBRARY'))
 


### PR DESCRIPTION
This is a shot at fixing the distribution size for unix.   I changed the patterns so we can explicitly set the debug and optimization flags from platform.  The requires scrubbing all the existing flags in the sysconfig.

Also fixes a bug with coverage and tracing.   Not sure why the extension position is hard coded, but the number drifted when we added the jar to the extension list.