### PR TITLE
Fixes #1108

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -5,6 +5,9 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 
 Latest Changes:
 - **1.4.2_dev0 - 2022-10-26**
+
+  - Fixed crash when calling subscript on JArray.
+
 - **1.4.1 - 2022-10-26**
   
   - Fixed issue with startJVM changing locale settings.

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -716,6 +716,12 @@ static PyObject *PyJPClass_array(PyJPClass *self, PyObject *item)
 	JPContext *context = PyJPModule_getContext();
 	JPJavaFrame frame = JPJavaFrame::outer(context);
 
+	if (self->m_Class == NULL)
+	{
+		PyErr_Format(PyExc_TypeError, "Cannot instantiate unspecified array type");
+		return NULL;
+	}
+
 	if (PyIndex_Check(item))
 	{
 		long sz = PyLong_AsLong(item);

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -597,3 +597,7 @@ class ArrayTestCase(common.JPypeTestCase):
         # Test multidimensional
         self.assertEqual(JDouble[5, 5].getClass(), JArray(JDouble, 2)(5).getClass())
         self.assertEqual(JObject[5, 5].getClass(), JArray(JObject, 2)(5).getClass())
+
+    def testJArrayIndex(self):
+        with self.assertRaises(TypeError):
+            jpype.JArray[10]


### PR DESCRIPTION
Crash on NULL when JArray uses as the target of subscript.