### PR TITLE
Support for order conversion on Arrays

### DIFF
--- a/native/common/jp_convert.cpp
+++ b/native/common/jp_convert.cpp
@@ -386,10 +386,55 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 			}
 			break;
 		case 'n':
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<Py_ssize_t>::toZ>::call8;
+				case 'b': return &Reverse<Convert<Py_ssize_t>::toB>::call8;
+				case 'c': return &Reverse<Convert<Py_ssize_t>::toC>::call8;
+				case 's': return &Reverse<Convert<Py_ssize_t>::toS>::call8;
+				case 'i': return &Reverse<Convert<Py_ssize_t>::toI>::call8;
+				case 'j': return &Reverse<Convert<Py_ssize_t>::toJ>::call8;
+				case 'f': return &Reverse<Convert<Py_ssize_t>::toF>::call8;
+				case 'd': return &Reverse<Convert<Py_ssize_t>::toD>::call8;
+			}
+			else switch (to[0])
+			{
+				case 'z': return &Convert<Py_ssize_t>::toZ;
+				case 'b': return &Convert<Py_ssize_t>::toB;
+				case 'c': return &Convert<Py_ssize_t>::toC;
+				case 's': return &Convert<Py_ssize_t>::toS;
+				case 'i': return &Convert<Py_ssize_t>::toI;
+				case 'j': return &Convert<Py_ssize_t>::toJ;
+				case 'f': return &Convert<Py_ssize_t>::toF;
+				case 'd': return &Convert<Py_ssize_t>::toD;
+			}
+			break;
 		case 'N':
-		case 'P':
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<size_t>::toZ>::call8;
+				case 'b': return &Reverse<Convert<size_t>::toB>::call8;
+				case 'c': return &Reverse<Convert<size_t>::toC>::call8;
+				case 's': return &Reverse<Convert<size_t>::toS>::call8;
+				case 'i': return &Reverse<Convert<size_t>::toI>::call8;
+				case 'j': return &Reverse<Convert<size_t>::toJ>::call8;
+				case 'f': return &Reverse<Convert<size_t>::toF>::call8;
+				case 'd': return &Reverse<Convert<size_t>::toD>::call8;
+			}
+			else switch (to[0])
+			{
+				case 'z': return &Convert<size_t>::toZ;
+				case 'b': return &Convert<size_t>::toB;
+				case 'c': return &Convert<size_t>::toC;
+				case 's': return &Convert<size_t>::toS;
+				case 'i': return &Convert<size_t>::toI;
+				case 'j': return &Convert<size_t>::toJ;
+				case 'f': return &Convert<size_t>::toF;
+				case 'd': return &Convert<size_t>::toD;
+			}
+			break;
 		default: break;
 	}
-	PyErr_Format(PyExc_TypeError, "Unable to handle buffer type '%s'", from);
+	PyErr_Format(PyExc_ValueError, "Unable to handle buffer type '%s'", from);
 	JP_RAISE_PYTHON();
 }

--- a/native/common/jp_convert.cpp
+++ b/native/common/jp_convert.cpp
@@ -80,6 +80,49 @@ public:
 	}
 
 } ;
+
+template <jvalue func(void *c) >
+class Reverse
+{
+public:
+
+	static jvalue call2(void* c)
+	{
+		char r[2];
+		char* c2 = (char*)c;
+		r[0]=c2[1];
+		r[1]=c2[0];
+		return func(r);
+	}
+
+	static jvalue call4(void* c)
+	{
+		char r[4];
+		char* c2 = (char*)c;
+		r[0]=c2[3];
+		r[1]=c2[2];
+		r[2]=c2[1];
+		r[3]=c2[0];
+		return func(r);
+	}
+
+	static jvalue call8(void* c)
+	{
+		char r[8];
+		char* c2 = (char*)c;
+		r[0]=c2[7];
+		r[1]=c2[6];
+		r[2]=c2[5];
+		r[3]=c2[4];
+		r[4]=c2[3];
+		r[5]=c2[2];
+		r[6]=c2[1];
+		r[7]=c2[0];
+		return func(r);
+	}
+} ;
+
+
 } // namespace
 
 jconverter getConverter(const char* from, int itemsize, const char* to)
@@ -87,11 +130,37 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 	// If not specified then the type is bytes
 	if (from == NULL)
 		from = "B";
