### PR TITLE
Arrays generated wrong array type

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -84,6 +84,7 @@ jobs:
       mac-3.9:
         imageName: "macos-10.14"
         python.version: '3.9'
+        jpypetest.fast: 'true'
 
   pool:
     vmImage: $(imageName)

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,10 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.2.2_dev0 - 2021-01-03**
+  
+  - Fixed a bug with arrays created using the short cut.  The wrong type
+    was being returned.
+
 - **1.2.1 - 2021-01-02**
 
   - Missing stub files added.

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -712,10 +712,9 @@ static PyObject *PyJPClass_array(PyJPClass *self, PyObject *item)
 	if (PyIndex_Check(item))
 	{
 		long sz = PyLong_AsLong(item);
-		JPClass *cls = self->m_Class->newArrayType(frame, 1);
-		jvalue v;
-		v.l = (jobject) cls->newArrayOf(frame, sz);
-		return cls->convertToPythonObject(frame, v, true).keep();
+		JPArrayClass *cls = (JPArrayClass*) self->m_Class->newArrayType(frame, 1);
+		JPValue v = cls->newArray(frame, sz);
+		return cls->convertToPythonObject(frame, v.getValue(), true).keep();
 	}
 
 	if (PySlice_Check(item))

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -577,7 +577,7 @@ class ArrayTestCase(common.JPypeTestCase):
         self.assertEqual(ja.length, len(ja))
 
     def testShortcut(self):
-        # Test for odd bug introduced in 1.2.1
+        # Test for odd bug introduced in 1.0.0
         # This is unlikely to be reintroduced, but we can check anyway.
         # The class of when created using the shortcut should always match the type created using the old method
 

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -575,3 +575,25 @@ class ArrayTestCase(common.JPypeTestCase):
     def testLengthProperty(self):
         ja = JArray(JInt)([1, 2, 3])
         self.assertEqual(ja.length, len(ja))
+
+    def testShortcut(self):
+        # Test for odd bug introduced in 1.2.1
+        # This is unlikely to be reintroduced, but we can check anyway.
+        # The class of when created using the shortcut should always match the type created using the old method
+
+        # Check primitives
+        self.assertEqual(JBoolean[5].getClass(), JArray(JBoolean)(5).getClass())
+        self.assertEqual(JChar[5].getClass(), JArray(JChar)(5).getClass())
+        self.assertEqual(JByte[5].getClass(), JArray(JByte)(5).getClass())
+        self.assertEqual(JShort[5].getClass(), JArray(JShort)(5).getClass())
+        self.assertEqual(JInt[5].getClass(), JArray(JInt)(5).getClass())
+        self.assertEqual(JFloat[5].getClass(), JArray(JFloat)(5).getClass())
+        self.assertEqual(JDouble[5].getClass(), JArray(JDouble)(5).getClass())
+
+        # Check Objects
+        self.assertEqual(JString[5].getClass(), JArray(JString)(5).getClass())
+        self.assertEqual(JObject[5].getClass(), JArray(JObject)(5).getClass())
+
+        # Test multidimensional
+        self.assertEqual(JDouble[5, 5].getClass(), JArray(JDouble, 2)(5).getClass())
+        self.assertEqual(JObject[5, 5].getClass(), JArray(JObject, 2)(5).getClass())


### PR DESCRIPTION
This PR corrects a bug in the generation of arrays.   When ``jpype.JDouble[10]`` was call it produced an instance of ``double[10][]`` rather than ``double[10]`` as intended.   Oddly the bad wrapper passed most tests because the wrapper class was set to the type for ``double[]``.  It only failed because the memory was becoming corrupt when JNI calls on the bad wrapper eventually trigger a fault.   

I finally figured out when I passed the object to a field and the resulting field type came back with a different array type.   I can add tests for this bug but it is pretty obscure because the JNI is trusting on these memory accesses and thus there is no way to guarantee a failure.

Fixes #944