### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,12 @@ jpypeLib = Extension(name='_jpype', **setupext.platform.Platform(
     include_dirs=[Path('native', 'common', 'include'),
                   Path('native', 'python', 'include'),
                   Path('native', 'embedded', 'include')],
-    sources=[Path('native', 'common', '*.cpp'),
-             Path('native', 'python', '*.cpp'),
-             Path('native', 'embedded', '*.cpp')], platform=platform,
+    sources=sorted(map(str, list(Path('native', 'common').glob('*.cpp'))+
+             list(Path('native', 'python').glob('*.cpp'))+
+             list(Path('native', 'embedded').glob('*.cpp')))), platform=platform,
 ))
 jpypeJar = Extension(name="org.jpype",
-                     sources=glob.glob(str(Path("native", "java", "**", "*.java")), recursive=True),
+                     sources=sorted(map(str, Path("native", "java").glob("**/*.java"))),
                      language="java",
                      libraries=["lib/asm-8.0.1.jar"]
                      )


### PR DESCRIPTION
Sort input file list
so that `_jpype.cpython-36m-x86_64-linux-gnu.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.