### PR TITLE
Fix issue with numpy arrays.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,8 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.3.1_dev0 - 2021-06-05**
+  - Fix issue with numpy arrays with no dimensions resulting in crash..
+
 - **1.3.0 - 2021-05-19**
 
   - Fixes for memory issues found when upgrading to Python 3.10 beta.

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -469,6 +469,11 @@ public:
 		// If it is a buffer we only need to test the first item in the list
 		JPPySequence seq = JPPySequence::use(match.object);
 		jlong length = seq.size();
+		if (length == -1 && PyErr_Occurred())
+		{
+			PyErr_Clear();
+			return match.type = JPMatch::_none;
+		}
 		match.type = JPMatch::_implicit;
 		if (length > 0)
 		{
@@ -491,6 +496,7 @@ public:
 
 	virtual jvalue convert(JPMatch &match) override
 	{
+		JP_TRACE_IN("JPConversionBuffer::convert");
 		JPJavaFrame frame(*match.frame);
 		jvalue res;
 		JPArrayClass *acls = (JPArrayClass *) match.closure;
@@ -500,6 +506,7 @@ public:
 		ccls->setArrayRange(frame, array, 0, length, 1, match.object);
 		res.l = frame.keep(array);
 		return res;
+		JP_TRACE_OUT;
 	}
 }  _bufferConversion;
 
@@ -516,6 +523,11 @@ public:
 		JPClass *componentType = acls->getComponentType();
 		JPPySequence seq = JPPySequence::use(match.object);
 		jlong length = seq.size();
+		if (length==-1 && PyErr_Occurred())
+		{
+			PyErr_Clear();
+			return match.type = JPMatch::_none;
+		}
 		match.type = JPMatch::_implicit;
 		for (jlong i = 0; i < length && match.type > JPMatch::_none; i++)
 		{

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -286,6 +286,7 @@ void JPypeException::toPython()
 {
 	string mesg;
 	JP_TRACE_IN("JPypeException::toPython");
+	JP_TRACE("err", PyErr_Occurred());
 	try
 	{
 		// Check the signals before processing the exception
@@ -297,6 +298,11 @@ void JPypeException::toPython()
 		mesg = getMessage();
 		JP_TRACE(m_Error.l);
 		JP_TRACE(mesg.c_str());
+
+		// We already have a Python error on the stack.
+		if (PyErr_Occurred())
+			return;
+
 		if (m_Type == JPError::_java_error)
 		{
 			JP_TRACE("Java exception");


### PR DESCRIPTION
Fixes #1020 

Addresses an issue where the return code on calling len() on an numpy array with no diminsions was failing.   To prevent fucture crashes it checks the error sets on exception toPython to make sure the missing error is not eaten which was causing the double throw failure.   