### PR TITLE
Fix the azure pipeline to use a non-deprecated Windows version

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -63,18 +63,20 @@ jobs:
         imageName: "ubuntu-latest"
         python.version: '3.9'
       windows-3.6:
-        imageName: "vs2017-win2016"
+        imageName: "windows-2019"
         python.version: '3.6'
       windows-3.7:
-        imageName: "vs2017-win2016"
+        imageName: "windows-2019"
         python.version: '3.7'
       windows-3.8:
-        imageName: "vs2017-win2016"
+        imageName: "windows-2019"
         python.version: '3.8'
-        #windows-3.9:
-        #imageName: "vs2017-win2016"
-        #python.version: '3.9'
-        #jpypetest.fast: 'true'
+      windows-3.9:
+        imageName: "windows-2019"
+        python.version: '3.9'
+      windows-3.10:
+        imageName: "windows-2019"
+        python.version: '3.10'
       mac-3.9:
         imageName: "macos-11"
         python.version: '3.9'

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -387,7 +387,7 @@ class ArrayTestCase(common.JPypeTestCase):
         self.assertTrue(np.all(a[:, :, 4:-2] == JArray.of(a[:, :, 4:-2])))
 
     def checkArrayOfCast(self, jtype, dtype):
-        a = np.random.randint(0, 1, size=100, dtype=np.bool)
+        a = np.random.randint(0, 1, size=100, dtype=bool)
         ja = JArray.of(a, dtype=jtype)
         self.assertIsInstance(ja, JArray(jtype))
         self.assertTrue(np.all(a.astype(dtype) == ja))
@@ -434,7 +434,7 @@ class ArrayTestCase(common.JPypeTestCase):
 
     @common.requireNumpy
     def testArrayOfBoolean(self):
-        self.checkArrayOf(JBoolean, np.bool, 0, 1)
+        self.checkArrayOf(JBoolean, bool, 0, 1)
 
     @common.requireNumpy
     def testArrayOfByte(self):
@@ -462,7 +462,7 @@ class ArrayTestCase(common.JPypeTestCase):
 
     @common.requireNumpy
     def testArrayOfBooleanCast(self):
-        self.checkArrayOfCast(JBoolean, np.bool)
+        self.checkArrayOfCast(JBoolean, bool)
 
     @common.requireNumpy
     def testArrayOfByteCast(self):

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -144,9 +144,10 @@ class BufferTestCase(common.JPypeTestCase):
         )
 
         na = np.random.randint(0, 2**64 - 1, size=n, dtype=np.uint64)
-        np.testing.assert_array_equal(
+        np.testing.assert_array_almost_equal(
             np.array(jtype(na), dtype=dtype),
             np.array(na, dtype=dtype),
+            decimal=6,
         )
 
         na = np.random.random(n).astype(np.float32)

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -15,16 +15,13 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
-import jpype
-import sys
-import logging
-import time
 import common
 from jpype.types import *
 
 
 try:
     import numpy as np
+    import numpy.testing
     gotNP = True
 except ImportError:
     gotNP = False
@@ -96,40 +93,73 @@ class BufferTestCase(common.JPypeTestCase):
                         bytes(np.array(data[::-2], dtype=np.int32)))
 
     def executeConvert(self, jtype, dtype):
+
         n = 100
-        na = np.random.randint(0, 1, size=n).astype(np.bool)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        na = np.random.randint(0, 1, size=n).astype(bool)
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(-2**7, 2**7 - 1, size=n, dtype=np.int8)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(0, 2**8 - 1, size=n, dtype=np.uint8)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(-2**15, 2**15 - 1, size=n, dtype=np.int16)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(0, 2**16 - 1, size=n, dtype=np.uint16)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(-2**31, 2**31 - 1, size=n, dtype=np.int32)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(0, 2**32 - 1, size=n, dtype=np.uint32)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(-2**63, 2**63 - 1, size=n, dtype=np.int64)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.randint(0, 2**64 - 1, size=n, dtype=np.uint64)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.random(n).astype(np.float32)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
+
         na = np.random.random(n).astype(np.float64)
-        self.assertTrue(np.all(np.array(jtype(na), dtype=dtype)
-                               == np.array(na, dtype=dtype)))
+        np.testing.assert_array_equal(
+            np.array(jtype(na), dtype=dtype),
+            np.array(na, dtype=dtype),
+        )
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBoolConvert(self):

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -163,7 +163,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBoolConvert(self):
-        self.executeConvert(JArray(JBoolean), np.bool)
+        self.executeConvert(JArray(JBoolean), bool)
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testByteConvert(self):
@@ -211,7 +211,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBooleanToNP1D(self):
-        self.executeIntTest(JBoolean, [0, 1], (100,), np.bool, "?")
+        self.executeIntTest(JBoolean, [0, 1], (100,), bool, "?")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testCharToNP1D(self):
@@ -243,7 +243,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBooleanToNP2D(self):
-        self.executeIntTest(JBoolean, [0, 1], (11, 10), np.bool, "?")
+        self.executeIntTest(JBoolean, [0, 1], (11, 10), bool, "?")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testCharToNP2D(self):
@@ -275,7 +275,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testBooleanToNP3D(self):
-        self.executeIntTest(JBoolean, [0, 1], (11, 10, 9), np.bool, "?")
+        self.executeIntTest(JBoolean, [0, 1], (11, 10, 9), bool, "?")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testCharToNP3D(self):

