### PR TITLE
Add aarch64 wheel support

### DIFF
--- a/.azure/release.yml
+++ b/.azure/release.yml
@@ -34,6 +34,11 @@ stages:
           plat: manylinux2010_x86_64
           image: quay.io/pypa/manylinux2010_x86_64
           python.architecture: x64
+        64Bit2014:
+          arch: aarch64
+          plat: manylinux2014_aarch64
+          image: quay.io/pypa/manylinux2014_aarch64
+          python.architecture: aarch64
         64Bit:
           arch: x86_64
           plat: manylinux1_x86_64

--- a/.azure/scripts/wheels-linux.yml
+++ b/.azure/scripts/wheels-linux.yml
@@ -10,6 +10,13 @@ steps:
     path: dist
 
 - script: |
+    sudo apt-get update
+    sudo apt-get install -y qemu qemu-user-static qemu-user binfmt-support
+    sudo docker run --rm --privileged hypriot/qemu-register
+  condition: and(succeeded(), eq(variables['arch'], 'aarch64'))
+  displayName: 'Install QEMU'
+
+- script: |
     ls -l
     ls -l dist
   displayName: Sanity check 


### PR DESCRIPTION
Fix: Add aarch64 wheel build support using qemu. 
Few build failures are there on Windows not related to my changes.
