### PR TITLE
fix - #1016: Make functional conversion check argument count

### DIFF
--- a/native/common/include/jp_typemanager.h
+++ b/native/common/include/jp_typemanager.h
@@ -41,6 +41,7 @@ public:
 	JPClass* findClassForObject(jobject obj);
 	void populateMethod(void* method, jobject obj);
 	void populateMembers(JPClass* cls);
+    int interfaceParameterCount(JPClass* cls);
 
 private:
 	JPContext* m_Context;
@@ -50,6 +51,7 @@ private:
 	jmethodID m_FindClassForObject;
 	jmethodID m_PopulateMethod;
 	jmethodID m_PopulateMembers;
+    jmethodID m_InterfaceParameterCount;
 } ;
 
 #endif // _JPCLASS_H_

--- a/native/common/jp_functional.cpp
+++ b/native/common/jp_functional.cpp
@@ -41,64 +41,64 @@ public:
 		if (!PyCallable_Check(match.object))
 			return match.type = JPMatch::_none;
 
-        // Modified from https://stackoverflow.com/a/1117735
-        bool has_parameter_count = false;
-        // Get the __code__ attribute of the function, which contains details about the function
-        // Note: __code__ is func_code in Python 2.x
-        PyObject* function_code_object = PyObject_GetAttrString(match.object, "__code__");
-        if(function_code_object) {
-            // get the argument count
-            PyObject* parameter_count_obj = PyObject_GetAttrString(function_code_object, "co_argcount");
-            if(parameter_count_obj) {
-                has_parameter_count = true;
-                int optional_parameter_count = 0;
-                int flags = 0;
-                const int ACCEPT_VARGS_MASK = 0x04; // From https://docs.python.org/3/reference/datamodel.html
-                PyObject* flags_obj = PyObject_GetAttrString(function_code_object, "co_flags");
-                if (flags_obj) {
-                    flags = PyLong_AsLong(flags_obj);
-                    Py_DECREF(flags_obj);
-                }
-                PyObject* optional_parameter_tuple = PyObject_GetAttrString(match.object, "__defaults__");
-                if (optional_parameter_tuple && optional_parameter_tuple != Py_None) {
-                    optional_parameter_count = PyTuple_Size(optional_parameter_tuple);
-                    Py_DECREF(optional_parameter_tuple);
-                }
-                const int parameter_count = PyLong_AsLong(parameter_count_obj);
-                const int java_parameter_count = cls->getContext()->getTypeManager()->interfaceParameterCount(cls);
-                const bool is_varargs = (flags & ACCEPT_VARGS_MASK) == ACCEPT_VARGS_MASK;
+		// Modified from https://stackoverflow.com/a/1117735
+		bool has_parameter_count = false;
+		// Get the __code__ attribute of the function, which contains details about the function
+		// Note: __code__ is func_code in Python 2.x
+		PyObject* function_code_object = PyObject_GetAttrString(match.object, "__code__");
+		if(function_code_object) {
+			// get the argument count
+			PyObject* parameter_count_obj = PyObject_GetAttrString(function_code_object, "co_argcount");
+			if(parameter_count_obj) {
+				has_parameter_count = true;
+				int optional_parameter_count = 0;
+				int flags = 0;
+				const int ACCEPT_VARGS_MASK = 0x04; // From https://docs.python.org/3/reference/datamodel.html
+				PyObject* flags_obj = PyObject_GetAttrString(function_code_object, "co_flags");
+				if (flags_obj) {
+					flags = PyLong_AsLong(flags_obj);
+					Py_DECREF(flags_obj);
+				}
+				PyObject* optional_parameter_tuple = PyObject_GetAttrString(match.object, "__defaults__");
+				if (optional_parameter_tuple && optional_parameter_tuple != Py_None) {
+					optional_parameter_count = PyTuple_Size(optional_parameter_tuple);
+					Py_DECREF(optional_parameter_tuple);
+				}
+				const int parameter_count = PyLong_AsLong(parameter_count_obj);
+				const int java_parameter_count = cls->getContext()->getTypeManager()->interfaceParameterCount(cls);
+				const bool is_varargs = (flags & ACCEPT_VARGS_MASK) == ACCEPT_VARGS_MASK;
 
-                // def my_func(x, y=None) should be both a Function and a BiFunction
-                // i.e. the number of parameters accepted by the interface MUST
-                // 1. Be at most the maximum number of parameters accepted by the python function (parameter_count)
-                //    (Unless the function accept a variable number of arguments, then this restriction does not
-                //     apply).
-                // 2. Be at least the minumum number of parameters accepted by the python function
-                // (parameter_count - optional_parameter_count = number of required parameters).
-                // Notes:
-                // - keywords vargs does not remove restriction 1
-                // - keyword only arguments are not counted.
-                if ((!is_varargs && parameter_count < java_parameter_count) ||
-                    parameter_count - optional_parameter_count > java_parameter_count) {
-                    match.type = JPMatch::_none;
-                } else {
-                	match.conversion = this;
-                	match.closure = cls;
-                	match.type = JPMatch::_implicit;
-                }
+				// def my_func(x, y=None) should be both a Function and a BiFunction
+				// i.e. the number of parameters accepted by the interface MUST
+				// 1. Be at most the maximum number of parameters accepted by the python function (parameter_count)
+				//    (Unless the function accept a variable number of arguments, then this restriction does not
+				//     apply).
+				// 2. Be at least the minumum number of parameters accepted by the python function
+				// (parameter_count - optional_parameter_count = number of required parameters).
+				// Notes:
+				// - keywords vargs does not remove restriction 1
+				// - keyword only arguments are not counted.
+				if ((!is_varargs && parameter_count < java_parameter_count) ||
+					parameter_count - optional_parameter_count > java_parameter_count) {
+					match.type = JPMatch::_none;
+				} else {
+					match.conversion = this;
+					match.closure = cls;
+					match.type = JPMatch::_implicit;
+				}
 
-                Py_DECREF(parameter_count_obj);
-            }
-            Py_DECREF(function_code_object);
-        }
-        PyErr_Clear();
-        if (!has_parameter_count) {
-		    match.conversion = this;
-		    match.closure = cls;
-		    return match.type = JPMatch::_implicit;
-        } else {
-            return match.type;
-        }
+				Py_DECREF(parameter_count_obj);
+			}
+			Py_DECREF(function_code_object);
+		}
+		PyErr_Clear();
+		if (!has_parameter_count) {
+			match.conversion = this;
+			match.closure = cls;
+			return match.type = JPMatch::_implicit;
+		} else {
+			return match.type;
+		}
 	}
 
 	virtual void getInfo(JPClass *cls, JPConversionInfo &info) override