+
+	// Skip specifiers
+	bool reverse = false;
+	unsigned int x = 1;
+	bool little = *((char*)&x)==1;
+	switch (from[0])
+	{
+		case '!':
+		case '>':
+			if (little)
+				reverse = true;
+			from++;
+			break;
+		case '<':
+			if (!little)
+				reverse = true;
+			from++;
+			break;
+		case '@':
+		case '=':
+			from++;
+		default:
+			break;
+	}
+
 	// Standard size for 'l' is 4 in docs, but numpy uses format 'l' for long long
 	if (itemsize == 8 && from[0] == 'l')
 		from = "q";
 	if (itemsize == 8 && from[0] == 'L')
 		from = "Q";
+
 	switch (from[0])
 	{
 		case '?':
@@ -108,7 +177,7 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<int8_t>::toF;
 				case 'd': return &Convert<int8_t>::toD;
 			}
-			return 0;
+			break;
 		case 'B':
 			switch (to[0])
 			{
@@ -121,9 +190,20 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<uint8_t>::toF;
 				case 'd': return &Convert<uint8_t>::toD;
 			}
-			return 0;
+			break;
 		case 'h':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<int16_t>::toZ>::call2;
+				case 'b': return &Reverse<Convert<int16_t>::toB>::call2;
+				case 'c': return &Reverse<Convert<int16_t>::toC>::call2;
+				case 's': return &Reverse<Convert<int16_t>::toS>::call2;
+				case 'i': return &Reverse<Convert<int16_t>::toI>::call2;
+				case 'j': return &Reverse<Convert<int16_t>::toJ>::call2;
+				case 'f': return &Reverse<Convert<int16_t>::toF>::call2;
+				case 'd': return &Reverse<Convert<int16_t>::toD>::call2;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<int16_t>::toZ;
 				case 'b': return &Convert<int16_t>::toB;
@@ -134,9 +214,20 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<int16_t>::toF;
 				case 'd': return &Convert<int16_t>::toD;
 			}
-			return 0;
+			break;
 		case 'H':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<uint16_t>::toZ>::call2;
+				case 'b': return &Reverse<Convert<uint16_t>::toB>::call2;
+				case 'c': return &Reverse<Convert<uint16_t>::toC>::call2;
+				case 's': return &Reverse<Convert<uint16_t>::toS>::call2;
+				case 'i': return &Reverse<Convert<uint16_t>::toI>::call2;
+				case 'j': return &Reverse<Convert<uint16_t>::toJ>::call2;
+				case 'f': return &Reverse<Convert<uint16_t>::toF>::call2;
+				case 'd': return &Reverse<Convert<uint16_t>::toD>::call2;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<uint16_t>::toZ;
 				case 'b': return &Convert<uint16_t>::toB;
@@ -147,10 +238,21 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<uint16_t>::toF;
 				case 'd': return &Convert<uint16_t>::toD;
 			}
-			return 0;
+			break;
 		case 'i':
 		case 'l':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<int32_t>::toZ>::call4;
+				case 'b': return &Reverse<Convert<int32_t>::toB>::call4;
+				case 'c': return &Reverse<Convert<int32_t>::toC>::call4;
+				case 's': return &Reverse<Convert<int32_t>::toS>::call4;
+				case 'i': return &Reverse<Convert<int32_t>::toI>::call4;
+				case 'j': return &Reverse<Convert<int32_t>::toJ>::call4;
+				case 'f': return &Reverse<Convert<int32_t>::toF>::call4;
+				case 'd': return &Reverse<Convert<int32_t>::toD>::call4;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<int32_t>::toZ;
 				case 'b': return &Convert<int32_t>::toB;
@@ -161,10 +263,21 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<int32_t>::toF;
 				case 'd': return &Convert<int32_t>::toD;
 			}
-			return 0;
+			break;
 		case 'I':
 		case 'L':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<uint32_t>::toZ>::call4;
+				case 'b': return &Reverse<Convert<uint32_t>::toB>::call4;
+				case 'c': return &Reverse<Convert<uint32_t>::toC>::call4;
+				case 's': return &Reverse<Convert<uint32_t>::toS>::call4;
+				case 'i': return &Reverse<Convert<uint32_t>::toI>::call4;
+				case 'j': return &Reverse<Convert<uint32_t>::toJ>::call4;
+				case 'f': return &Reverse<Convert<uint32_t>::toF>::call4;
+				case 'd': return &Reverse<Convert<uint32_t>::toD>::call4;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<uint32_t>::toZ;
 				case 'b': return &Convert<uint32_t>::toB;
