### PR TITLE
Changes needed for Python 3.10 GC changes.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -6,6 +6,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 Latest Changes:
 - **1.2.2_dev0 - 2021-01-03**
 
+  - Fixes for memory issues found when upgrading to Python 3.10 beta.
+
   - Add additional diagnositics for importing of non-public class.
 
   - Fixed issue with classes with unsatified dependencies leading to a crash

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -528,7 +528,6 @@ PyTracebackObject *tb_create(
 	frame->f_trace = NULL;
 	frame->f_valuestack = NULL;
 	frame->f_localsplus[0] = NULL;
-	frame->f_stackdepth = 0;
 
 	// Allow GC on the frame
 	PyObject_GC_Track(frame);

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -497,40 +497,38 @@ PyTracebackObject *tb_create(
 	if (code == NULL)
 		return NULL;
 
-	// Create a frame for the traceback.
-	PyFrameObject *frame = (PyFrameObject*) PyObject_GC_New(PyFrameObject, &PyFrame_Type);
+	// This is a bit of a kludge.  Python lacks a way to directly create
+	// a frame from a code object except when creating from the threadstate.
+	//
+	// In reviewing Python implementation, I find that the only element accessed
+	// in the thread state was the previous frame to link to.  Because frame 
+	// objects change a lot between different Python versions, trying to 
+	// replicate the actions of setting up a frame is difficult to keep portable.
+	//
+	// Python 3.10 introduces the additional requirement that the global
+	// dictionary supplied must have a __builtins__.  We can do this once
+	// when create the module.
+	//
+	// If instead we create a thread state and point the field it needs to the
+	// previous frame we create the frames using the defined API.  Much more 
+	// portable, but we have to create a big (uninitialized object) each time we
+	// want to pass in the previous frame.
+	PyThreadState state;
+	if (last_traceback != NULL)
+		state.frame = last_traceback->tb_frame;
+	else
+		state.frame = NULL;
 
-	// We could fail to get a frame
+	// Create a frame for the traceback.
+	PyFrameObject *frame = PyFrame_New(&state, code, dict, NULL);
+	
+	// frame just borrows the reference rather than claiming it
+	// so we need to get rid of the extra reference here.
+	Py_DECREF(code);
+	
+	// If we don't get the frame object there is no point
 	if (frame == NULL)
 		return NULL;
-
-	// This code must match the pattern in cpython/Objects/frameobject.c:frame_dealloc()
-	// Every required field should be 0 or properly set and referenced.
-	
-	// f_back
-	if (last_traceback != NULL)
-	{
-		frame->f_back = last_traceback->tb_frame;
-		Py_INCREF(frame->f_back);
-	}
-	else
-		frame->f_back = NULL;
-	// f_builtins
-	frame->f_builtins = dict;
-	Py_INCREF(frame->f_builtins);
-	// f_globals
-	frame->f_globals = dict;
-	Py_INCREF(frame->f_globals);
-	// f_locals
-	frame->f_locals = NULL;
-	// f_code (steal the reference)
-	frame->f_code = (PyCodeObject*) code;
-	frame->f_trace = NULL;
-	frame->f_valuestack = NULL;
-	frame->f_localsplus[0] = NULL;
-
-	// Allow GC on the frame
-	PyObject_GC_Track(frame);
 
 	// Create a traceback
 	PyTracebackObject *traceback = (PyTracebackObject*) 

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -158,6 +158,8 @@ PyObject  *PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases);
 PyObject  *PyJPValue_alloc(PyTypeObject* type, Py_ssize_t nitems );
 void       PyJPValue_free(void* obj);
 void       PyJPValue_finalize(void* obj);
+int        PyJPValue_traverse(PyObject *self, visitproc visit, void *arg);
+int        PyJPValue_clear(PyObject *self);
 
 // Generic methods that operate on any object with a Java slot
 PyObject  *PyJPValue_str(PyObject* self);

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -50,6 +50,13 @@ extern "C"
 {
 #endif
 
+// Needed to write common code with older versions
+#if PY_VERSION_HEX<0x03080000
+// Introduced in Python 3.8
+#define Py_TRASHCAN_BEGIN(X, Y)
+#define Py_TRASHCAN_END
+#endif
+
 PyMODINIT_FUNC PyInit__jpype();
 
 /**

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -51,7 +51,7 @@ extern "C"
 #endif
 
 // Needed to write common code with older versions
-#if PY_VERSION_HEX<0x03080000
+#ifndef Py_TRASHCAN_BEGIN
 // Introduced in Python 3.8
 #define Py_TRASHCAN_BEGIN(X, Y)
 #define Py_TRASHCAN_END

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -55,8 +55,10 @@ static void PyJPMethod_dealloc(PyJPMethod *self)
 {
 	JP_PY_TRY("PyJPMethod_dealloc");
 	PyObject_GC_UnTrack(self);
+	Py_TRASHCAN_BEGIN(self, PyJPMethod_dealloc)
 	PyJPMethod_clear(self);
 	Py_TYPE(self)->tp_free(self);
+	Py_TRASHCAN_END
 	JP_PY_CATCH_NONE(); // GCOVR_EXCL_LINE
 }
 

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -728,6 +728,12 @@ PyMODINIT_FUNC PyInit__jpype()
 	Py_INCREF(module);
 	PyJPModule = module;
 	PyModule_AddStringConstant(module, "__version__", "1.2.2_dev0");
+	
+	// Our module will be used for PyFrame object and it is a requirement that
+	// we have a builtins in our dictionary.
+	PyObject *builtins = PyEval_GetBuiltins();
+	Py_INCREF(builtins);
+	PyModule_AddObject(module, "__builtins__", builtins);
 
 	PyJPClassMagic = PyDict_New();
 	// Initialize each of the python extension types

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -23,7 +23,6 @@ import logging
 from os import path
 import sys
 import unittest
-import platform
 
 CLASSPATH = None
 fast = False
@@ -34,7 +33,9 @@ def version(v):
 
 
 def requirePythonAfter(required):
-    pversion = tuple([int(i) for i in platform.python_version_tuple()])
+    import re
+    import platform
+    pversion = tuple([int(re.search(r'\d+',i).group()) for i in platform.python_version_tuple()])
 
     def g(func):
         def f(self):


### PR DESCRIPTION
This PR contains a series of changes required to operate on Python 3.10.   Some changes in the GC system imposed additional requirements which were not satisfied.   I intend this for the 1.3 release, but the required changes warrant review before inclusion.  Once this is approved I can continue with the release.

This PR may need additional updates if it fails the CI.   Some changes for 3.10 may be incompatible with older Python versions. 

One reference counting problem was discovered with the PyFrame objects that this fixes.   The rest are changes to fix the GC.   We had one under count on a reference which required a manual increment.   It seems like there may be a bug in Python regarding importing modules.
