### PR TITLE
Docfix

### DIFF
--- a/doc/quickguide.py
+++ b/doc/quickguide.py
@@ -43,14 +43,6 @@ def python(s):
 """ % s
 
 
-def generic(s):
-    return """
-.. code-block::
-
-    %s
-""" % s
-
-
 def entry(Desc=None, Java=None, Python=None, Notes=None):
     global footnotes, footnotecounter
     if not Java:
@@ -296,7 +288,7 @@ entry("Checking if Java object wrapper", None,
 # Casting
 entry("Casting to a specific type",
       java("BaseClass b = (BaseClass)myObject;"),
-      generic("b = (BaseClass) @ myObject"),
+      python("b = (BaseClass) @ myObject"),
       "Matmul(@) is used as the casting operator.")
 endSection()
 
@@ -703,7 +695,7 @@ entry("Extending classes", None, None,
 
 entry("Lambdas",
         java('DoubleUnaryOperator u = (p->p*2);'),
-        generic('u=DoubleUnaryOperator@(lambda x: x*2)'),
+        python('u=DoubleUnaryOperator@(lambda x: x*2)'),
         'Any Java functional interface can take a lambda or callable.')
 endSection()
 

--- a/doc/quickguide.py
+++ b/doc/quickguide.py
@@ -112,7 +112,7 @@ print("""
 
     package org.pkg;
 
-    publc class BaseClass
+    public class BaseClass
     {
        public void callMember(int i)
        {}

--- a/doc/quickguide.rst
+++ b/doc/quickguide.rst
@@ -27,7 +27,7 @@ to be dangerous.
 
     package org.pkg;
 
-    public class BaseClass
+    publc class BaseClass
     {
        public void callMember(int i)
        {}
@@ -248,7 +248,7 @@ module, loaded using ``JPackage`` or loaded with the ``JClass`` factory.
 |                           |                                                         |                                                         |
 +---------------------------+---------------------------------------------------------+---------------------------------------------------------+
 |                           |                                                         |                                                         |
-| Casting to a specific     | .. code-block:: java                                    | .. code-block::                                         |
+| Casting to a specific     | .. code-block:: java                                    | .. code-block:: python                                  |
 | type [11]_                |                                                         |                                                         |
 |                           |     BaseClass b = (BaseClass)myObject;                  |     b = (BaseClass) @ myObject                          |
 |                           |                                                         |                                                         |
@@ -706,7 +706,7 @@ with an interface for each methods that are to be accessed from Python.
 | Extending classes [23]_   |                                                         |                                                         |
 +---------------------------+---------------------------------------------------------+---------------------------------------------------------+
 |                           |                                                         |                                                         |
-| Lambdas [24]_             | .. code-block:: java                                    | .. code-block::                                         |
+| Lambdas [24]_             | .. code-block:: java                                    | .. code-block:: python                                  |
 |                           |                                                         |                                                         |
 |                           |     DoubleUnaryOperator u = (p->p*2);                   |     u=DoubleUnaryOperator@(lambda x: x*2)               |
 |                           |                                                         |                                                         |

--- a/doc/quickguide.rst
+++ b/doc/quickguide.rst
@@ -27,7 +27,7 @@ to be dangerous.
 
     package org.pkg;
 
-    publc class BaseClass
+    public class BaseClass
     {
        public void callMember(int i)
        {}

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -3172,6 +3172,36 @@ JPype Known limitations
 This section lists those limitations that are unlikely to change, as they come
 from external sources.
 
+Annotations
+-----------
+
+Some frameworks such as Spring use Java annotations to indicate specific
+actions.  These may be either runtime annotations or compile time annotations.
+Occasionally while using JPype someone would like to add a Java annotation to a
+JProxy method so that a framework like Spring can pick up that annotation.
+
+JPype uses the Java supplied ``Proxy`` to implement an interface.  That API
+does not support addition of a runtime annotation to a method or class.  Thus,
+all methods and classes when probed with reflection that are implemented in
+Python will come back with no annotations.   
+
+Further, the majority of annotation magic within Java is actually performed at
+compile time.  This is accomplished using an annotation processor.  When a
+class or method is annotated, the compiler checks to see if there is an
+annotation processor which then can produce new code or modify the class
+annotations.  As this is a compile time process, even if annotations were added
+by Python to a class they would still not be active as the corresponding
+compilation phase would not have been executed.   
+
+This is a limitation of the implementation of annotations by the Java virtual
+machine.  It is technically possible though the use of specialized code
+generation with the ASM library or other code generation to add a runtime
+annotation.  Or through exploits of the Java virtual machine annotation
+implementation one can add annotation to existing Java classes.  But these
+annotations are unlikely to be useful. As such JPype will not be able to
+support class or method annotations.
+
+
 Restarting the JVM
 -------------------
 


### PR DESCRIPTION
This PR 

Fixes #998
Fixes #940
Fixes #991

- Corrects a formatting issue that was resulting in missing examples in the quick guide regarding the casting operator.
- Added section on casting operator to the user guide
- Added section on array operators to the user guide
- Added section on pass by reference to get back results from modified Java arrays.
- Added section on annotations to limitations 