### PR TITLE
Attempt to add cause info

### DIFF
--- a/jpype/_jexception.py
+++ b/jpype/_jexception.py
@@ -32,6 +32,14 @@ class JException(_jpype._JException, internal=True):
     ``java.lang.Throwable``.
 
     """
+    def __new__(cls, *args):
+        self = _jpype._JException.__new__(cls, *args)
+        # Exceptions generated from Java require a different path.
+        if len(args) == 2 and type(args[1]) == tuple:
+            return self
+        # Connect the Java cause to the __cause__ field.
+        self.__cause__ = _jpype._java_lang_Throwable.getCause(self)
+        return self
 
     # Included for compatibility with JPype 0.6.3
     def message(self):

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -382,8 +382,10 @@ JPPyObject JPClass::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool
 						JPPyString::fromStringUTF8(frame.toString(value.l)).get()));
 			}
 		}
+		JPValue jv(cls, value);
+		JPPyObject cap = JPPyObject::claim(PyCapsule_New(&jv, JValueKey, NULL));
 		JPPyObject tuple1 = JPPyObject::call(PyTuple_Pack(2,
-				_JObjectKey, tuple0.get()));
+				cap.get(), tuple0.get()));
 		// Exceptions need new and init
 		obj = JPPyObject::call(PyObject_Call(wrapper.get(), tuple1.get(), NULL));
 	} else
@@ -393,10 +395,11 @@ JPPyObject JPClass::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool
 		PyObject *obj2 = type->tp_alloc(type, 0);
 		JP_PY_CHECK();
 		obj = JPPyObject::claim(obj2);
+
+		// Fill in the Java slot
+		PyJPValue_assignJavaSlot(frame, obj.get(), JPValue(cls, value));
 	}
 
-	// Fill in the Java slot
-	PyJPValue_assignJavaSlot(frame, obj.get(), JPValue(cls, value));
 	return obj;
 	JP_TRACE_OUT;
 }

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -151,9 +151,9 @@ extern PyObject *_JClassDoc;
 extern PyObject *_JMethodDoc;
 extern PyObject *_JMethodAnnotations;
 extern PyObject *_JMethodCode;
-extern PyObject *_JObjectKey;
 extern PyObject *_JVMNotRunning;
 extern PyObject* PyJPClassMagic;
+extern char* JValueKey;
 
 extern JPContext* JPContext_global;
 

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -72,6 +72,7 @@ PyObject* _JMethodAnnotations = NULL;
 PyObject* _JMethodCode = NULL;
 PyObject* _JObjectKey = NULL;
 PyObject* _JVMNotRunning = NULL;
+char* JValueKey = "jvalue";
 
 void PyJPModule_loadResources(PyObject* module)
 {
@@ -120,8 +121,6 @@ void PyJPModule_loadResources(PyObject* module)
 		_JMethodCode = PyObject_GetAttrString(module, "getMethodCode");
 		JP_PY_CHECK();
 		Py_INCREF(_JMethodCode);
-
-		_JObjectKey = PyCapsule_New(module, "constructor key", NULL);
 
 	}	catch (JPypeException&)  // GCOVR_EXCL_LINE
 	{


### PR DESCRIPTION
This is a work in progress to link Java exception causes with Python ones.  Unfortunately, the cause slot is already used when throwing from Java to Python, so it is not clear if this can actually be made into a function PR.

Potentially fixes #1047 