### PR TITLE
Correct the buffer protocol format type for longs

### DIFF
--- a/jpype/_jarray.py
+++ b/jpype/_jarray.py
@@ -126,7 +126,7 @@ class _JArrayProto(object):
 
 
 def _toJavaClass(tp):
-    """(internal) Converts a class type in python into a internal java class.
+    """(internal) Converts a class type in python into an internal java class.
 
     Used mainly to support JArray.
 
@@ -135,11 +135,11 @@ def _toJavaClass(tp):
      - (JClass) just returns the java type.
      - (type) uses a lookup table to find the class.
     """
-    # if it a string than we lookup the class by name.
+    # if it is a string than we lookup the class by name.
     if isinstance(tp, str):
         return _jpype._java_lang_Class.forName(tp)
 
-    # if is a java.lang.Class instance, then no coversion required
+    # if is a java.lang.Class instance, then no conversion required
     if isinstance(tp, _jpype._JClass):
         return tp
 
@@ -149,7 +149,7 @@ def _toJavaClass(tp):
     except KeyError:
         pass
 
-    # See if it a class type
+    # See if it is a class type
     try:
         return tp.class_
     except AttributeError:

--- a/jpype/nio.py
+++ b/jpype/nio.py
@@ -21,7 +21,7 @@ __all__ = ['convertToDirectBuffer']
 
 
 def convertToDirectBuffer(obj):
-    __doc__ = '''Efficiently convert all array.array and numpy ndarray types, string and unicode to java.nio.Buffer objects.'''
+    '''Efficiently convert all array.array and numpy ndarray types, string and unicode to java.nio.Buffer objects.'''
 
     memoryview_of_obj = memoryview(obj)
 

--- a/native/common/jp_convert.cpp
+++ b/native/common/jp_convert.cpp
@@ -82,155 +82,361 @@ public:
 } ;
 } // namespace
 
-jconverter getConverter(const char* from, int itemsize, const char* to)
-{
-	// If not specified then the type is bytes
-	if (from == NULL)
-		from = "B";
-	// Standard size for 'l' is 4 in docs, but numpy uses format 'l' for long long
-	if (itemsize == 8 && from[0] == 'l')
-		from = "q";
-	if (itemsize == 8 && from[0] == 'L')
-		from = "Q";
-	switch (from[0])
-	{
-		case '?':
-		case 'c':
-		case 'b':
-			switch (to[0])
-			{
-				case 'z': return &Convert<int8_t>::toZ;
-				case 'b': return &Convert<int8_t>::toB;
-				case 'c': return &Convert<int8_t>::toC;
-				case 's': return &Convert<int8_t>::toS;
-				case 'i': return &Convert<int8_t>::toI;
-				case 'j': return &Convert<int8_t>::toJ;
-				case 'f': return &Convert<int8_t>::toF;
-				case 'd': return &Convert<int8_t>::toD;
-			}
-			return 0;
-		case 'B':
-			switch (to[0])
-			{
-				case 'z': return &Convert<uint8_t>::toZ;
-				case 'b': return &Convert<uint8_t>::toB;
-				case 'c': return &Convert<uint8_t>::toC;
-				case 's': return &Convert<uint8_t>::toS;
-				case 'i': return &Convert<uint8_t>::toI;
-				case 'j': return &Convert<uint8_t>::toJ;
-				case 'f': return &Convert<uint8_t>::toF;
-				case 'd': return &Convert<uint8_t>::toD;
-			}
-			return 0;
-		case 'h':
-			switch (to[0])
-			{
-				case 'z': return &Convert<int16_t>::toZ;
-				case 'b': return &Convert<int16_t>::toB;
-				case 'c': return &Convert<int16_t>::toC;
-				case 's': return &Convert<int16_t>::toS;
-				case 'i': return &Convert<int16_t>::toI;
-				case 'j': return &Convert<int16_t>::toJ;
-				case 'f': return &Convert<int16_t>::toF;
-				case 'd': return &Convert<int16_t>::toD;
-			}
-			return 0;
-		case 'H':
-			switch (to[0])
-			{
-				case 'z': return &Convert<uint16_t>::toZ;
-				case 'b': return &Convert<uint16_t>::toB;
-				case 'c': return &Convert<uint16_t>::toC;
-				case 's': return &Convert<uint16_t>::toS;
-				case 'i': return &Convert<uint16_t>::toI;
-				case 'j': return &Convert<uint16_t>::toJ;
-				case 'f': return &Convert<uint16_t>::toF;
-				case 'd': return &Convert<uint16_t>::toD;
-			}
-			return 0;
-		case 'i':
-		case 'l':
-			switch (to[0])
-			{
-				case 'z': return &Convert<int32_t>::toZ;
-				case 'b': return &Convert<int32_t>::toB;
-				case 'c': return &Convert<int32_t>::toC;
-				case 's': return &Convert<int32_t>::toS;
-				case 'i': return &Convert<int32_t>::toI;
-				case 'j': return &Convert<int32_t>::toJ;
-				case 'f': return &Convert<int32_t>::toF;
-				case 'd': return &Convert<int32_t>::toD;
-			}
-			return 0;
-		case 'I':
-		case 'L':
-			switch (to[0])
-			{
-				case 'z': return &Convert<uint32_t>::toZ;
-				case 'b': return &Convert<uint32_t>::toB;
-				case 'c': return &Convert<uint32_t>::toC;
-				case 's': return &Convert<uint32_t>::toS;
-				case 'i': return &Convert<uint32_t>::toI;
-				case 'j': return &Convert<uint32_t>::toJ;
-				case 'f': return &Convert<uint32_t>::toF;
-				case 'd': return &Convert<uint32_t>::toD;
-			}
-			return 0;
-		case 'q':
-			switch (to[0])
-			{
-				case 'z': return &Convert<int64_t>::toZ;
-				case 'b': return &Convert<int64_t>::toB;
-				case 'c': return &Convert<int64_t>::toC;
-				case 's': return &Convert<int64_t>::toS;
-				case 'i': return &Convert<int64_t>::toI;
-				case 'j': return &Convert<int64_t>::toJ;
-				case 'f': return &Convert<int64_t>::toF;
-				case 'd': return &Convert<int64_t>::toD;
-			}
-			return 0;
-		case 'Q':
-			switch (to[0])
-			{
-				case 'z': return &Convert<uint64_t>::toZ;
-				case 'b': return &Convert<uint64_t>::toB;
-				case 'c': return &Convert<uint64_t>::toC;
-				case 's': return &Convert<uint64_t>::toS;
-				case 'i': return &Convert<uint64_t>::toI;
-				case 'j': return &Convert<uint64_t>::toJ;
-				case 'f': return &Convert<uint64_t>::toF;
-				case 'd': return &Convert<uint64_t>::toD;
-			}
-			return 0;
-		case 'f':
-			switch (to[0])
-			{
-				case 'z': return &Convert<float>::toZ;
-				case 'b': return &Convert<float>::toB;
-				case 'c': return &Convert<float>::toC;
-				case 's': return &Convert<float>::toS;
-				case 'i': return &Convert<float>::toI;
-				case 'j': return &Convert<float>::toJ;
-				case 'f': return &Convert<float>::toF;
-				case 'd': return &Convert<float>::toD;
-			}
-			return 0;
-		case 'd':
-			switch (to[0])
-			{
-				case 'z': return &Convert<double>::toZ;
-				case 'b': return &Convert<double>::toB;
-				case 'c': return &Convert<double>::toC;
-				case 's': return &Convert<double>::toS;
-				case 'i': return &Convert<double>::toI;
-				case 'j': return &Convert<double>::toJ;
-				case 'f': return &Convert<double>::toF;
-				case 'd': return &Convert<double>::toD;
-			}
-			return 0;
-		case 'n':
-		case 'N':
-		case 'P':
-		default: return 0;
-	}
+
+jconverter getConverter(const char *from, int itemsize, const char *to) {
+    // "From" codes are documented at https://docs.python.org/3/library/struct.html#format-characters.
+    // "To" codes correspond to the codes under "Type Signatures" in https://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/types.html#wp428
+    // Note that from "l" and "L" codes deviate from the documentation to follow the numpy convention.
+    std::string from_actual;
+    if (from) {
+        from_actual = from;
+    } else {
+        // If not specified then the type is bytes
+        from_actual = "B";
+    }
+
+    char byte_order_code; // One of "@=<>!".
+    char data_type_code;  // One of "cbB?hHiIlLqQfdspP".
+
+    std::string all_byte_order_codes = "@=<>!";
+    if (all_byte_order_codes.find(from_actual[0]) != std::string::npos) {
+        byte_order_code = from_actual[0];
+        data_type_code = from_actual[1];
+    } else {
+        byte_order_code = '@';
+        data_type_code = from_actual[0];
+    }
+
+    std::string unsupported_byte_order_codes = "<>!";
+    if (unsupported_byte_order_codes.find(byte_order_code) != std::string::npos) {
+        // We don't try to implement endian swapping, or figure out the host's endianness.
+        throw std::invalid_argument("Unable convert to specific requested endianness");
+    }
+
+    if (byte_order_code == '@') {
+        // Native size
+        switch (data_type_code) {
+        case '?':
+        case 'c':
+            switch (to[0]) {
+            case 'z': return &Convert<char>::toZ;
+            case 'b': return &Convert<char>::toB;
+            case 'c': return &Convert<char>::toC;
+            case 's': return &Convert<char>::toS;
+            case 'i': return &Convert<char>::toI;
+            case 'j': return &Convert<char>::toJ;
+            case 'f': return &Convert<char>::toF;
+            case 'd': return &Convert<char>::toD;
+            default: break;
+            }
+        case 'b':
+            switch (to[0]) {
+            case 'z': return &Convert<signed char>::toZ;
+            case 'b': return &Convert<signed char>::toB;
+            case 'c': return &Convert<signed char>::toC;
+            case 's': return &Convert<signed char>::toS;
+            case 'i': return &Convert<signed char>::toI;
+            case 'j': return &Convert<signed char>::toJ;
+            case 'f': return &Convert<signed char>::toF;
+            case 'd': return &Convert<signed char>::toD;
+            default: break;
+            }
+        case 'B':
+            switch (to[0]) {
+            case 'z': return &Convert<unsigned char>::toZ;
+            case 'b': return &Convert<unsigned char>::toB;
+            case 'c': return &Convert<unsigned char>::toC;
+            case 's': return &Convert<unsigned char>::toS;
+            case 'i': return &Convert<unsigned char>::toI;
+            case 'j': return &Convert<unsigned char>::toJ;
+            case 'f': return &Convert<unsigned char>::toF;
+            case 'd': return &Convert<unsigned char>::toD;
+            default: break;
+            }
+        case 'h':
+            switch (to[0]) {
+            case 'z': return &Convert<short>::toZ;
+            case 'b': return &Convert<short>::toB;
+            case 'c': return &Convert<short>::toC;
+            case 's': return &Convert<short>::toS;
+            case 'i': return &Convert<short>::toI;
+            case 'j': return &Convert<short>::toJ;
+            case 'f': return &Convert<short>::toF;
+            case 'd': return &Convert<short>::toD;
+            default: break;
+            }
+        case 'H':
+            switch (to[0]) {
+            case 'z': return &Convert<unsigned short>::toZ;
+            case 'b': return &Convert<unsigned short>::toB;
+            case 'c': return &Convert<unsigned short>::toC;
+            case 's': return &Convert<unsigned short>::toS;
+            case 'i': return &Convert<unsigned short>::toI;
+            case 'j': return &Convert<unsigned short>::toJ;
+            case 'f': return &Convert<unsigned short>::toF;
+            case 'd': return &Convert<unsigned short>::toD;
+            default: break;
+            }
+        case 'i':
+            switch (to[0]) {
+            case 'z': return &Convert<int>::toZ;
+            case 'b': return &Convert<int>::toB;
+            case 'c': return &Convert<int>::toC;
+            case 's': return &Convert<int>::toS;
+            case 'i': return &Convert<int>::toI;
+            case 'j': return &Convert<int>::toJ;
+            case 'f': return &Convert<int>::toF;
+            case 'd': return &Convert<int>::toD;
+            default: break;
+            }
+        case 'I':
+            switch (to[0]) {
+            case 'z': return &Convert<unsigned int>::toZ;
+            case 'b': return &Convert<unsigned int>::toB;
+            case 'c': return &Convert<unsigned int>::toC;
+            case 's': return &Convert<unsigned int>::toS;
+            case 'i': return &Convert<unsigned int>::toI;
+            case 'j': return &Convert<unsigned int>::toJ;
+            case 'f': return &Convert<unsigned int>::toF;
+            case 'd': return &Convert<unsigned int>::toD;
+            default: break;
+            }
+        case 'l':
+            switch (to[0]) {
+            case 'z': return &Convert<long>::toZ;
+            case 'b': return &Convert<long>::toB;
+            case 'c': return &Convert<long>::toC;
+            case 's': return &Convert<long>::toS;
+            case 'i': return &Convert<long>::toI;
+            case 'j': return &Convert<long>::toJ;
+            case 'f': return &Convert<long>::toF;
+            case 'd': return &Convert<long>::toD;
+            default: break;
+            }
+        case 'L':
+            switch (to[0]) {
+            case 'z': return &Convert<unsigned long>::toZ;
+            case 'b': return &Convert<unsigned long>::toB;
+            case 'c': return &Convert<unsigned long>::toC;
+            case 's': return &Convert<unsigned long>::toS;
+            case 'i': return &Convert<unsigned long>::toI;
+            case 'j': return &Convert<unsigned long>::toJ;
+            case 'f': return &Convert<unsigned long>::toF;
+            case 'd': return &Convert<unsigned long>::toD;
+            default: break;
+            }
+        case 'q':
+            switch (to[0]) {
+            case 'z': return &Convert<long long>::toZ;
+            case 'b': return &Convert<long long>::toB;
+            case 'c': return &Convert<long long>::toC;
+            case 's': return &Convert<long long>::toS;
+            case 'i': return &Convert<long long>::toI;
+            case 'j': return &Convert<long long>::toJ;
+            case 'f': return &Convert<long long>::toF;
+            case 'd': return &Convert<long long>::toD;
+            default: break;
+            }
+        case 'Q':
+            switch (to[0]) {
+            case 'z': return &Convert<unsigned long long>::toZ;
+            case 'b': return &Convert<unsigned long long>::toB;
+            case 'c': return &Convert<unsigned long long>::toC;
+            case 's': return &Convert<unsigned long long>::toS;
+            case 'i': return &Convert<unsigned long long>::toI;
+            case 'j': return &Convert<unsigned long long>::toJ;
+            case 'f': return &Convert<unsigned long long>::toF;
+            case 'd': return &Convert<unsigned long long>::toD;
+            default: break;
+            }
+        case 'n':
+        case 'N':
+        case 'f':
+            switch (to[0]) {
+            case 'z': return &Convert<float>::toZ;
+            case 'b': return &Convert<float>::toB;
+            case 'c': return &Convert<float>::toC;
+            case 's': return &Convert<float>::toS;
+            case 'i': return &Convert<float>::toI;
+            case 'j': return &Convert<float>::toJ;
+            case 'f': return &Convert<float>::toF;
+            case 'd': return &Convert<float>::toD;
+            default: break;
+            }
+        case 'd':
+            switch (to[0]) {
+            case 'z': return &Convert<double>::toZ;
+            case 'b': return &Convert<double>::toB;
+            case 'c': return &Convert<double>::toC;
+            case 's': return &Convert<double>::toS;
+            case 'i': return &Convert<double>::toI;
+            case 'j': return &Convert<double>::toJ;
+            case 'f': return &Convert<double>::toF;
+            case 'd': return &Convert<double>::toD;
+            default: break;
+            }
+        case 'P':
+        default: break;
+        }
+    } else {
+        // "Standard size" types
+        switch (data_type_code) {
+        case '?':
+        case 'c':
+        case 'b':
+            switch (to[0]) {
+            case 'z': return &Convert<int8_t>::toZ;
+            case 'b': return &Convert<int8_t>::toB;
+            case 'c': return &Convert<int8_t>::toC;
+            case 's': return &Convert<int8_t>::toS;
+            case 'i': return &Convert<int8_t>::toI;
+            case 'j': return &Convert<int8_t>::toJ;
+            case 'f': return &Convert<int8_t>::toF;
+            case 'd': return &Convert<int8_t>::toD;
+            default: break;
+            }
+        case 'B':
+            switch (to[0]) {
+            case 'z': return &Convert<uint8_t>::toZ;
+            case 'b': return &Convert<uint8_t>::toB;
+            case 'c': return &Convert<uint8_t>::toC;
+            case 's': return &Convert<uint8_t>::toS;
+            case 'i': return &Convert<uint8_t>::toI;
+            case 'j': return &Convert<uint8_t>::toJ;
+            case 'f': return &Convert<uint8_t>::toF;
+            case 'd': return &Convert<uint8_t>::toD;
+            default: break;
+            }
+        case 'h':
+            switch (to[0]) {
+            case 'z': return &Convert<int16_t>::toZ;
+            case 'b': return &Convert<int16_t>::toB;
+            case 'c': return &Convert<int16_t>::toC;
+            case 's': return &Convert<int16_t>::toS;
+            case 'i': return &Convert<int16_t>::toI;
+            case 'j': return &Convert<int16_t>::toJ;
+            case 'f': return &Convert<int16_t>::toF;
+            case 'd': return &Convert<int16_t>::toD;
+            default: break;
+            }
+        case 'H':
+            switch (to[0]) {
+            case 'z': return &Convert<uint16_t>::toZ;
+            case 'b': return &Convert<uint16_t>::toB;
+            case 'c': return &Convert<uint16_t>::toC;
+            case 's': return &Convert<uint16_t>::toS;
+            case 'i': return &Convert<uint16_t>::toI;
+            case 'j': return &Convert<uint16_t>::toJ;
+            case 'f': return &Convert<uint16_t>::toF;
+            case 'd': return &Convert<uint16_t>::toD;
+            default: break;
+            }
+        case 'i':
+            switch (to[0]) {
+            case 'z': return &Convert<int32_t>::toZ;
+            case 'b': return &Convert<int32_t>::toB;
+            case 'c': return &Convert<int32_t>::toC;
+            case 's': return &Convert<int32_t>::toS;
+            case 'i': return &Convert<int32_t>::toI;
+            case 'j': return &Convert<int32_t>::toJ;
+            case 'f': return &Convert<int32_t>::toF;
+            case 'd': return &Convert<int32_t>::toD;
+            default: break;
+            }
+        case 'I':
+            switch (to[0]) {
+            case 'z': return &Convert<uint32_t>::toZ;
+            case 'b': return &Convert<uint32_t>::toB;
+            case 'c': return &Convert<uint32_t>::toC;
+            case 's': return &Convert<uint32_t>::toS;
+            case 'i': return &Convert<uint32_t>::toI;
+            case 'j': return &Convert<uint32_t>::toJ;
+            case 'f': return &Convert<uint32_t>::toF;
+            case 'd': return &Convert<uint32_t>::toD;
+            default: break;
+            }
+        case 'l':
+            // Despite the Python standard format documentation, we follow np.dtype('=l').itemsize == 8
+            switch (to[0]) {
+            case 'z': return &Convert<int64_t>::toZ;
+            case 'b': return &Convert<int64_t>::toB;
+            case 'c': return &Convert<int64_t>::toC;
+            case 's': return &Convert<int64_t>::toS;
+            case 'i': return &Convert<int64_t>::toI;
+            case 'j': return &Convert<int64_t>::toJ;
+            case 'f': return &Convert<int64_t>::toF;
+            case 'd': return &Convert<int64_t>::toD;
+            default: break;
+            }
+        case 'L':
+            // Despite the standard format documentation, we follow np.dtype('=L').itemsize == 8
+            switch (to[0]) {
+            case 'z': return &Convert<uint64_t>::toZ;
+            case 'b': return &Convert<uint64_t>::toB;
+            case 'c': return &Convert<uint64_t>::toC;
+            case 's': return &Convert<uint64_t>::toS;
+            case 'i': return &Convert<uint64_t>::toI;
+            case 'j': return &Convert<uint64_t>::toJ;
+            case 'f': return &Convert<uint64_t>::toF;
+            case 'd': return &Convert<uint64_t>::toD;
+            default: break;
+            }
+        case 'q':
+            switch (to[0]) {
+            case 'z': return &Convert<int64_t>::toZ;
+            case 'b': return &Convert<int64_t>::toB;
+            case 'c': return &Convert<int64_t>::toC;
+            case 's': return &Convert<int64_t>::toS;
+            case 'i': return &Convert<int64_t>::toI;
+            case 'j': return &Convert<int64_t>::toJ;
+            case 'f': return &Convert<int64_t>::toF;
+            case 'd': return &Convert<int64_t>::toD;
+            default: break;
+            }
+        case 'Q':
+            switch (to[0]) {
+            case 'z': return &Convert<uint64_t>::toZ;
+            case 'b': return &Convert<uint64_t>::toB;
+            case 'c': return &Convert<uint64_t>::toC;
+            case 's': return &Convert<uint64_t>::toS;
+            case 'i': return &Convert<uint64_t>::toI;
+            case 'j': return &Convert<uint64_t>::toJ;
+            case 'f': return &Convert<uint64_t>::toF;
+            case 'd': return &Convert<uint64_t>::toD;
+            default: break;
+            }
+        case 'f':
+            switch (to[0]) {
+            case 'z': return &Convert<float>::toZ;
+            case 'b': return &Convert<float>::toB;
+            case 'c': return &Convert<float>::toC;
+            case 's': return &Convert<float>::toS;
+            case 'i': return &Convert<float>::toI;
+            case 'j': return &Convert<float>::toJ;
+            case 'f': return &Convert<float>::toF;
+            case 'd': return &Convert<float>::toD;
+            default: break;
+            }
+        case 'd':
+            switch (to[0]) {
+            case 'z': return &Convert<double>::toZ;
+            case 'b': return &Convert<double>::toB;
+            case 'c': return &Convert<double>::toC;
+            case 's': return &Convert<double>::toS;
+            case 'i': return &Convert<double>::toI;
+            case 'j': return &Convert<double>::toJ;
+            case 'f': return &Convert<double>::toF;
+            case 'd': return &Convert<double>::toD;
+            default: break;
+            }
+        case 'n':
+        case 'N':
+        case 'P':
+        default: break;
+        }
+    }
+
+    std::stringstream message;
+    message << "Unable to convert from " << from_actual << " to " << to;
+    throw std::invalid_argument(message.str());
 }

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -289,7 +289,7 @@ void JPDoubleType::getView(JPArrayView& view)
 	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
 	view.m_Memory = (void*) frame.GetDoubleArrayElements(
 			(jdoubleArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "d";
+	view.m_Buffer.format = "=d";
 	view.m_Buffer.itemsize = sizeof (jdouble);
 }
 
@@ -309,7 +309,7 @@ void JPDoubleType::releaseView(JPArrayView& view)
 
 const char* JPDoubleType::getBufferFormat()
 {
-	return "d";
+	return "=d";
 }
 
 Py_ssize_t JPDoubleType::getItemSize()

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -272,7 +272,7 @@ void JPFloatType::getView(JPArrayView& view)
 	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
 	view.m_Memory = (void*) frame.GetFloatArrayElements(
 			(jfloatArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "f";
+	view.m_Buffer.format = "=f";
 	view.m_Buffer.itemsize = sizeof (jfloat);
 }
 
@@ -292,7 +292,7 @@ void JPFloatType::releaseView(JPArrayView& view)
 
 const char* JPFloatType::getBufferFormat()
 {
-	return "f";
+	return "=f";
 }
 
 Py_ssize_t JPFloatType::getItemSize()

--- a/native/common/jp_inttype.cpp
+++ b/native/common/jp_inttype.cpp
@@ -275,7 +275,7 @@ void JPIntType::getView(JPArrayView& view)
 	view.m_IsCopy = false;
 	view.m_Memory = (void*) frame.GetIntArrayElements(
 			(jintArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "i";
+	view.m_Buffer.format = "=i";
 	view.m_Buffer.itemsize = sizeof (jint);
 }
 
@@ -295,12 +295,12 @@ void JPIntType::releaseView(JPArrayView& view)
 
 const char* JPIntType::getBufferFormat()
 {
-	return "i";
+	return "=i";
 }
 
 Py_ssize_t JPIntType::getItemSize()
 {
-	return sizeof (jfloat);
+	return sizeof (jint);
 }
 
 void JPIntType::copyElements(JPJavaFrame &frame, jarray a, jsize start, jsize len,

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -274,7 +274,7 @@ void JPLongType::getView(JPArrayView& view)
 	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
 	view.m_Memory = (void*) frame.GetLongArrayElements(
 			(jlongArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "q";
+	view.m_Buffer.format = "l";
 	view.m_Buffer.itemsize = sizeof (jlong);
 }
 
@@ -294,7 +294,7 @@ void JPLongType::releaseView(JPArrayView& view)
 
 const char* JPLongType::getBufferFormat()
 {
-	return "q";
+	return "l";
 }
 
 Py_ssize_t JPLongType::getItemSize()

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -274,7 +274,7 @@ void JPLongType::getView(JPArrayView& view)
 	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
 	view.m_Memory = (void*) frame.GetLongArrayElements(
 			(jlongArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "l";
+	view.m_Buffer.format = "=q";
 	view.m_Buffer.itemsize = sizeof (jlong);
 }
 
@@ -294,7 +294,7 @@ void JPLongType::releaseView(JPArrayView& view)
 
 const char* JPLongType::getBufferFormat()
 {
-	return "l";
+	return "=q";
 }
 
 Py_ssize_t JPLongType::getItemSize()

--- a/native/jni_include/jni.h
+++ b/native/jni_include/jni.h
@@ -50,19 +50,9 @@ typedef uint8_t  jboolean; /* unsigned 8 bits */
 typedef int8_t   jbyte;    /* signed 8 bits */
 typedef uint16_t jchar;    /* unsigned 16 bits */
 typedef int16_t  jshort;   /* signed 16 bits */
-#if defined(_WIN32)
-    typedef long jint;
-#else
-    typedef int32_t  jint;     /* signed 32 bits */
-#endif
+typedef int32_t  jint;     /* signed 32 bits */
+typedef int64_t  jlong;    /* signed 64 bits */
 
-// define jlong
-#ifdef _LP64 /* 64-bit build */
-    typedef int64_t  jlong;    /* signed 64 bits */
-//    typedef long jlong;
-#else
-    typedef long long jlong;
-#endif
 typedef float    jfloat;   /* 32-bit IEEE 754 */
 typedef double   jdouble;  /* 64-bit IEEE 754 */
 

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -367,6 +367,10 @@ class ArrayTestCase(common.JPypeTestCase):
         self.assertIsInstance(ja, JArray(jtype))
         self.assertEqual(len(ja), 100)
         self.assertTrue(np.all(a == ja))
+        conversion_type = np.array(ja).dtype
+        expected_dtype = np.dtype(dtype)
+        self.assertEqual(conversion_type, expected_dtype)
+        self.assertEqual(conversion_type.type, expected_dtype.type)
 
         a = np.reshape(a, (20, 5))
         ja = JArray.of(a)

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -75,8 +75,7 @@ class BufferTestCase(common.JPypeTestCase):
         data = [1, 2, 3, 4, 5]
         ja = JArray(JInt)(data)
         b = memoryview(ja)  # Create a view
-        with self.assertRaises(TypeError):
-            b[0] = 123  # Alter the memory using the view
+        self.assertTrue(b.readonly)
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testSlice(self):
@@ -162,7 +161,7 @@ class BufferTestCase(common.JPypeTestCase):
     def executeIntTest(self, jtype, limits, size, dtype, code):
         data = np.random.randint(limits[0], limits[1], size=size, dtype=dtype)
         a = JArray(jtype, data.ndim)(data.tolist())
-        u = np.array(a)
+        u = np.array(a, dtype=dtype)
         self.assertTrue(np.all(data == u))
         self.assertEqual(u.dtype, np.dtype(dtype))
         self.assertEqual(u.dtype.type, np.dtype(dtype).type)
@@ -199,19 +198,19 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntToNP1D(self):
-        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (100,), np.int32, "i")
+        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (100,), np.int32, "=i")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP1D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "l")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "=q")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP1D(self):
-        self.executeFloatTest(JFloat, (100,), np.float32, "f")
+        self.executeFloatTest(JFloat, (100,), np.float32, "=f")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testDoubleToNP1D(self):
-        self.executeFloatTest(JDouble, (100,), np.float64, "d")
+        self.executeFloatTest(JDouble, (100,), np.float64, "=d")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBooleanToNP2D(self):
@@ -231,19 +230,19 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntToNP2D(self):
-        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (11, 10), np.int32, "i")
+        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (11, 10), np.int32, "=i")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP2D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "l")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "=q")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP2D(self):
-        self.executeFloatTest(JFloat, (11, 10), np.float32, "f")
+        self.executeFloatTest(JFloat, (11, 10), np.float32, "=f")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testDoubleToNP2D(self):
-        self.executeFloatTest(JDouble, (11, 10), np.float64, "d")
+        self.executeFloatTest(JDouble, (11, 10), np.float64, "=d")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBooleanToNP3D(self):
@@ -265,17 +264,17 @@ class BufferTestCase(common.JPypeTestCase):
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntToNP3D(self):
         self.executeIntTest(JInt, [-2**31, 2**31 - 1],
-                            (11, 10, 9), np.int32, "i")
+                            (11, 10, 9), np.int32, "=i")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP3D(self):
         self.executeIntTest(JLong, [-2**63, 2**63 - 1],
-                            (11, 10, 9), np.int64, "l")
+                            (11, 10, 9), np.int64, "=q")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP3D(self):
-        self.executeFloatTest(JFloat, (11, 10, 9), np.float32, "f")
+        self.executeFloatTest(JFloat, (11, 10, 9), np.float32, "=f")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testDoubleToNP3D(self):
-        self.executeFloatTest(JDouble, (11, 10, 9), np.float64, "d")
+        self.executeFloatTest(JDouble, (11, 10, 9), np.float64, "=d")

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -161,7 +161,7 @@ class BufferTestCase(common.JPypeTestCase):
     def executeIntTest(self, jtype, limits, size, dtype, code):
         data = np.random.randint(limits[0], limits[1], size=size, dtype=dtype)
         a = JArray(jtype, data.ndim)(data.tolist())
-        u = np.array(a, dtype=dtype)
+        u = np.array(a)
         self.assertTrue(np.all(data == u))
         self.assertEqual(u.dtype, np.dtype(dtype))
         self.assertEqual(u.dtype.type, np.dtype(dtype).type)

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -164,6 +164,8 @@ class BufferTestCase(common.JPypeTestCase):
         a = JArray(jtype, data.ndim)(data.tolist())
         u = np.array(a)
         self.assertTrue(np.all(data == u))
+        self.assertEqual(u.dtype, np.dtype(dtype))
+        self.assertEqual(u.dtype.type, np.dtype(dtype).type)
         mv = memoryview(a)
         self.assertEqual(mv.format, code)
         self.assertEqual(mv.shape, data.shape)
@@ -201,7 +203,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP1D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "q")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "l")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP1D(self):
@@ -233,7 +235,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP2D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "q")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "l")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP2D(self):
@@ -268,7 +270,7 @@ class BufferTestCase(common.JPypeTestCase):
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP3D(self):
         self.executeIntTest(JLong, [-2**63, 2**63 - 1],
-                            (11, 10, 9), np.int64, "q")
+                            (11, 10, 9), np.int64, "l")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP3D(self):


### PR DESCRIPTION
The docs on this are https://docs.python.org/3/c-api/buffer.html#c.Py_buffer.format and https://docs.python.org/3/library/struct.html#format-characters.

Current behaviour claims that the format is "long long", which as I understand on some platforms differs to int64 (I didn't verify this). Even so, before this change:

```python
>>> np.array(jp.JArray(jp.JLong)([1, 2])).dtype.type
<class 'numpy.longlong'>
```

Whereas numpy does:

```python
>>> np.array([1, 2], dtype=np.long).dtype.type
<class 'numpy.int64'>
```