### PR TITLE
Fixes #1105

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,9 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.4.2_dev0 - 2022-10-26**
+
+  - Fixed direct byte buffers not reporting nbytes correctly when cast to memoryview.
+
 - **1.4.1 - 2022-10-26**
   
   - Fixed issue with startJVM changing locale settings.

--- a/native/common/jp_buffer.cpp
+++ b/native/common/jp_buffer.cpp
@@ -38,6 +38,7 @@ JPBuffer::JPBuffer(const JPValue &value)
 	m_Buffer.shape = &m_Capacity;
 	m_Buffer.strides = &m_Buffer.itemsize;
 	m_Buffer.suboffsets = 0;
+	m_Buffer.len = m_Buffer.itemsize * m_Capacity;
 	JP_TRACE_OUT;  // GCOVR_EXCL_LINE
 }
 

--- a/test/jpypetest/test_bytebuffer.py
+++ b/test/jpypetest/test_bytebuffer.py
@@ -46,3 +46,6 @@ class ByteBufferCase(common.JPypeTestCase):
         bb = jpype.nio.convertToDirectBuffer(a)
         self.assertIsInstance(repr(bb), str)
         self.assertEqual(repr(bb), "<java buffer 'java.nio.DirectByteBuffer'>")
+
+    def testMemoryView(self):
+        self.assertEquals(memoryview(jpype.java.nio.ByteBuffer.allocateDirect(100)).nbytes, 100)


### PR DESCRIPTION
While attempting to use directbyte buffers with Python io, I found that the nbytes was never set which caused random and unpredictable behaviors.   Fixed and added test.
