### PR TITLE
jpype#1091: allow null characters in strings when convertStrings=True

### DIFF
--- a/native/common/jp_stringtype.cpp
+++ b/native/common/jp_stringtype.cpp
@@ -47,7 +47,7 @@ JPPyObject JPStringType::convertToPythonObject(JPJavaFrame& frame, jvalue val, b
 		if (context->getConvertStrings())
 		{
 			string str = frame.toStringUTF8((jstring) (val.l));
-			return JPPyObject::call(PyUnicode_FromString(str.c_str()));
+			return JPPyObject::call(PyUnicode_FromStringAndSize(str.c_str(), str.length()));
 		}
 	}
 

--- a/test/harness/jpype/str/Test.java
+++ b/test/harness/jpype/str/Test.java
@@ -31,8 +31,12 @@ public class Test
     return "memberCall";
   }
 
-  public String callWithNullBytes() {
+  public static String callWithNullBytes() {
     return "call\0With\0Null\0Bytes";
+  }
+
+  public static String returnArgument(String argument) {
+    return argument;
   }
 
   public static final String array[] =

--- a/test/harness/jpype/str/Test.java
+++ b/test/harness/jpype/str/Test.java
@@ -31,6 +31,10 @@ public class Test
     return "memberCall";
   }
 
+  public String callWithNullBytes() {
+    return "call\0With\0Null\0Bytes";
+  }
+
   public static final String array[] =
   {
     "apples", "banana", "cherries", "dates", "elderberry"

--- a/test/jpypetest/test_legacy.py
+++ b/test/jpypetest/test_legacy.py
@@ -79,3 +79,8 @@ class LegacyTestCase(unittest.TestCase):
         r = self._test().callProxy(p, "roundtrip")
         self.assertEqual(r, "roundtrip")
         self.assertIsInstance(r, str)
+
+    def testNullBytes(self):
+        s = self._test().callWithNullBytes()
+        self.assertEqual(s, "call\u0000With\u0000Null\u0000Bytes")
+        self.assertIsInstance(s, str)

--- a/test/jpypetest/test_legacy.py
+++ b/test/jpypetest/test_legacy.py
@@ -81,6 +81,16 @@ class LegacyTestCase(unittest.TestCase):
         self.assertIsInstance(r, str)
 
     def testNullBytes(self):
-        s = self._test().callWithNullBytes()
+        s = self._test.callWithNullBytes()
         self.assertEqual(s, "call\u0000With\u0000Null\u0000Bytes")
+        self.assertIsInstance(s, str)
+
+        s = self._test.returnArgument("\u0394 16 byte encoded text\u0000with null\u0000 bytes \u1394")
+        self.assertEqual(s, "\u0394 16 byte encoded text\u0000with null\u0000 bytes \u1394")
+        self.assertIsInstance(s, str)
+
+        s = self._test.returnArgument("\U0001F468\u200D\U0001F9B2 32 byte encoded text"
+                                      "\u0000with null\u0000 bytes \U0001F468\u200D\U0001F9B2")
+        self.assertEqual(s, "\U0001F468\u200D\U0001F9B2 32 byte encoded text"
+                            "\u0000with null\u0000 bytes \U0001F468\u200D\U0001F9B2")
         self.assertIsInstance(s, str)


### PR DESCRIPTION
Previously, `PyUnicode_FromString(str.c_str())` was used when convertStrings=True. If the string contains null bytes, this will terminate the string early. To allow strings with null bytes to be returned, `PyUnicode_FromStringAndSize(str.c_str(), str.length())` is now used instead, which create a Unicode object from the pointer with the given length (instead of the position of the first NULL character), thus allowing null bytes in the string.

Fixes #1091 