### PR TITLE
Update the release scripts to include Python 3.10

### DIFF
--- a/.azure/release.yml
+++ b/.azure/release.yml
@@ -30,11 +30,6 @@ stages:
     strategy:
       matrix:
           # Disabled because it is fetching beta images
-          #        64Bit2010:
-          #          arch: x86_64
-          #          plat: manylinux2010_x86_64
-          #          image: quay.io/pypa/manylinux2010_x86_64
-          #          python.architecture: x64
           #        64Bit2014:
           #          arch: aarch64
           #          plat: manylinux2014_aarch64
@@ -43,12 +38,12 @@ stages:
         64Bit:
           arch: x86_64
           plat: manylinux1_x86_64
-          image: quay.io/pypa/manylinux1_x86_64
+          image: quay.io/pypa/manylinux2010_x86_64
           python.architecture: x64
         32Bit:
           arch: i686
           plat: manylinux1_i686
-          image: quay.io/pypa/manylinux1_i686
+          image: quay.io/pypa/manylinux2010_i686
           python.architecture: x86
     pool:
       vmImage: "ubuntu-latest"

--- a/.azure/scripts/build-wheels.sh
+++ b/.azure/scripts/build-wheels.sh
@@ -2,13 +2,10 @@
 set -e -x
 
 # Collect the pythons
-pys=(/opt/python/*/bin)
+pys=(/opt/python/cp*/bin)
 
-# Filter out Python 3.4
+# Exclude specific Pythons (3.6)
 pys=(${pys[@]//*36*/})
-pys=(${pys[@]//*35*/})
-pys=(${pys[@]//*34*/})
-pys=(${pys[@]//*27*/})
 
 # Compile wheels
 for PYBIN in "${pys[@]}"; do


### PR DESCRIPTION
Update the release scripts to include Python 3.10, and drop Python 3.6. Manylinux2010 images (centos6) are now provided instead of manylinux1 (centos5) in order to support Python 3.10


(apologies to @Thrameos for missing this in https://github.com/jpype-project/jpype/pull/1061#issuecomment-1126713213, I started fixing it once I saw your comment, and then realised you'd already solved most of the problems. Here are the only 2 things that weren't addressed I think (including a release of a Python 3.10 manylinux wheel))

I have bumped from manylinux1 to manylinux2010. The former is no longer actively supported, and there is no Python 3.10 available in them. If you are concerned about dropping manylinux1 for older Python versions, we should do some more rationalisation of the release script I think.