### PR TITLE
Fix java.nio.file import in AutoCloseable example

### DIFF
--- a/doc/java/lang.py
+++ b/doc/java/lang.py
@@ -25,7 +25,7 @@ class AutoCloseable:
 
     .. code-block:: python
 
-        from java.nio.files import Files, Paths
+        from java.nio.file import Files, Paths
         with Files.newInputStream(Paths.get("foo")) as fd:
           # operate on the input stream
 


### PR DESCRIPTION
This PR proposes to fix the import in `AutoCloseable` example. The current example fails as below:


```python
>>> from java.nio.files import Files, Paths
```
```
Traceback (most recent call last):
  File "org.jpype.JPypeContext.java", line -1, in org.jpype.JPypeContext.callMethod
  ...
java.lang.ClassNotFoundException: java.lang.ClassNotFoundException: java.nio.files
  ...
ImportError: Failed to import 'java.nio.files'
```

It has to be `java.nio.file`:

```python
>>> from java.nio.file import Files, Paths
```