--- a/native/common/jp_functional.cpp
+++ b/native/common/jp_functional.cpp
@@ -40,9 +40,65 @@ public:
 	{
 		if (!PyCallable_Check(match.object))
 			return match.type = JPMatch::_none;
-		match.conversion = this;
-		match.closure = cls;
-		return match.type = JPMatch::_implicit;
+        // Modified from https://stackoverflow.com/a/1117735
+
+        bool has_parameter_count = false;
+        // Get the __code__ attribute of the function, which contains details about the function
+        // Note: __code__ is func_code in Python 2.x
+        PyObject* function_code_object = PyObject_GetAttrString(match.object, "__code__");
+        if(function_code_object) {
+            // get the argument count
+            PyObject* parameter_count_obj = PyObject_GetAttrString(function_code_object, "co_argcount");
+            if(parameter_count_obj) {
+                has_parameter_count = true;
+                int optional_parameter_count = 0;
+                int flags = 0;
+                const int ACCEPT_VARGS_MASK = 0x04; // From https://docs.python.org/3/reference/datamodel.html
+                PyObject* flags_obj = PyObject_GetAttrString(function_code_object, "co_flags");
+                if (flags_obj) {
+                    flags = PyLong_AsLong(flags_obj);
+                    Py_DECREF(flags_obj);
+                }
+                PyObject* optional_parameter_tuple = PyObject_GetAttrString(match.object, "__defaults__");
+                if (optional_parameter_tuple && optional_parameter_tuple != Py_None) {
+                    optional_parameter_count = PyTuple_Size(optional_parameter_tuple);
+                    Py_DECREF(optional_parameter_tuple);
+                }
+                const int parameter_count = PyLong_AsLong(parameter_count_obj);
+                const int java_parameter_count = cls->getContext()->getTypeManager()->interfaceParameterCount(cls);
+                const bool is_varargs = (flags & ACCEPT_VARGS_MASK) == ACCEPT_VARGS_MASK;
+
+                // def my_func(x, y=None) should be both a Function and a BiFunction
+                // i.e. the number of parameters accepted by the interface MUST
+                // 1. Be at most the maximum number of parameters accepted by the python function (parameter_count)
+                //    (Unless the function accept a variable number of arguments, then this restriction does not
+                //     apply).
+                // 2. Be at least the minumum number of parameters accepted by the python function
+                // (parameter_count - optional_parameter_count = number of required parameters).
+                // Notes:
+                // - keywords vargs does not remove restriction 1
+                // - keyword only arguments are not counted.
+                if ((!is_varargs && parameter_count < java_parameter_count) ||
+                    parameter_count - optional_parameter_count > java_parameter_count) {
+                    match.type = JPMatch::_none;
+                } else {
+                	match.conversion = this;
+                	match.closure = cls;
+                	match.type = JPMatch::_implicit;
+                }
+
+                Py_DECREF(parameter_count_obj);
+            }
+            Py_DECREF(function_code_object);
+        }
+
+        if (!has_parameter_count) {
+		    match.conversion = this;
+		    match.closure = cls;
+		    return match.type = JPMatch::_implicit;
+        } else {
+            return match.type;
+        }
 	}
 
 	virtual void getInfo(JPClass *cls, JPConversionInfo &info) override