@@ -175,9 +288,20 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<uint32_t>::toF;
 				case 'd': return &Convert<uint32_t>::toD;
 			}
-			return 0;
+			break;
 		case 'q':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<int64_t>::toZ>::call8;
+				case 'b': return &Reverse<Convert<int64_t>::toB>::call8;
+				case 'c': return &Reverse<Convert<int64_t>::toC>::call8;
+				case 's': return &Reverse<Convert<int64_t>::toS>::call8;
+				case 'i': return &Reverse<Convert<int64_t>::toI>::call8;
+				case 'j': return &Reverse<Convert<int64_t>::toJ>::call8;
+				case 'f': return &Reverse<Convert<int64_t>::toF>::call8;
+				case 'd': return &Reverse<Convert<int64_t>::toD>::call8;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<int64_t>::toZ;
 				case 'b': return &Convert<int64_t>::toB;
@@ -188,9 +312,20 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<int64_t>::toF;
 				case 'd': return &Convert<int64_t>::toD;
 			}
-			return 0;
+			break;
 		case 'Q':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<uint64_t>::toZ>::call8;
+				case 'b': return &Reverse<Convert<uint64_t>::toB>::call8;
+				case 'c': return &Reverse<Convert<uint64_t>::toC>::call8;
+				case 's': return &Reverse<Convert<uint64_t>::toS>::call8;
+				case 'i': return &Reverse<Convert<uint64_t>::toI>::call8;
+				case 'j': return &Reverse<Convert<uint64_t>::toJ>::call8;
+				case 'f': return &Reverse<Convert<uint64_t>::toF>::call8;
+				case 'd': return &Reverse<Convert<uint64_t>::toD>::call8;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<uint64_t>::toZ;
 				case 'b': return &Convert<uint64_t>::toB;
@@ -201,9 +336,20 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<uint64_t>::toF;
 				case 'd': return &Convert<uint64_t>::toD;
 			}
-			return 0;
+			break;
 		case 'f':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<float>::toZ>::call4;
+				case 'b': return &Reverse<Convert<float>::toB>::call4;
+				case 'c': return &Reverse<Convert<float>::toC>::call4;
+				case 's': return &Reverse<Convert<float>::toS>::call4;
+				case 'i': return &Reverse<Convert<float>::toI>::call4;
+				case 'j': return &Reverse<Convert<float>::toJ>::call4;
+				case 'f': return &Reverse<Convert<float>::toF>::call4;
+				case 'd': return &Reverse<Convert<float>::toD>::call4;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<float>::toZ;
 				case 'b': return &Convert<float>::toB;
@@ -214,9 +360,20 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<float>::toF;
 				case 'd': return &Convert<float>::toD;
 			}
-			return 0;
+			break;
 		case 'd':
-			switch (to[0])
+			if (reverse) switch (to[0])
+			{
+				case 'z': return &Reverse<Convert<double>::toZ>::call8;
+				case 'b': return &Reverse<Convert<double>::toB>::call8;
+				case 'c': return &Reverse<Convert<double>::toC>::call8;
+				case 's': return &Reverse<Convert<double>::toS>::call8;
+				case 'i': return &Reverse<Convert<double>::toI>::call8;
+				case 'j': return &Reverse<Convert<double>::toJ>::call8;
+				case 'f': return &Reverse<Convert<double>::toF>::call8;
+				case 'd': return &Reverse<Convert<double>::toD>::call8;
+			}
+			else switch (to[0])
 			{
 				case 'z': return &Convert<double>::toZ;
 				case 'b': return &Convert<double>::toB;
@@ -227,10 +384,12 @@ jconverter getConverter(const char* from, int itemsize, const char* to)
 				case 'f': return &Convert<double>::toF;
 				case 'd': return &Convert<double>::toD;
 			}
-			return 0;
+			break;
 		case 'n':
 		case 'N':
 		case 'P':
-		default: return 0;
+		default: break;
 	}
+	PyErr_Format(PyExc_TypeError, "Unable to handle buffer type '%s'", from);
+	JP_RAISE_PYTHON();
 }

