### PR TITLE
Bug fix for Python 3.9

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,8 +12,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import jpype
-import jpype.imports
 from unittest import mock
 import sys
 import os
@@ -146,6 +144,8 @@ mockModule._JPackage = _JPackage
 mockModule._JClassHints = _JClassHints
 mockModule._hasClass = lambda x: False
 sys.modules['_jpype'] = mockModule
+import jpype
+import jpype.imports
 
 # For some reason jpype.imports does not work if called in sphinx. Importing
 # it here solved the problem.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import jpype.imports
 import jpype
+import jpype.imports
 from unittest import mock
 import sys
 import os

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,6 +12,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import jpype.imports
+import jpype
+from unittest import mock
 import sys
 import os
 
@@ -54,18 +57,19 @@ copyright = u'2014-18, Steve Menard, Luis Nell and others'
 # built documents.
 #
 # The short X.Y version.
-from unittest import mock
 
 
-def TypeMock_init(self, *args, **kwargs):
-    object.__init__(self)
+class ObjectMock(object):
+    def __init__(self, *args, **kwargs):
+        self._kwargs = kwargs
+        self._to = mock.Mock
+        object.__init__(self)
 
-
-def TypeMock_getattr(self, key):
-    kwargs = self._kwargs
-    m = self._to(**kwargs)
-    object.__setattr__(self, key, m)
-    return m
+    def __getattr__(self, key):
+        kwargs = self._kwargs
+        m = self._to(**kwargs)
+        object.__setattr__(self, key, m)
+        return m
 
 
 class TypeMock(type):
@@ -73,8 +77,8 @@ class TypeMock(type):
         if not bases:
             bases = tuple([])
 
-        members['__init__'] = TypeMock_init
-        members['__getattr__'] = TypeMock_getattr
+        members['__init__'] = ObjectMock.__init__
+        members['__getattr__'] = ObjectMock.__getattr__
         members['_kwargs'] = kwargs
         members['_to'] = to
         members['__slots__'] = []
@@ -116,6 +120,19 @@ class _JPackage:
         pass
 
 
+# Monkey patch (this is needed to catch errors for missing TypeMock)
+m = mock.Mock.__getattr__
+
+
+def patch(self, key):
+    if key == "__name__":
+        return "FIXME TypeMock is missing"
+    return m(self, key)
+
+
+mock.Mock.__getattr__ = patch
+
+
 mockModule = mock.MagicMock()
 mockModule.isStarted = mock.Mock(return_value=False)
 mockModule._JArray = TypeMock("_JArray")
@@ -123,16 +140,15 @@ mockModule._JClass = _JClass
 mockModule._JField = TypeMock("_JField")
 mockModule._JMethod = TypeMock("_JMethod")
 mockModule._JObject = TypeMock("_JObject")
+mockModule._JProxy = TypeMock("_JProxy")
+mockModule._JException = TypeMock("_JException")
 mockModule._JPackage = _JPackage
-# TypeMock("_JPackage")
 mockModule._JClassHints = _JClassHints
 mockModule._hasClass = lambda x: False
 sys.modules['_jpype'] = mockModule
 
 # For some reason jpype.imports does not work if called in sphinx. Importing
 # it here solved the problem.
-import jpype
-import jpype.imports
 version = jpype.__version__
 # The full version, including alpha/beta/rc tags.
 release = jpype.__version__

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -185,7 +185,7 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 
 	jniArgs.nOptions = (jint) args.size();
 	JP_TRACE("NumOptions", jniArgs.nOptions);
-	jniArgs.options = (JavaVMOption*) malloc(sizeof (JavaVMOption) * jniArgs.nOptions);
+	jniArgs.options = new JavaVMOption[jniArgs.nOptions];
 	memset(jniArgs.options, 0, sizeof (JavaVMOption) * jniArgs.nOptions);
 	for (int i = 0; i < jniArgs.nOptions; i++)
 	{
@@ -204,7 +204,7 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		JP_TRACE("Exception in CreateJVM?");
 	}
 	JP_TRACE("JVM created");
-	free(jniArgs.options);
+	delete [] jniArgs.options;
 
 	if (m_JavaVM == NULL)
 	{

--- a/native/common/jp_platform.cpp
+++ b/native/common/jp_platform.cpp
@@ -175,10 +175,12 @@ public:
 
 namespace
 {
-PLATFORM_ADAPTER adapter;
+PLATFORM_ADAPTER* adapter;
 }
 
 JPPlatformAdapter* JPPlatformAdapter::getAdapter()
 {
-	return &adapter;
+	if (adapter == NULL)
+		adapter = new PLATFORM_ADAPTER();
+	return adapter;
 }

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -58,7 +58,7 @@ PyMODINIT_FUNC PyInit__jpype();
  * @param exception
  * @param str
  */
-void Py_SetStringWithCause(PyObject *exception, const char *str);
+void PyJP_SetStringWithCause(PyObject *exception, const char *str);
 
 /**
  * Get a new reference to a method or property in the type dictionary without
@@ -68,7 +68,7 @@ void Py_SetStringWithCause(PyObject *exception, const char *str);
  * @param attr_name
  * @return
  */
-PyObject* Py_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name);
+PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name);
 
 /**
  * Fast check to see if a type derives from another.
@@ -80,8 +80,8 @@ PyObject* Py_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name);
  * @param obj
  * @return 1 if object derives from type.
  */
