### PR TITLE
Remove dunder methods from java.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -6,6 +6,10 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 Latest Changes:
 - **1.3.1_dev0 - 2021-06-05**
 
+  - Fixed issue when Java classes with dunder methods such as  ``__del__`` 
+    caused conflicts in Python type system.   Java method which match dunder 
+    patterns are longer translated to Python.
+
   - Fix issue with numpy arrays with no dimensions resulting in crash..
 
   - Support for user defined conversions for java.lang.Class and array types.

--- a/jpype/_jclass.py
+++ b/jpype/_jclass.py
@@ -124,7 +124,9 @@ def _jclassPre(name, bases, members):
         k2 = pysafe(k)
         if k2 != k:
             del members[k]
-            members[k2] = v
+            # Remove unmappable functions
+            if k2:
+                members[k2] = v
 
     # Apply customizers
     hints = _jcustomizer.getClassHints(name)

--- a/jpype/_pykeywords.py
+++ b/jpype/_pykeywords.py
@@ -28,6 +28,8 @@ _KEYWORDS = set((
 
 
 def pysafe(s):
+    if s.startswith("__"):
+        return None
     if s in _KEYWORDS:
         return s + "_"
     return s

--- a/test/jpypetest/test_keywords.py
+++ b/test/jpypetest/test_keywords.py
@@ -26,4 +26,6 @@ class KeywordsTestCase(common.JPypeTestCase):
 
     def testKeywords(self):
         for kw in keyword.kwlist:
-            self.assertTrue(jpype._pykeywords.pysafe(kw).endswith("_"))
+            safe = jpype._pykeywords.pysafe(kw)
+            self.assertEquals(type(safe), str)
+            self.assertTrue(safe.endswith("_"))

--- a/test/jpypetest/test_keywords.py
+++ b/test/jpypetest/test_keywords.py
@@ -27,5 +27,8 @@ class KeywordsTestCase(common.JPypeTestCase):
     def testKeywords(self):
         for kw in keyword.kwlist:
             safe = jpype._pykeywords.pysafe(kw)
+            if kw.startswith("_"):
+                continue
             self.assertEqual(type(safe), str, "Fail on keyword %s" % kw)
             self.assertTrue(safe.endswith("_"))
+        self.assertEqual(jpype._pykeywords.pysafe("__del__"), None)

--- a/test/jpypetest/test_keywords.py
+++ b/test/jpypetest/test_keywords.py
@@ -27,5 +27,5 @@ class KeywordsTestCase(common.JPypeTestCase):
     def testKeywords(self):
         for kw in keyword.kwlist:
             safe = jpype._pykeywords.pysafe(kw)
-            self.assertEquals(type(safe), str)
+            self.assertEqual(type(safe), str, "Fail on keyword %s", kw)
             self.assertTrue(safe.endswith("_"))

--- a/test/jpypetest/test_keywords.py
+++ b/test/jpypetest/test_keywords.py
@@ -27,5 +27,5 @@ class KeywordsTestCase(common.JPypeTestCase):
     def testKeywords(self):
         for kw in keyword.kwlist:
             safe = jpype._pykeywords.pysafe(kw)
-            self.assertEqual(type(safe), str, "Fail on keyword %s", kw)
+            self.assertEqual(type(safe), str, "Fail on keyword %s" % kw)
             self.assertTrue(safe.endswith("_"))


### PR DESCRIPTION
If a Java method contains ``__`` then the resulting class will often have unexpected and buggy behavior as it will try to repoint Python internals to Java methods.   This PR removes any method which starts with double underscore from the class definition.   Double underscore is a Python convention for a dunder method and also violates the conventions for Java.  This may break code which was doing "very bad things."  We could rename those as something like ``j__del__`` or something if it seems necessary to try to support such an oddly named function.  But for now I removed the dangerous java defined dunder functions.  (Adding an underscore just made ``__del_`` cause breakage, so our normal conventions don't apply.)

Fixes #1050

@astrelsky  I am not sure what you are doing trying to declare a dunder method in Java.  This would normally be accomplished with a class customizer.   I was not able to replicate the segfault, but I can prevent it from reaching that branch.   If you have additional clarifications it would help. 