--- a/native/common/jp_inttype.cpp
+++ b/native/common/jp_inttype.cpp
@@ -275,7 +275,7 @@ void JPIntType::getView(JPArrayView& view)
 	view.m_IsCopy = false;
 	view.m_Memory = (void*) frame.GetIntArrayElements(
 			(jintArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "i";
+	view.m_Buffer.format = "=i";
 	view.m_Buffer.itemsize = sizeof (jint);
 }
 
@@ -295,7 +295,7 @@ void JPIntType::releaseView(JPArrayView& view)
 
 const char* JPIntType::getBufferFormat()
 {
-	return "i";
+	return "=i";
 }
 
 Py_ssize_t JPIntType::getItemSize()

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -274,7 +274,7 @@ void JPLongType::getView(JPArrayView& view)
 	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
 	view.m_Memory = (void*) frame.GetLongArrayElements(
 			(jlongArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "q";
+	view.m_Buffer.format = "l";
 	view.m_Buffer.itemsize = sizeof (jlong);
 }
 
@@ -294,7 +294,7 @@ void JPLongType::releaseView(JPArrayView& view)
 
 const char* JPLongType::getBufferFormat()
 {
-	return "q";
+	return "l";
 }
 
 Py_ssize_t JPLongType::getItemSize()

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -274,7 +274,7 @@ void JPLongType::getView(JPArrayView& view)
 	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
 	view.m_Memory = (void*) frame.GetLongArrayElements(
 			(jlongArray) view.m_Array->getJava(), &view.m_IsCopy);
-	view.m_Buffer.format = "l";
+	view.m_Buffer.format = "=q";
 	view.m_Buffer.itemsize = sizeof (jlong);
 }
 
@@ -294,7 +294,7 @@ void JPLongType::releaseView(JPArrayView& view)
 
 const char* JPLongType::getBufferFormat()
 {
-	return "l";
+	return "=q";
 }
 
 Py_ssize_t JPLongType::getItemSize()

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -244,7 +244,7 @@ jchar JPPyString::asCharUTF16(PyObject* pyobj)
 		Py_UCS4 value = PyUnicode_READ_CHAR(pyobj, 0);
 		if (value > 0xffff)
 		{
-			JP_RAISE(PyExc_ValueError, "Unable to pack 4 byte unicode into java char");
+			JP_RAISE(PyExc_ValueError, "Unable to pack 4 byte unicode into Java char");
 		}
 		return value;
 	}
@@ -268,12 +268,12 @@ jchar JPPyString::asCharUTF16(PyObject* pyobj)
 		Py_UCS4 value = PyUnicode_ReadChar(pyobj, 0);
 		if (value > 0xffff)
 		{
-			JP_RAISE(PyExc_ValueError, "Unable to pack 4 byte unicode into java char");
+			JP_RAISE(PyExc_ValueError, "Unable to pack 4 byte unicode into Java char");
 		}
 		return value;
 	}
 #endif
-	PyErr_Format(PyExc_TypeError, "Unable to convert '%s'  to char", Py_TYPE(pyobj)->tp_name);
+	PyErr_Format(PyExc_TypeError, "Unable to convert '%s' to Java char", Py_TYPE(pyobj)->tp_name);
 	JP_RAISE_PYTHON();
 }
 

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -600,12 +600,12 @@ class ArrayTestCase(common.JPypeTestCase):
 
     def executeOrder(self, jtype, dtype):
         a = np.array([1, 2, 3])
-        ja2 = jpype.JLong[:](a)
+        ja2 = jtype[:](a)
         for order in ("=", "<", ">"):
             dt = np.dtype(dtype).newbyteorder(order)
             a = np.array([1, 2, 3], dtype=dt)
-            ja = jpype.JLong[:](a)
-            self.assertTrue(jpype.java.util.Arrays.equals(ja, ja2))
+            ja = jtype[:](a)
+            self.assertTrue(jpype.java.util.Arrays.equals(ja, ja2), "Order issue with %s %s" % (jtype, dtype))
 
     @common.requireNumpy
     def testOrder(self):

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -597,18 +597,3 @@ class ArrayTestCase(common.JPypeTestCase):
         # Test multidimensional
         self.assertEqual(JDouble[5, 5].getClass(), JArray(JDouble, 2)(5).getClass())
         self.assertEqual(JObject[5, 5].getClass(), JArray(JObject, 2)(5).getClass())