-int Py_IsInstanceSingle(PyObject* obj, PyTypeObject* type);
-int Py_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj);
+int PyJP_IsInstanceSingle(PyObject* obj, PyTypeObject* type);
+int PyJP_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj);
 
 struct PyJPArray
 {
@@ -146,6 +146,7 @@ extern PyObject *_JMethodAnnotations;
 extern PyObject *_JMethodCode;
 extern PyObject *_JObjectKey;
 extern PyObject *_JVMNotRunning;
+extern PyObject* PyJPClassMagic;
 
 extern JPContext* JPContext_global;
 

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -702,10 +702,14 @@ PyMODINIT_FUNC PyInit__jpype()
 {
 	JP_PY_TRY("PyInit__jpype");
 	JPContext_global = new JPContext();
+
+#if PY_VERSION_HEX<0x03070000
 	// This is required for python versions prior to 3.7.
 	// It is called by the python initialization starting from 3.7,
-	// but is safe to call afterwards.
-	//PyEval_InitThreads();
+	// but is safe to call afterwards.  Starting 3.9 this issues a 
+	// deprecation warning.
+	PyEval_InitThreads();
+#endif
 
 	// Initialize the module (depends on python version)
 	PyObject* module = PyModule_Create(&moduledef);

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -597,7 +597,6 @@ PyObject* examine(PyObject *module, PyObject *other)
 	printf("    free: %p\n", type->tp_free);
 	printf("    finalize: %p\n", type->tp_finalize);
 	printf("======\n");
-	fflush(stdout);
 
 	return PyBool_FromLong(ret);
 	JP_PY_CATCH(NULL);
@@ -705,7 +704,7 @@ PyMODINIT_FUNC PyInit__jpype()
 	// This is required for python versions prior to 3.7.
 	// It is called by the python initialization starting from 3.7,
 	// but is safe to call afterwards.
-	PyEval_InitThreads();
+	//PyEval_InitThreads();
 
 	// Initialize the module (depends on python version)
 	PyObject* module = PyModule_Create(&moduledef);

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -126,7 +126,7 @@ void PyJPModule_loadResources(PyObject* module)
 	}	catch (JPypeException&)  // GCOVR_EXCL_LINE
 	{
 		// GCOVR_EXCL_START
-		Py_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
+		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
 		JP_RAISE_PYTHON();
 		// GCOVR_EXCL_STOP
 	}
@@ -141,7 +141,7 @@ extern "C"
 // GCOVR_EXCL_START
 // This is used exclusively during startup
 
-void Py_SetStringWithCause(PyObject *exception,
+void PyJP_SetStringWithCause(PyObject *exception,
 		const char *str)
 {
 	// See _PyErr_TrySetFromCause
@@ -163,7 +163,7 @@ void Py_SetStringWithCause(PyObject *exception,
 }
 // GCOVR_EXCL_STOP
 
-PyObject* Py_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
+PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 {
 	JP_PY_TRY("Py_GetAttrDescriptor");
 	if (type->tp_mro == NULL)
@@ -196,7 +196,7 @@ PyObject* Py_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 	JP_PY_CATCH(NULL); // GCOVR_EXCL_LINE
 }
 
-int Py_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj)
+int PyJP_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj)
 {
 	if (type == NULL || obj == NULL)
 		return 0;  // GCOVR_EXCL_LINE
@@ -208,11 +208,11 @@ int Py_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj)
 	return PyTuple_GetItem(mro1, n1 - n2) == (PyObject*) type;
 }
 
-int Py_IsInstanceSingle(PyObject* obj, PyTypeObject* type)
+int PyJP_IsInstanceSingle(PyObject* obj, PyTypeObject* type)
 {
 	if (type == NULL || obj == NULL)
 		return 0; // GCOVR_EXCL_LINE
-	return Py_IsSubClassSingle(type, Py_TYPE(obj));
+	return PyJP_IsSubClassSingle(type, Py_TYPE(obj));
 }
 
 #ifndef ANDROID
