### PR TITLE
TypeError when the platform was not recognized

### DIFF
--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -110,7 +110,7 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
         jni_md_platform = 'zos'
 
     else:
-        jni_md_platform = None
+        jni_md_platform = ''
         distutils.log.warn("Your platform '%s' is not being handled explicitly."
                            " It may work or not!", platform)
 

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -109,7 +109,7 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
         distutils.log.info("Add zos settings")
         jni_md_platform = 'zos'
 
-    elif platform == 'solaris':
+    elif platform == 'sunos5':
         distutils.log.info("Add solaris settings")
         jni_md_platform = 'solaris'
         

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -109,6 +109,10 @@ def Platform(include_dirs=None, sources=None, platform=sys.platform):
         distutils.log.info("Add zos settings")
         jni_md_platform = 'zos'
 
+    elif platform == 'solaris':
+        distutils.log.info("Add solaris settings")
+        jni_md_platform = 'solaris'
+        
     else:
         jni_md_platform = ''
         distutils.log.warn("Your platform '%s' is not being handled explicitly."


### PR DESCRIPTION
Script crashed because None on line 113 is not a String and cannot be used with os.path.join(str, str, str)

Suggest changing string to empty string or other 

Full error:
Your platform 'sunos5' is not being handled explicitly. It may work or not!
Traceback (most recent call last):
  File "setup.py", line 45, in <module>
    Path('native', 'embedded', '*.cpp')], platform=platform,
  File "REDACTED/jpype-master/setupext/platform.py", line 123, in Platform
    distutils.log.info("Add JNI directory %s" % os.path.join(java_home, 'include', jni_md_platform))
  File "REDACTED/lib/python3.6/posixpath.py", line 92, in join
    genericpath._check_arg_types('join', a, *p)
  File "REDACTED/lib/python3.6/genericpath.py", line 149, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'NoneType'