### PR TITLE
Preserve locale through startJVM

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,9 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.4.1_dev0 - 2022-05-14**
+  
+  - Fixed issue with startJVM changing locale settings.
+
 - **1.4.0 - 2022-05-14**
 
   - Support for all different buffer type conversions.

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -215,13 +215,15 @@ def startJVM(*args, **kwargs):
                         % (','.join([str(i) for i in kwargs])))
 
     try:
-        # Keep the current locale settings, else Java will replace them.
         import locale
-        categories = [locale.LC_CTYPE, locale.LC_COLLATE, locale.LC_TIME,
-                      locale.LC_MONETARY, locale.LC_NUMERIC]
+        # Gather a list of locale settings that Java may override (excluding LC_ALL)
+        categories = [getattr(locale, i) for i in locale.__all__ if i.startswith('LC_') and i != 'LC_ALL']
+        # Keep the current locale settings, else Java will replace them.
         prior = [locale.getlocale(i) for i in categories]
+        # Start the JVM
         _jpype.startup(jvmpath, tuple(args),
                        ignoreUnrecognized, convertStrings, interrupt)
+        # Collect required resources for operation
         initializeResources()
         # Restore locale
         for i, j in zip(categories, prior):

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -218,7 +218,7 @@ def startJVM(*args, **kwargs):
         # Keep the current locale settings, else Java will replace them.
         import locale
         categories = [locale.LC_CTYPE, locale.LC_COLLATE, locale.LC_TIME,
-                      locale.LC_MONETARY, locale.LC_MESSAGES, locale.LC_NUMERIC]
+                      locale.LC_MONETARY, locale.LC_NUMERIC]
         prior = [locale.getlocale(i) for i in categories]
         _jpype.startup(jvmpath, tuple(args),
                        ignoreUnrecognized, convertStrings, interrupt)

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -215,9 +215,17 @@ def startJVM(*args, **kwargs):
                         % (','.join([str(i) for i in kwargs])))
 
     try:
+        # Keep the current locale settings, else Java will replace them.
+        import locale
+        categories = [locale.LC_CTYPE, locale.LC_COLLATE, locale.LC_TIME,
+                      locale.LC_MONETARY, locale.LC_MESSAGES, locale.LC_NUMERIC]
+        prior = [locale.getlocale(i) for i in categories]
         _jpype.startup(jvmpath, tuple(args),
                        ignoreUnrecognized, convertStrings, interrupt)
         initializeResources()
+        # Restore locale
+        for i, j in zip(categories, prior):
+            locale.setlocale(i, j)
     except RuntimeError as ex:
         source = str(ex)
         if "UnsupportedClassVersion" in source:


### PR DESCRIPTION
Patch to fix behavior with locale.   It appears that Python and Java are using the same C library for locale.  When starting the JVM it reinitialized the locale to different values than the current Python settings.  To fix this we store the locale variables prior to starting the JVM and restore them so that we don't mess up the user settings.

It is not clear if this needs to be a switchable behavior.  If it should be optional then I would recommend preserving by default as it is the expected behavior. 

Fixes #1078