### PR TITLE
Add support for building on z/OS

### DIFF
--- a/setupext/build_ext.py
+++ b/setupext/build_ext.py
@@ -313,7 +313,7 @@ class BuildExtCommand(build_ext):
             build_dir = os.path.join(self.build_temp, ext.name, "classes")
             os.makedirs(build_dir, exist_ok=True)
             os.makedirs(dirname, exist_ok=True)
-            cmd1 = shlex.split('%s -cp "%s" -d "%s" -g:none -source %s -target %s' %
+            cmd1 = shlex.split('%s -cp "%s" -d "%s" -g:none -source %s -target %s -encoding UTF-8' %
                                (javac, classpath, build_dir, target_version, target_version))
             cmd1.extend(ext.sources)
             debug = "-g:none"

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -105,6 +105,10 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
         jni_md_platform = 'linux'
         static = False
 
+    elif platform == 'zos':
+        distutils.log.info("Add zos settings")
+        jni_md_platform = 'zos'
+
     else:
         jni_md_platform = None
         distutils.log.warn("Your platform '%s' is not being handled explicitly."


### PR DESCRIPTION
This just let's us be able to install JPype when using z/OS. There's two problems on the platform currently:

1) `setupext/platform.py` - When running the installation with `JAVA_HOME` set, `jni_md_platform` will be set to None, but it will have found jni.ini, and so attempt to use `jni_md_platform` and error out. This sets it properly so the build can continue.

2) `setupext/build_ext.py` - When compiling the Java source files with javac, the expected/default encoding for the source file is EBCDIC on z/OS. When pulling down the source from git or similar has this in ascii and not EBCDIC, it'll throw an error when it tries to compile it. We put the -encoding to signify the expected encoding of the file. I don't expect any additional failures from this (no new failures from my test Ubuntu 18.04 machine), but it could be wrapped in a check for z/OS if needed.