-
-    def executeOrder(self, jtype, dtype):
-        a = np.array([1, 2, 3])
-        ja2 = jtype[:](a)
-        for order in ("=", "<", ">"):
-            dt = np.dtype(dtype).newbyteorder(order)
-            a = np.array([1, 2, 3], dtype=dt)
-            ja = jtype[:](a)
-            self.assertTrue(jpype.java.util.Arrays.equals(ja, ja2), "Order issue with %s %s" % (jtype, dtype))
-
-    @common.requireNumpy
-    def testOrder(self):
-        for i in (jpype.JShort, jpype.JInt, jpype.JLong, jpype.JFloat, jpype.JDouble):
-            for j in (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64):
-                self.executeOrder(i, j)

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -610,5 +610,5 @@ class ArrayTestCase(common.JPypeTestCase):
     @common.requireNumpy
     def testOrder(self):
         for i in (jpype.JShort, jpype.JInt, jpype.JLong, jpype.JFloat, jpype.JDouble):
-            for j in (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64):
+            for j in (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64):
                 self.executeOrder(i, j)

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -597,3 +597,18 @@ class ArrayTestCase(common.JPypeTestCase):
         # Test multidimensional
         self.assertEqual(JDouble[5, 5].getClass(), JArray(JDouble, 2)(5).getClass())
         self.assertEqual(JObject[5, 5].getClass(), JArray(JObject, 2)(5).getClass())
+
+    def executeOrder(self, jtype, dtype):
+        a = np.array([1, 2, 3])
+        ja2 = jpype.JLong[:](a)
+        for order in ("=", "<", ">"):
+            dt = np.dtype(dtype).newbyteorder(order)
+            a = np.array([1, 2, 3], dtype=dt)
+            ja = jpype.JLong[:](a)
+            self.assertTrue(jpype.java.util.Arrays.equals(ja, ja2))
+
+    @common.requireNumpy
+    def testOrder(self):
+        for i in (jpype.JShort, jpype.JInt, jpype.JLong, jpype.JFloat, jpype.JDouble):
+            for j in (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64):
+                self.executeOrder(i, j)

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -201,7 +201,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP1D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "q")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "l")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP1D(self):
@@ -233,7 +233,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP2D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "q")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "l")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP2D(self):
@@ -268,7 +268,7 @@ class BufferTestCase(common.JPypeTestCase):
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP3D(self):
         self.executeIntTest(JLong, [-2**63, 2**63 - 1],
-                            (11, 10, 9), np.int64, "q")
+                            (11, 10, 9), np.int64, "l")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP3D(self):

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -71,10 +71,24 @@ class BufferTestCase(common.JPypeTestCase):
         ja = JArray(JLong)(data)
         self.assertEqual(len(bytes(ja)), 6 * 8)
 
-    def testMemoryViewWrite(self):
+    def testMemoryViewWriteShort(self):
+        data = [1, 2, 3, 4, 5]
+        ja = JArray(JShort)(data)
+        b = memoryview(ja).cast("B")  # Create a view
+        with self.assertRaises(TypeError):
+            b[0] = 123  # Alter the memory using the view
+
+    def testMemoryViewWriteInt(self):
         data = [1, 2, 3, 4, 5]
         ja = JArray(JInt)(data)
-        b = memoryview(ja)  # Create a view
+        b = memoryview(ja).cast("B")  # Create a view
+        with self.assertRaises(TypeError):
+            b[0] = 123  # Alter the memory using the view
+
+    def testMemoryViewWriteLong(self):
+        data = [1, 2, 3, 4, 5]
+        ja = JArray(JLong)(data)
+        b = memoryview(ja).cast("B")  # Create a view
         with self.assertRaises(TypeError):
             b[0] = 123  # Alter the memory using the view
 
@@ -163,12 +177,12 @@ class BufferTestCase(common.JPypeTestCase):
         data = np.random.randint(limits[0], limits[1], size=size, dtype=dtype)
         a = JArray(jtype, data.ndim)(data.tolist())
         u = np.array(a)
-        self.assertEqual(u.dtype.type, dtype)
-        self.assertTrue(np.all(data == u))
         mv = memoryview(a)
-        self.assertEqual(mv.format, code)
+        self.assertEqual(mv.format, code, "Type issue %s" % type(a))
         self.assertEqual(mv.shape, data.shape)
         self.assertTrue(mv.readonly)
