### PR TITLE
Remove 3.5 from test matrix

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -50,9 +50,6 @@ jobs:
   dependsOn: Deps
   strategy:
     matrix:
-      linux-3.5:
-        imageName: "ubuntu-latest"
-        python.version: '3.5'
       linux-3.6:
         imageName: "ubuntu-latest"
         python.version: '3.6'
@@ -65,9 +62,6 @@ jobs:
       linux-3.9:
         imageName: "ubuntu-latest"
         python.version: '3.9'
-      windows-3.5:
-        imageName: "vs2017-win2016"
-        python.version: '3.5'
       windows-3.6:
         imageName: "vs2017-win2016"
         python.version: '3.6'


### PR DESCRIPTION
It appears that Python 3.5 is no longer supported on azure.  Removing from test matrix.