### PR TITLE
Launch JVM in new thread

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,9 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.4.1_dev0 - 2022-05-14**
+
+  - Launch JVM in an independent thread.
+
 - **1.4.0 - 2022-05-14**
 
   - Support for all different buffer type conversions.

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -230,3 +230,6 @@ class JProxy(_jpype._JProxy):
         if not isinstance(obj, _jpype._JProxy):
             return obj
         return obj.__javainst__
+
+
+_jpype.JProxy = JProxy

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -198,12 +198,16 @@ public:
 	JPStringType* _java_lang_String;
 	JPClass* _java_nio_ByteBuffer;
 
+	void launch();
 private:
-
 	void loadEntryPoints(const string& path);
 
 	jint(JNICALL * CreateJVM_Method)(JavaVM **pvm, void **penv, void *args);
 	jint(JNICALL * GetCreatedJVMs_Method)(JavaVM **pvm, jsize size, jsize * nVms);
+
+	bool m_IgnoreUnrecognized = false;
+	const StringVector* m_Args;
+	string m_VmPath;
 
 private:
 	JPContext(const JPContext& orig);

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -69,10 +69,6 @@ static DWORD WINAPI jcontext_run(PVOID arg)
 	ctx->launch();
 	jcontext_status = 1;
 	WakeConditionVariable(&jcontext_signal);
-	ReleaseSRWLockShared(&jcontext_mutex);
-
-	// Wait for message to kill JVM
-	AcquireSRWLockShared(&jcontext_mutex);
 	while (jcontext_status == 1)
 	{
 		SleepConditionVariableSRW(&jcontext_signal, &jcontext_mutex, INFINITE, 0);
@@ -138,10 +134,6 @@ static int jcontext_run(void* arg)
 	ctx->launch();
 	jcontext_status = 1;
 	cnd_signal(&jcontext_signal);
-	mtx_unlock(&jcontext_mutex);
-
-	// Wait for message to kill JVM
-	mtx_lock(&jcontext_mutex);
 	while (jcontext_status == 1)
 	{
 		cnd_wait(&jcontext_signal, &jcontext_mutex);

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -354,15 +354,8 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		JP_RAISE(PyExc_SystemError, "restart jvm");
 
 	// Get the entry points in the shared library
-	try
-	{
-		JP_TRACE("Load entry points");
-		loadEntryPoints(vmPath);
-	} catch (JPypeException& ex)
-	{
-		ex.getMessage();
-		throw;
-	}
+	JP_TRACE("Load entry points");
+	loadEntryPoints(vmPath);
 
 	{
 		JPPyCallRelease call;


### PR DESCRIPTION
This is an attempt to solve the OSX issue in which the JVM main thread and the GUI thread must be separate or the GUI will go into a deadlock.   Unfortunately, I have no way to test this particular PR as I don't have access to that architecture.    If someone can tell me if this fixes the deadlock issue (or makes it worse), it would be appreciated. 