--- a/native/common/jp_functional.cpp
+++ b/native/common/jp_functional.cpp
@@ -40,8 +40,8 @@ public:
 	{
 		if (!PyCallable_Check(match.object))
 			return match.type = JPMatch::_none;
-        // Modified from https://stackoverflow.com/a/1117735
 
+        // Modified from https://stackoverflow.com/a/1117735
         bool has_parameter_count = false;
         // Get the __code__ attribute of the function, which contains details about the function
         // Note: __code__ is func_code in Python 2.x
@@ -91,7 +91,7 @@ public:
             }
             Py_DECREF(function_code_object);
         }
-
+        PyErr_Clear();
         if (!has_parameter_count) {
 		    match.conversion = this;
 		    match.closure = cls;

--- a/native/common/jp_methoddispatch.cpp
+++ b/native/common/jp_methoddispatch.cpp
@@ -67,14 +67,16 @@ bool JPMethodDispatch::findOverload(JPJavaFrame& frame, JPMethodMatch &bestMatch
 	// found, and one to hold the test of the next overload.
 	JPMethodMatch match = bestMatch;
 
-	// Check each overload in order (the TypeManager orders them by priority
+
+    bool is_first_match = true;
+    // Check each overload in order (the TypeManager orders them by priority
 	// according to Java overload rules).
 	for (JPMethodList::iterator it = m_Overloads.begin(); it != m_Overloads.end(); ++it)
 	{
 		JPMethod* current = *it;
 
 		JP_TRACE("Trying to match", current->toString());
-		current->matches(frame, match, callInstance, arg);
+        current->matches(frame, match, callInstance, arg);
 
 		JP_TRACE("  match ended", match.m_Type);
 		if (match.m_Type == JPMatch::_exact)
@@ -88,9 +90,10 @@ bool JPMethodDispatch::findOverload(JPJavaFrame& frame, JPMethodMatch &bestMatch
 			continue;
 
 		// If this is the first match then make it the best.
-		if (bestMatch.m_Overload == 0)
+		if (is_first_match)
 		{
 			bestMatch = match;
+            is_first_match = false;
 			continue;
 		}
 

--- a/native/common/jp_methoddispatch.cpp
+++ b/native/common/jp_methoddispatch.cpp
@@ -61,22 +61,23 @@ bool JPMethodDispatch::findOverload(JPJavaFrame& frame, JPMethodMatch &bestMatch
 		// Anything better than explicit constitutes a hit on the cache
 		if (bestMatch.m_Type > JPMatch::_explicit)
 			return true;
+		else
+			// bad match so forget the overload.
+			bestMatch.m_Overload = 0;
 	}
 
 	// We need two copies of the match.  One to hold the best match we have
 	// found, and one to hold the test of the next overload.
 	JPMethodMatch match = bestMatch;
 
-
-    bool is_first_match = true;
-    // Check each overload in order (the TypeManager orders them by priority
+	// Check each overload in order (the TypeManager orders them by priority
 	// according to Java overload rules).
 	for (JPMethodList::iterator it = m_Overloads.begin(); it != m_Overloads.end(); ++it)
 	{
 		JPMethod* current = *it;
 
 		JP_TRACE("Trying to match", current->toString());
-        current->matches(frame, match, callInstance, arg);
+		current->matches(frame, match, callInstance, arg);
 
 		JP_TRACE("  match ended", match.m_Type);
 		if (match.m_Type == JPMatch::_exact)
@@ -90,10 +91,9 @@ bool JPMethodDispatch::findOverload(JPJavaFrame& frame, JPMethodMatch &bestMatch
 			continue;
 
 		// If this is the first match then make it the best.
-		if (is_first_match)
+		if (bestMatch.m_Overload == 0)
 		{
 			bestMatch = match;
-            is_first_match = false;
 			continue;
 		}
 

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -27,6 +27,7 @@ JPTypeManager::JPTypeManager(JPJavaFrame& frame)
 	m_FindClassForObject = frame.GetMethodID(cls, "findClassForObject", "(Ljava/lang/Object;)J");
 	m_PopulateMethod = frame.GetMethodID(cls, "populateMethod", "(JLjava/lang/reflect/Executable;)V");
 	m_PopulateMembers = frame.GetMethodID(cls, "populateMembers", "(Ljava/lang/Class;)V");
+    m_InterfaceParameterCount = frame.GetMethodID(cls, "interfaceParameterCount", "(Ljava/lang/Class;)I");
 
 	// The object instance will be loaded later
 	JP_TRACE_OUT;
@@ -96,4 +97,14 @@ void JPTypeManager::populateMembers(JPClass* cls)
 	val[0].l = (jobject) cls->getJavaClass();
 	frame.CallVoidMethodA(m_JavaTypeManager.get(), m_PopulateMembers, val);
 	JP_TRACE_OUT;
+}
+
+int JPTypeManager::interfaceParameterCount(JPClass *cls)
+{
+    JP_TRACE_IN("JPTypeManager::interfaceParameterCount");
+    JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+    jvalue val[1];
+    val[0].l = (jobject) cls->getJavaClass();
+    return frame.CallIntMethodA(m_JavaTypeManager.get(), m_InterfaceParameterCount, val);
+    JP_TRACE_OUT;
 }

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -101,10 +101,10 @@ void JPTypeManager::populateMembers(JPClass* cls)
 
 int JPTypeManager::interfaceParameterCount(JPClass *cls)
 {
-    JP_TRACE_IN("JPTypeManager::interfaceParameterCount");
-    JPJavaFrame frame = JPJavaFrame::outer(m_Context);
-    jvalue val[1];
-    val[0].l = (jobject) cls->getJavaClass();
-    return frame.CallIntMethodA(m_JavaTypeManager.get(), m_InterfaceParameterCount, val);
-    JP_TRACE_OUT;
+	JP_TRACE_IN("JPTypeManager::interfaceParameterCount");
+	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	jvalue val[1];
+	val[0].l = (jobject) cls->getJavaClass();
+	return frame.CallIntMethodA(m_JavaTypeManager.get(), m_InterfaceParameterCount, val);
+	JP_TRACE_OUT;
 }

--- a/native/java/org/jpype/manager/ClassDescriptor.java
+++ b/native/java/org/jpype/manager/ClassDescriptor.java
@@ -46,6 +46,7 @@ public class ClassDescriptor
   public int methodCounter = 0;
   public long[] fields;
   public long anonymous;
+  public int functional_interface_parameter_count = -1; // -1 = unset; -2 = not a functional interface
 
   ClassDescriptor(Class cls, long classPtr)
   {

--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -301,6 +301,34 @@ public class TypeManager
   }
 
   /**
+   * Returns the number of arguments an interface only unimplemented method accept.
+   *
+   * @param interfaceClass The class of the interface
+   * @return the number of arguments the only unimplemented method of the interface accept.
+   */
+  public int interfaceParameterCount(Class<?> interfaceClass) {
+    ClassDescriptor classDescriptor = classMap.get(interfaceClass);
+    if (classDescriptor.functional_interface_parameter_count != -1) {
+      return classDescriptor.functional_interface_parameter_count;
+    }
+    int abstractMethodParameterCount = -1;
+    for (Method method : interfaceClass.getMethods()) {
+      if (Modifier.isAbstract(method.getModifiers())) {
+        if (abstractMethodParameterCount != -1) {
+          classDescriptor.functional_interface_parameter_count = -2;
+          return -2;
+        }
+        abstractMethodParameterCount = method.getParameterCount();
+      }
+    }
+    if (abstractMethodParameterCount == -1) {
+      abstractMethodParameterCount = -2;
+    }
+    classDescriptor.functional_interface_parameter_count = abstractMethodParameterCount;
+    return abstractMethodParameterCount;
+  }
+
+  /**
    * Get a class for an object.
    *
    * @param object is the object to interrogate.

--- a/test/harness/jpype/overloads/Test2.java
+++ b/test/harness/jpype/overloads/Test2.java
@@ -1,0 +1,45 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.overloads;
+
+import java.util.List;
+
+public class Test2
+{
+    interface NoArg {
+        public String apply();
+    }
+
+    interface SingleArg {
+        public String apply(int a);
+    }
+
+    interface TwoArg {
+        public String apply(int a, int b);
+    }
+
+    public String testFunctionalInterfaces(NoArg noArg) {
+        return "NoArg";
+    }
+
+    public String testFunctionalInterfaces(SingleArg singleArg) {
+        return "SingleArg";
+    }
+
+    public String testFunctionalInterfaces(TwoArg twoArg) {
+        return "TwoArg";
+    }
+}

--- a/test/harness/jpype/overloads/Test2.java
+++ b/test/harness/jpype/overloads/Test2.java
@@ -19,20 +19,23 @@ import java.util.List;
 
 public class Test2
 {
-    interface NoArg {
+    @FunctionalInterface
+    public interface NoArg {
         public String apply();
     }
 
-    interface SingleArg {
+    @FunctionalInterface
+    public interface SingleArg {
         public String apply(int a);
     }
 
-    interface TwoArg {
+    @FunctionalInterface
+    public interface TwoArg {
         public String apply(int a, int b);
     }
 
     public String testFunctionalInterfaces(NoArg noArg) {
-        return "NoArg";
+        return "NoArgs";
     }
 
     public String testFunctionalInterfaces(SingleArg singleArg) {

--- a/test/jpypetest/test_overloads.py
+++ b/test/jpypetest/test_overloads.py
@@ -210,8 +210,6 @@ class OverloadTestCase(common.JPypeTestCase):
         def my_fun_kw(*, keyword_arg=None):
             return 'my_fun_kw'
 
-        def my_fun_pos_only(x, /, y):
-            return 'my_fun_pos_only'
         test2 = self.__jp.Test2()
         self.assertRaisesRegex(
             TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun)
@@ -219,4 +217,3 @@ class OverloadTestCase(common.JPypeTestCase):
             TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun_vargs)
         self.assertEqual('SingleArg', test2.testFunctionalInterfaces(my_fun_kwargs))
         self.assertEqual('NoArgs', test2.testFunctionalInterfaces(my_fun_kw))
-        self.assertEqual('TwoArg', test2.testFunctionalInterfaces(my_fun_pos_only))

--- a/test/jpypetest/test_overloads.py
+++ b/test/jpypetest/test_overloads.py
@@ -190,3 +190,33 @@ class OverloadTestCase(common.JPypeTestCase):
             pass
         else:
             self.assertEqual('B', testdefault.defaultMethod())
+
+    def testFunctionalInterfacesWithDifferentSignatures(self):
+        test2 = self.__jp.Test2()
+        self.assertEqual('NoArgs', test2.testFunctionalInterfaces(lambda: 'NoArgs'))
+        self.assertEqual('SingleArg', test2.testFunctionalInterfaces(lambda a: 'SingleArg'))
+        self.assertEqual('TwoArg', test2.testFunctionalInterfaces(lambda a, b: 'TwoArg'))
+
+    def testFunctionalInterfacesWithDefaults(self):
+        def my_fun(x, y=None):
+            return 'my_fun'
+
+        def my_fun_vargs(x, *vargs):
+            return 'my_fun_vargs'
+
+        def my_fun_kwargs(x, **kwargs):
+            return 'my_fun_kwargs'
+
+        def my_fun_kw(*, keyword_arg=None):
+            return 'my_fun_kw'
+
+        def my_fun_pos_only(x, /, y):
+            return 'my_fun_pos_only'
+        test2 = self.__jp.Test2()
+        self.assertRaisesRegex(
+            TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun)
+        self.assertRaisesRegex(
+            TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun_vargs)
+        self.assertEqual('SingleArg', test2.testFunctionalInterfaces(my_fun_kwargs))
+        self.assertEqual('NoArgs', test2.testFunctionalInterfaces(my_fun_kw))
+        self.assertEqual('TwoArg', test2.testFunctionalInterfaces(my_fun_pos_only))

--- a/test/jpypetest/test_overloads.py
+++ b/test/jpypetest/test_overloads.py
@@ -210,10 +210,16 @@ class OverloadTestCase(common.JPypeTestCase):
         def my_fun_kw(*, keyword_arg=None):
             return 'my_fun_kw'
 
+        class my_fun_class:
+            def __call__(self):
+                return 'my_fun_class'
+
         test2 = self.__jp.Test2()
         self.assertRaisesRegex(
             TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun)
         self.assertRaisesRegex(
             TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun_vargs)
+        self.assertRaisesRegex(
+            TypeError, 'Ambiguous overloads found', test2.testFunctionalInterfaces, my_fun_class)
         self.assertEqual('SingleArg', test2.testFunctionalInterfaces(my_fun_kwargs))
         self.assertEqual('NoArgs', test2.testFunctionalInterfaces(my_fun_kw))


### PR DESCRIPTION
Motivation:

For a Java class with multiple overloads, reducing required casting and reduced TypeError caused by Python function accepting a different argument count than a Java `@FunctionalInterface`.

```java
public class MyClass {
    public static String apply(Function map) {
        return "Function apply";
    }

    public static String apply(BiFunction map) {
        return "BiFunction apply";
    }
}
```

Overloads:
```python
import jpype
import jpype.imports
from jpype import JImplements, JOverride, JObject

jpype.startJVM(classpath=['...'])

from org.acme import MyClass

assert str(MyClass.apply(lambda a: a)) == "Function apply"
assert str(MyClass.apply(lambda a, b: a)) == "BiFunction apply"
```

Old Behaviour:
```
TypeError: Ambiguous overloads found for org.acme.MyClass.apply(function) between:
	public static java.lang.String org.acme.MyClass.apply(java.util.function.BiFunction)
	public static java.lang.String org.acme.MyClass.apply(java.util.function.Function)
```

New Behaviour:
```
>>>  str(MyClass.apply(lambda a: a))
'Function apply'
>>>  str(MyClass.apply(lambda a, b: a))
'BiFunction apply'
```

Bad Casts
```
assert str(MyClass.apply(JObject(lambda a: a, BiFunction))) == 'Function apply'
assert str(MyClass.apply(JObject(lambda a, b: a, Function))) == 'BiFunction apply'
```

Old Behaviour:
```
TypeError: <lambda>() takes 1 positional argument but 2 were given
```

New Behaviour:
```
TypeError: Unable to cast 'function' to java type 'java.util.function.BiFunction'
```

This commit modify functional conversion to check argument count:

1. If the Java functional interface have more parameters than
   the Python function and the Python function does not accept
   variable arguments, conversion type is none

2. If the Java functional interface have less parameters than
   the number of required positional parameters of the Python
   function, conversion type is none

3. Otherwise, conversion type is implict.

I tested on my issue-reproducer and I can confirm it fixes the issue. I added some tests, but I couldn't figure out how to run them locally.

Fixes #1016