+        self.assertEqual(u.dtype.type, dtype, "Problem with %s %s" % (jtype, dtype))
+        self.assertTrue(np.all(data == u))
 
     def executeFloatTest(self, jtype, size, dtype, code):
         data = np.random.rand(*size).astype(dtype)
@@ -198,7 +212,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntToNP1D(self):
-        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (100,), np.int32, "i")
+        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (100,), np.int32, "=i")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP1D(self):
@@ -230,7 +244,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntToNP2D(self):
-        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (11, 10), np.int32, "i")
+        self.executeIntTest(JInt, [-2**31, 2**31 - 1], (11, 10), np.int32, "=i")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP2D(self):
@@ -264,7 +278,7 @@ class BufferTestCase(common.JPypeTestCase):
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntToNP3D(self):
         self.executeIntTest(JInt, [-2**31, 2**31 - 1],
-                            (11, 10, 9), np.int32, "i")
+                            (11, 10, 9), np.int32, "=i")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP3D(self):

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -163,6 +163,7 @@ class BufferTestCase(common.JPypeTestCase):
         data = np.random.randint(limits[0], limits[1], size=size, dtype=dtype)
         a = JArray(jtype, data.ndim)(data.tolist())
         u = np.array(a)
+        self.assertEqual(u.dtype.type, dtype)
         self.assertTrue(np.all(data == u))
         mv = memoryview(a)
         self.assertEqual(mv.format, code)
@@ -201,7 +202,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP1D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "l")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (100,), np.int64, "=q")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP1D(self):
@@ -233,7 +234,7 @@ class BufferTestCase(common.JPypeTestCase):
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP2D(self):
-        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "l")
+        self.executeIntTest(JLong, [-2**63, 2**63 - 1], (11, 10), np.int64, "=q")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP2D(self):
@@ -268,7 +269,7 @@ class BufferTestCase(common.JPypeTestCase):
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongToNP3D(self):
         self.executeIntTest(JLong, [-2**63, 2**63 - 1],
-                            (11, 10, 9), np.int64, "l")
+                            (11, 10, 9), np.int64, "=q")
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testFloatToNP3D(self):

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -292,3 +292,125 @@ class BufferTestCase(common.JPypeTestCase):
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testDoubleToNP3D(self):
         self.executeFloatTest(JDouble, (11, 10, 9), np.float64, "d")
+
+    def executeOrder(self, jtype, dtype):
+        a = np.array([1, 2, 3])
+        ja2 = jtype[:](a)
+        for order in ("=", "<", ">"):
+            dt = np.dtype(dtype).newbyteorder(order)
+            a = np.array([1, 2, 3], dtype=dt)
+            ja = jtype[:](a)
+            self.assertTrue(jpype.java.util.Arrays.equals(ja, ja2), "Order issue with %s %s" % (jtype, dtype))
+
+    @common.requireNumpy
+    def testOrder(self):
+        for i in (jpype.JBoolean, jpype.JByte, jpype.JShort, jpype.JInt, jpype.JLong, jpype.JFloat, jpype.JDouble):
+            for j in (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64, np.float32, np.float64):
+                self.executeOrder(i, j)
+        for j in (np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint16, np.uint32, np.uint64):
+            self.executeOrder(jpype.JChar, j)
+
+    def testMemoryByte(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JByte[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryInt(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JInt[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryShort(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JShort[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryLong(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JLong[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryFloat(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JFloat[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryDouble(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JDouble[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryBoolean(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JBoolean[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        for dtype in ("s", "p", "P", "e"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))
+
+    def testMemoryChar(self):
+        mv = memoryview(bytes(256))
+        jtype = jpype.JChar[:]
+
+        # Simple checks
+        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "n", "N"):
+            jtype(mv.cast(dtype))
+            jtype(mv.cast("@" + dtype))
+
+        jtype(mv.cast("P"))
+        for dtype in ("s", "p", "f", "d", "@f", "@d"):
+            with self.assertRaises(Exception):
+                jtype(mv.cast(dtype))


### PR DESCRIPTION
@pelson  If the goal is simply to change the reported type to "l" then wouldn't this be simpler.

The problem of course is that direct buffers are still type "q".  But if you try to fix that you get this error...

"RuntimeError: Item size 8 for PEP 3118 buffer format string >l does not match the dtype i item size 4."

Because long is supposed to be 4 not 8.   So the correct type should be "q" for Java long.