@@ -560,8 +560,9 @@ static PyObject* PyJPModule_isPackage(PyObject *module, PyObject *pkg)
 }
 
 
+#if 0
 // GCOVR_EXCL_START
-
+// This code was used in testing the Java slot memory layout.  It serves no purpose outside of debugging that issue.
 PyObject* examine(PyObject *module, PyObject *other)
 {
 	JP_PY_TRY("examine");
@@ -597,12 +598,12 @@ PyObject* examine(PyObject *module, PyObject *other)
 	printf("    free: %p\n", type->tp_free);
 	printf("    finalize: %p\n", type->tp_finalize);
 	printf("======\n");
-	fflush(stdout);
 
 	return PyBool_FromLong(ret);
 	JP_PY_CATCH(NULL);
 }
 // GCOVR_EXCL_STOP
+#endif
 
 // GCOVR_EXCL_START
 int _PyJPModule_trace = 0;
@@ -659,7 +660,6 @@ static PyMethodDef moduleMethods[] = {
 #endif
 	{"_getClass", (PyCFunction) PyJPModule_getClass, METH_O, ""},
 	{"_hasClass", (PyCFunction) PyJPModule_hasClass, METH_O, ""},
-	{"examine", (PyCFunction) examine, METH_O, ""},
 	{"_newArrayType", (PyCFunction) PyJPModule_newArrayType, METH_VARARGS, ""},
 	{"_collect", (PyCFunction) PyJPModule_collect, METH_VARARGS, ""},
 	{"gcStats", (PyCFunction) PyJPModule_gcStats, METH_NOARGS, ""},
@@ -714,6 +714,7 @@ PyMODINIT_FUNC PyInit__jpype()
 	PyJPModule = module;
 	PyModule_AddStringConstant(module, "__version__", "1.2.1_dev0");
 
+	PyJPClassMagic = PyDict_New();
 	// Initialize each of the python extension types
 	PyJPClass_initType(module);
 	PyJPObject_initType(module);

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -245,7 +245,7 @@ int PyJPValue_setattro(PyObject *self, PyObject *name, PyObject *value)
 	// Private members are accessed directly
 	if (PyUnicode_GetLength(name) && PyUnicode_ReadChar(name, 0) == '_')
 		return PyObject_GenericSetAttr(self, name, value);
-	JPPyObject f = JPPyObject::accept(Py_GetAttrDescriptor(Py_TYPE(self), name));
+	JPPyObject f = JPPyObject::accept(PyJP_GetAttrDescriptor(Py_TYPE(self), name));
 	if (f.isNull())
 	{
 		PyErr_Format(PyExc_AttributeError, "Field '%U' is not found", name);

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -63,14 +63,14 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
     static = True
     if platform == 'win32':
         distutils.log.info("Add windows settings")
-        platform_specific['libraries'] = ['Advapi32']
+   #     platform_specific['libraries'] = ['Advapi32']
         platform_specific['define_macros'] = [('WIN32', 1)]
         if sys.version > '3':
             platform_specific['extra_compile_args'] = [
                 '/Zi', '/EHsc', '/std:c++14']
         else:
             platform_specific['extra_compile_args'] = ['/Zi', '/EHsc']
-        platform_specific['extra_link_args'] = ['/DEBUG']
+   #     platform_specific['extra_link_args'] = ['/DEBUG']
         jni_md_platform = 'win32'
 
     elif platform == 'darwin':

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -16,6 +16,7 @@
 #
 # *****************************************************************************
 import pytest
+import _jpype
 import jpype
 import common
 

--- a/test/jpypetest/test_coverage.py
+++ b/test/jpypetest/test_coverage.py
@@ -219,11 +219,6 @@ class CoverageCase(common.JPypeTestCase):
     def testModuleHasClass(self):
         self.assertTrue(_jpype._hasClass("java.lang.Object"))
 
-    def testModuleExamine(self):
-        # this is an internal testing routine for Java slots
-        _jpype.examine(jpype.JString)
-        _jpype.examine(jpype.JString("foo"))
-
     def testJClassBadClass(self):
         with self.assertRaises(Exception):
             jpype.JClass("not.a.class")


### PR DESCRIPTION
This fixes that problem with importing JPype on window 3.9.   A single static variable initializer was calling PyDict_New in pyjp_class.cpp which is not allowed because library loading does not hold the GIL.  However, a bug in Python which was not releasing the GIL was allowing the bad code to function.  When they corrected the GIL release bug it yanked the rug out from under us.  

Unfortunately as it did warrant a note in the change log in Python 3.9 for "Windows" nor had anyone reported this message as a symptom, it was a cold bug search for a bug that disappeared depending on the path that was taken.

This PR is end state after debugging.  So not every change was necessary to fix the bug.  If anything looks objectionable I can pull it.