--- a/test/jpypetest/test_conversionInt.py
+++ b/test/jpypetest/test_conversionInt.py
@@ -22,13 +22,10 @@ import logging
 import time
 import common
 
-
-def haveNumpy():
-    try:
-        import numpy
-        return True
-    except ImportError:
-        return False
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 
 class ConversionIntTestCase(common.JPypeTestCase):
@@ -39,32 +36,23 @@ class ConversionIntTestCase(common.JPypeTestCase):
     def testIntFromInt(self):
         self.assertEqual(self.Test.callInt(int(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testIntFromNPInt(self):
-        import numpy as np
-        self.assertEqual(self.Test.callInt(np.int(123)), 123)
-
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testIntFromNPInt8(self):
-        import numpy as np
         self.assertEqual(self.Test.callInt(np.int8(123)), 123)
         self.assertEqual(self.Test.callInt(np.uint8(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testIntFromNPInt16(self):
-        import numpy as np
         self.assertEqual(self.Test.callInt(np.int16(123)), 123)
         self.assertEqual(self.Test.callInt(np.uint16(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testIntFromNPInt32(self):
-        import numpy as np
         self.assertEqual(self.Test.callInt(np.int32(123)), 123)
         self.assertEqual(self.Test.callInt(np.uint32(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testIntFromNPInt64(self):
-        import numpy as np
         self.assertEqual(self.Test.callInt(np.int64(123)), 123)
         self.assertEqual(self.Test.callInt(np.uint64(123)), 123)
 
@@ -72,21 +60,13 @@ class ConversionIntTestCase(common.JPypeTestCase):
         with self.assertRaises(TypeError):
             self.Test.callInt(float(2))
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testIntFromNPFloat(self):
-        import numpy as np
-        with self.assertRaises(TypeError):
-            self.Test.callInt(np.float(2))
-
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testIntFromNPFloat32(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callInt(np.float32(2))
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testIntFromNPFloat64(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callInt(np.float64(2))
 

--- a/test/jpypetest/test_conversionLong.py
+++ b/test/jpypetest/test_conversionLong.py
@@ -23,12 +23,10 @@ import time
 import common
 
 
-def haveNumpy():
-    try:
-        import numpy
-        return True
-    except ImportError:
-        return False
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 
 class ConversionLongTestCase(common.JPypeTestCase):
@@ -39,32 +37,23 @@ class ConversionLongTestCase(common.JPypeTestCase):
     def testLongFromInt(self):
         self.assertEqual(self.Test.callLong(int(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testLongFromNPInt(self):
-        import numpy as np
-        self.assertEqual(self.Test.callLong(np.int(123)), 123)
-
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testLongFromNPInt8(self):
-        import numpy as np
         self.assertEqual(self.Test.callLong(np.int8(123)), 123)
         self.assertEqual(self.Test.callLong(np.uint8(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testLongFromNPInt16(self):
-        import numpy as np
         self.assertEqual(self.Test.callLong(np.int16(123)), 123)
         self.assertEqual(self.Test.callLong(np.uint16(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testLongFromNPInt32(self):
-        import numpy as np
         self.assertEqual(self.Test.callLong(np.int32(123)), 123)
         self.assertEqual(self.Test.callLong(np.uint32(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testLongFromNPInt64(self):
-        import numpy as np
         self.assertEqual(self.Test.callLong(np.int64(123)), 123)
         self.assertEqual(self.Test.callLong(np.uint64(123)), 123)
 
@@ -72,21 +61,13 @@ class ConversionLongTestCase(common.JPypeTestCase):
         with self.assertRaises(TypeError):
             self.Test.callLong(float(2))
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testLongFromNPFloat(self):
-        import numpy as np
-        with self.assertRaises(TypeError):
-            self.Test.callLong(np.float(2))
-
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testLongFromNPFloat32(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callLong(np.float32(2))
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testLongFromNPFloat64(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callLong(np.float64(2))
 

--- a/test/jpypetest/test_conversionShort.py
+++ b/test/jpypetest/test_conversionShort.py
@@ -23,12 +23,10 @@ import time
 import common
 
 
-def haveNumpy():
-    try:
-        import numpy
-        return True
-    except ImportError:
-        return False
+try:
+    import numpy as np
+except ImportError:
+    pass
 
 
 class ConversionShortTestCase(common.JPypeTestCase):
@@ -39,32 +37,23 @@ class ConversionShortTestCase(common.JPypeTestCase):
     def testShortFromInt(self):
         self.assertEqual(self.Test.callShort(int(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testShortFromNPInt(self):
-        import numpy as np
-        self.assertEqual(self.Test.callShort(np.int(123)), 123)
-
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testShortFromNPInt8(self):
-        import numpy as np
         self.assertEqual(self.Test.callShort(np.int8(123)), 123)
         self.assertEqual(self.Test.callShort(np.uint8(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testShortFromNPInt16(self):
-        import numpy as np
         self.assertEqual(self.Test.callShort(np.int16(123)), 123)
         self.assertEqual(self.Test.callShort(np.uint16(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testShortFromNPInt32(self):
-        import numpy as np
         self.assertEqual(self.Test.callShort(np.int32(123)), 123)
         self.assertEqual(self.Test.callShort(np.uint32(123)), 123)
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testShortFromNPInt64(self):
-        import numpy as np
         self.assertEqual(self.Test.callShort(np.int64(123)), 123)
         self.assertEqual(self.Test.callShort(np.uint64(123)), 123)
 
@@ -72,21 +61,13 @@ class ConversionShortTestCase(common.JPypeTestCase):
         with self.assertRaises(TypeError):
             self.Test.callShort(float(2))
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testShortFromNPFloat(self):
-        import numpy as np
-        with self.assertRaises(TypeError):
-            self.Test.callShort(np.float(2))
-
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testShortFromNPFloat32(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callShort(np.float32(2))
 
-    @common.unittest.skipUnless(haveNumpy(), "numpy not available")
+    @common.requireNumpy
     def testShortFromNPFloat64(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callShort(np.float64(2))
 

--- a/test/jpypetest/test_jboolean.py
+++ b/test/jpypetest/test_jboolean.py
@@ -67,31 +67,22 @@ class JBooleanTestCase(common.JPypeTestCase):
         self.assertEqual(self.Test.callBoolean(int(0)), False)
 
     @common.requireNumpy
-    def testBooleanFromNPInt(self):
-        import numpy as np
-        self.assertEqual(self.Test.callBoolean(np.int(123)), True)
-
-    @common.requireNumpy
     def testBooleanFromNPInt8(self):
-        import numpy as np
         self.assertEqual(self.Test.callBoolean(np.int8(123)), True)
         self.assertEqual(self.Test.callBoolean(np.uint8(123)), True)
 
     @common.requireNumpy
     def testBooleanFromNPInt16(self):
-        import numpy as np
         self.assertEqual(self.Test.callBoolean(np.int16(123)), True)
         self.assertEqual(self.Test.callBoolean(np.uint16(123)), True)
 
     @common.requireNumpy
     def testBooleanFromNPInt32(self):
-        import numpy as np
         self.assertEqual(self.Test.callBoolean(np.int32(123)), True)
         self.assertEqual(self.Test.callBoolean(np.uint32(123)), True)
 
     @common.requireNumpy
     def testBooleanFromNPInt64(self):
-        import numpy as np
         self.assertEqual(self.Test.callBoolean(np.int64(123)), True)
         self.assertEqual(self.Test.callBoolean(np.uint64(123)), True)
 
@@ -100,20 +91,12 @@ class JBooleanTestCase(common.JPypeTestCase):
             self.Test.callBoolean(float(2))
 
     @common.requireNumpy
-    def testBooleanFromNPFloat(self):
-        import numpy as np
-        with self.assertRaises(TypeError):
-            self.Test.callBoolean(np.float(2))
-
-    @common.requireNumpy
     def testBooleanFromNPFloat32(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callBoolean(np.float32(2))
 
     @common.requireNumpy
     def testBooleanFromNPFloat64(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.Test.callBoolean(np.float64(2))
 
@@ -128,9 +111,8 @@ class JBooleanTestCase(common.JPypeTestCase):
 
     @common.requireNumpy
     def testSetFromNPBoolArray(self):
-        import numpy as np
         n = 100
-        a = np.random.randint(0, 1, size=n, dtype=np.bool)
+        a = np.random.randint(0, 1, size=n, dtype=bool)
         jarr = jpype.JArray(jpype.JBoolean)(n)
         jarr[:] = a
         self.assertCountEqual(a, jarr)

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -75,31 +75,22 @@ class JByteTestCase(common.JPypeTestCase):
         self.assertEqual(self.fixture.callByte(int(123)), 123)
 
     @common.requireNumpy
-    def testByteFromNPInt(self):
-        import numpy as np
-        self.assertEqual(self.fixture.callByte(np.int(123)), 123)
-
-    @common.requireNumpy
     def testByteFromNPInt8(self):
-        import numpy as np
         self.assertEqual(self.fixture.callByte(np.int8(123)), 123)
         self.assertEqual(self.fixture.callByte(np.uint8(123)), 123)
 
     @common.requireNumpy
     def testByteFromNPInt16(self):
-        import numpy as np
         self.assertEqual(self.fixture.callByte(np.int16(123)), 123)
         self.assertEqual(self.fixture.callByte(np.uint16(123)), 123)
 
     @common.requireNumpy
     def testByteFromNPInt32(self):
-        import numpy as np
         self.assertEqual(self.fixture.callByte(np.int32(123)), 123)
         self.assertEqual(self.fixture.callByte(np.uint32(123)), 123)
 
     @common.requireNumpy
     def testByteFromNPInt64(self):
-        import numpy as np
         self.assertEqual(self.fixture.callByte(np.int64(123)), 123)
         self.assertEqual(self.fixture.callByte(np.uint64(123)), 123)
 
@@ -108,20 +99,12 @@ class JByteTestCase(common.JPypeTestCase):
             self.fixture.callByte(float(2))
 
     @common.requireNumpy
-    def testByteFromNPFloat(self):
-        import numpy as np
-        with self.assertRaises(TypeError):
-            self.fixture.callByte(np.float(2))
-
-    @common.requireNumpy
     def testByteFromNPFloat32(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.fixture.callByte(np.float32(2))
 
     @common.requireNumpy
     def testByteFromNPFloat64(self):
-        import numpy as np
         with self.assertRaises(TypeError):
             self.fixture.callByte(np.float64(2))
 

--- a/test/jpypetest/test_jdouble.py
+++ b/test/jpypetest/test_jdouble.py
@@ -374,8 +374,8 @@ class JDoubleTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(a, jarr)
 
     @common.requireNumpy
-    def testArrayInitFromNPFloat(self):
-        a = np.random.random(100).astype(np.float)
+    def testArrayInitFromFloat(self):
+        a = np.random.random(100).astype(float)
         jarr = JArray(JDouble)(a)
         self.assertElementsAlmostEqual(a, jarr)
 

--- a/test/jpypetest/test_jfloat.py
+++ b/test/jpypetest/test_jfloat.py
@@ -382,8 +382,8 @@ class JFloatTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(a, jarr)
 
     @common.requireNumpy
-    def testArrayInitFromNPFloat(self):
-        a = np.random.random(100).astype(np.float)
+    def testArrayInitFromFloat(self):
+        a = np.random.random(100).astype(float)
         jarr = JArray(JFloat)(a)
         self.assertElementsAlmostEqual(a, jarr)
 

--- a/test/jpypetest/test_jint.py
+++ b/test/jpypetest/test_jint.py
@@ -356,8 +356,8 @@ class JIntTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(expected, result)
 
     @common.requireNumpy
-    def testArrayInitFromNPInt(self):
-        a = np.random.randint(-2**31, 2**31 - 1, size=100, dtype=np.int)
+    def testArrayInitFromInt(self):
+        a = np.random.randint(-2**31, 2**31 - 1, size=100, dtype=int)
         self.checkArrayType(a, a)
 
     @common.requireNumpy

--- a/test/jpypetest/test_jlong.py
+++ b/test/jpypetest/test_jlong.py
@@ -356,8 +356,8 @@ class JLongTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(expected, result)
 
     @common.requireNumpy
-    def testArrayInitFromNPInt(self):
-        a = np.random.randint(-2**31, 2**31 - 1, size=100, dtype=np.int)
+    def testArrayInitFromInt(self):
+        a = np.random.randint(-2**31, 2**31 - 1, size=100, dtype=int)
         self.checkArrayType(a, a)
 
     @common.requireNumpy

--- a/test/jpypetest/test_jshort.py
+++ b/test/jpypetest/test_jshort.py
@@ -346,8 +346,8 @@ class JShortTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(expected, result)
 
     @common.requireNumpy
-    def testArrayInitFromNPInt(self):
-        a = np.random.randint(-2**31, 2**31 - 1, size=100, dtype=np.int)
+    def testArrayInitFromInt(self):
+        a = np.random.randint(-2**31, 2**31 - 1, size=100, dtype=int)
         self.checkArrayType(a, a.astype(np.int16))
 
     @common.requireNumpy


### PR DESCRIPTION
I'm currently seeing failures in #1039 due to a brownout of the win2016 azure image. This updates the pipeline to use windows 2019 (which requires updating the visual studio version).

See also https://github.com/actions/virtual-environments/issues/4312

I noticed that there is a possibility to test against x64 and x86, but wasn't sure how to enable this. Something that may be interesting for a future MR.