### PR TITLE
Allow FunctionalInterface conversion when the annotation is not present

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -9,6 +9,8 @@ Latest Changes:
   - Fixed crash when calling subscript on JArray.
 
   - Fixed direct byte buffers not reporting nbytes correctly when cast to memoryview.
+  - Expand the defintion for Functional interface to include classes without 
+    FunctionInterface annotation.
 
 - **1.4.1 - 2022-10-26**
   

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -287,6 +287,12 @@ void JPContext::initializeResources(JNIEnv* env, bool interrupt)
 		JPPyObject origin = JPPyObject::call(PyObject_GetAttrString(jpype.get(), "origin"));
 		val[2].l = frame.fromStringUTF8(JPPyString::asStringUTF8(origin.get()));
 	}
+
+	// Required before launch
+	m_Context_GetFunctionalID = frame.GetStaticMethodID(contextClass,
+			"getFunctional",
+			"(Ljava/lang/Class;)Ljava/lang/String;");
+
 	m_JavaContext = JPObjectRef(frame, frame.CallStaticObjectMethodA(contextClass, startMethod, val));
 
 	// Post launch
@@ -308,10 +314,6 @@ void JPContext::initializeResources(JNIEnv* env, bool interrupt)
 	m_Context_assembleID = frame.GetMethodID(contextClass,
 			"assemble",
 			"([ILjava/lang/Object;)Ljava/lang/Object;");
-
-	m_Context_GetFunctionalID = frame.GetMethodID(contextClass,
-			"getFunctional",
-			"(Ljava/lang/Class;)Ljava/lang/String;");
 
 	m_Context_CreateExceptionID = frame.GetMethodID(contextClass, "createException",
 			"(JJ)Ljava/lang/Exception;");

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -1170,8 +1170,8 @@ string JPJavaFrame::getFunctional(jclass c)
 {
 	jvalue v;
 	v.l = (jobject) c;
-	return toStringUTF8((jstring) CallObjectMethodA(
-			m_Context->m_JavaContext.get(),
+	return toStringUTF8((jstring) CallStaticObjectMethodA(
+			m_Context->m_ContextClass.get(),
 			m_Context->m_Context_GetFunctionalID, &v));
 }
 

--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -568,28 +568,8 @@ public class JPypeContext
    */
   public String getFunctional(Class cls)
   {
-    // If we don't find it to be a functional interface, then we won't return
-    // the SAM.
-    if (cls.getDeclaredAnnotation(FunctionalInterface.class) == null)
-      return null;
-    for (Method m : cls.getMethods())
-    {
-      if (Modifier.isAbstract(m.getModifiers()))
-      {
-        // This is a very odd construct.  Java allows for java.lang.Object
-        // methods to declared in FunctionalInterfaces and they don't count
-        // towards the single abstract method. So we have to probe the class
-        // until we find something that fails.
-        try
-        {
-          Object.class.getMethod(m.getName(), m.getParameterTypes());
-        } catch (NoSuchMethodException | SecurityException ex)
-        {
-          return m.getName();
-        }
-      }
-    }
-    return null;
+    Method m = JPypeUtilities.getFunctionalInterfaceMethod(cls);
+    return m != null ? m.getName() : null;
   }
 
   /**

--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -566,7 +566,7 @@ public class JPypeContext
    * @param cls
    * @return
    */
-  public String getFunctional(Class cls)
+  public static String getFunctional(Class cls)
   {
     Method m = JPypeUtilities.getFunctionalInterfaceMethod(cls);
     return m != null ? m.getName() : null;

--- a/native/java/org/jpype/JPypeUtilities.java
+++ b/native/java/org/jpype/JPypeUtilities.java
@@ -55,7 +55,7 @@ public class JPypeUtilities
     }
   }
 
-  static Method getFunctionalInterfaceMethod(Class cls)
+  public static Method getFunctionalInterfaceMethod(Class cls)
   {
     if (!cls.isInterface() || cls.isAnnotation() || isSealed.test(cls))
       return null;

--- a/native/java/org/jpype/JPypeUtilities.java
+++ b/native/java/org/jpype/JPypeUtilities.java
@@ -1,11 +1,47 @@
 package org.jpype;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandleProxies;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 public class JPypeUtilities
 {
+  
+  // a functional interface can only re-declare a public non-final method from Object
+  // this should end up being an array of equals, hashCode and toString
+  private static final Method[] OBJECT_METHODS =
+    Arrays.stream(Object.class.getMethods())
+      .filter(m -> !Modifier.isFinal(m.getModifiers()))
+      .toArray(Method[]::new);
+  
+  private static final Predicate<Class> isSealed;
+
+  static
+  {
+    Predicate<Class> result = null;
+    try
+    {
+      Method m = Class.class.getMethod("isSealed");
+      MethodHandle handle = MethodHandles.publicLookup().unreflect(m);
+      result = MethodHandleProxies.asInterfaceInstance(Predicate.class, handle);
+    } catch (IllegalAccessException e)
+    {
+      // it's a public method so this should never occur
+      throw new IllegalAccessError(e.getMessage());
+    } catch (NoSuchMethodException e)
+    {
+      // if isSealed doesn't exist then neither do sealed classes
+      result = c -> false;
+    }
+    isSealed = result;
+  }
 
   public static Path getJarPath(Class c)
   {
@@ -19,4 +55,56 @@ public class JPypeUtilities
     }
   }
 
+  static Method getFunctionalInterfaceMethod(Class cls)
+  {
+    if (!cls.isInterface() || cls.isAnnotation() || isSealed.test(cls))
+      return null;
+
+    Method result = null;
+    for (Method m : cls.getMethods())
+    {
+      if (Modifier.isAbstract(m.getModifiers()))
+      {
+        if (isObjectMethodOverride(m))
+          continue;
+        
+        if (result != null && !equals(m, result))
+          return null;
+
+        if (result == null || cls.equals(m.getDeclaringClass()))
+          result = m;
+      }
+    }
+    return result;
+  }
+
+  private static boolean isObjectMethodOverride(Method m)
+  {
+    for (Method objectMethod : OBJECT_METHODS)
+    {
+      if (equals(m, objectMethod))
+        return true;
+    }
+    return false;
+  }
+  
+  private static boolean equals(Method a, Method b)
+  {
+    // this should be the fastest possible short circuit
+    if (a.getParameterCount() != b.getParameterCount())
+      return false;
+
+    if (!a.getName().equals(b.getName()))
+      return false;
+
+    // if the return types are different it wouldn't compile
+    // parameters must be exactly the same and may not be an extended class
+    if (!Arrays.equals(a.getParameterTypes(), b.getParameterTypes()))
+      return false;
+
+    // if declared exceptions were different it wouldn't compile
+    // if it did compile then it is an override
+    return true;
+  }
+  
 }

--- a/native/java/org/jpype/manager/ClassDescriptor.java
+++ b/native/java/org/jpype/manager/ClassDescriptor.java
@@ -46,14 +46,18 @@ public class ClassDescriptor
   public int methodCounter = 0;
   public long[] fields;
   public long anonymous;
-  public int functional_interface_parameter_count = -1; // -1 = unset; -2 = not a functional interface
+  public int functional_interface_parameter_count; 
 
-  ClassDescriptor(Class cls, long classPtr)
+  ClassDescriptor(Class cls, long classPtr, Method method)
   {
     this.cls = cls;
     this.classPtr = classPtr;
     if (this.classPtr == 0)
       throw new NullPointerException("Class pointer is null for " + cls);
+    if (method != null)
+      functional_interface_parameter_count = method.getParameterCount();
+    else
+      functional_interface_parameter_count = -1;
   }
 
   long getMethod(Method requestedMethod)

--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -49,7 +49,6 @@ public class TypeManager
   public TypeFactory typeFactory = null;
   public TypeAudit audit = null;
   private ClassDescriptor java_lang_Object;
-  public Class<? extends Annotation> functionalAnnotation = null;
   // For reasons that are less than clear, this object cannot be created
   // during shutdown
   private Destroyer destroyer = new Destroyer();
@@ -73,15 +72,6 @@ public class TypeManager
         throw new RuntimeException("Cannot be restarted");
       isStarted = true;
       isShutdown = false;
-
-      try
-      {
-        this.functionalAnnotation = Class.forName("java.lang.FunctionalInterface")
-                .asSubclass(Annotation.class);
-      } catch (ClassNotFoundException ex)
-      {
-        // It is okay if we don't find this
-      }
 
       // Create the required minimum classes
       this.java_lang_Object = createClass(Object.class, true);
@@ -307,17 +297,9 @@ public class TypeManager
    * @param interfaceClass The class of the interface
    * @return the number of arguments the only unimplemented method of the interface accept.
    */
-  public int interfaceParameterCount(Class<?> interfaceClass) {
+  public int interfaceParameterCount(Class<?> interfaceClass)
+  {
     ClassDescriptor classDescriptor = classMap.get(interfaceClass);
-    if (classDescriptor.functional_interface_parameter_count != -1) {
-      return classDescriptor.functional_interface_parameter_count;
-    }
-    Method method = JPypeUtilities.getFunctionalInterfaceMethod(interfaceClass);
-    if (method == null) {
-      classDescriptor.functional_interface_parameter_count = -2;
-      return -2;
-    }
-    classDescriptor.functional_interface_parameter_count = method.getParameterCount();
     return classDescriptor.functional_interface_parameter_count;
   }
 
@@ -465,8 +447,10 @@ public class TypeManager
       modifiers |= ModifierCode.COMPARABLE.value;
     if (Buffer.class.isAssignableFrom(cls))
       modifiers |= ModifierCode.BUFFER.value | ModifierCode.SPECIAL.value;
-    if (this.functionalAnnotation != null
-            && cls.getAnnotation(this.functionalAnnotation) != null)
+
+    // Check if is Functional class
+    Method method = JPypeUtilities.getFunctionalInterfaceMethod(cls);
+    if (method != null)
       modifiers |= ModifierCode.FUNCTIONAL.value | ModifierCode.SPECIAL.value;
 
     // FIXME watch out for anonyous and lambda here.
@@ -481,9 +465,8 @@ public class TypeManager
             modifiers);
 
     // Cache the wrapper.
-    ClassDescriptor out = new ClassDescriptor(cls, classPtr);
+    ClassDescriptor out = new ClassDescriptor(cls, classPtr, method);
     this.classMap.put(cls, out);
-
     return out;
   }
 
@@ -518,7 +501,7 @@ public class TypeManager
                     componentTypePtr,
                     modifiers);
 
-    ClassDescriptor out = new ClassDescriptor(cls, classPtr);
+    ClassDescriptor out = new ClassDescriptor(cls, classPtr, null);
     this.classMap.put(cls, out);
     return out;
   }
@@ -537,7 +520,7 @@ public class TypeManager
             cls,
             this.getClass(boxed).classPtr,
             cls.getModifiers() & 0xffff);
-    this.classMap.put(cls, new ClassDescriptor(cls, classPtr));
+    this.classMap.put(cls, new ClassDescriptor(cls, classPtr, null));
   }
 
 //</editor-fold>

--- a/native/java/org/jpype/manager/TypeManager.java
+++ b/native/java/org/jpype/manager/TypeManager.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeSet;
 import org.jpype.JPypeContext;
+import org.jpype.JPypeUtilities;
 import org.jpype.proxy.JPypeProxy;
 
 /**
@@ -311,21 +312,13 @@ public class TypeManager
     if (classDescriptor.functional_interface_parameter_count != -1) {
       return classDescriptor.functional_interface_parameter_count;
     }
-    int abstractMethodParameterCount = -1;
-    for (Method method : interfaceClass.getMethods()) {
-      if (Modifier.isAbstract(method.getModifiers())) {
-        if (abstractMethodParameterCount != -1) {
-          classDescriptor.functional_interface_parameter_count = -2;
-          return -2;
-        }
-        abstractMethodParameterCount = method.getParameterCount();
-      }
+    Method method = JPypeUtilities.getFunctionalInterfaceMethod(interfaceClass);
+    if (method == null) {
+      classDescriptor.functional_interface_parameter_count = -2;
+      return -2;
     }
-    if (abstractMethodParameterCount == -1) {
-      abstractMethodParameterCount = -2;
-    }
-    classDescriptor.functional_interface_parameter_count = abstractMethodParameterCount;
-    return abstractMethodParameterCount;
+    classDescriptor.functional_interface_parameter_count = method.getParameterCount();
+    return classDescriptor.functional_interface_parameter_count;
   }
 
   /**

--- a/test/harness/jpype/functional/Annotated.java
+++ b/test/harness/jpype/functional/Annotated.java
@@ -1,0 +1,22 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+@FunctionalInterface
+public interface Annotated
+{
+  int call(int i);
+}

--- a/test/harness/jpype/functional/AnnotatedWithObjectMethods.java
+++ b/test/harness/jpype/functional/AnnotatedWithObjectMethods.java
@@ -1,0 +1,25 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+@FunctionalInterface
+public interface AnnotatedWithObjectMethods
+{
+  int call(int i);
+  boolean equals(Object o);
+  int hashCode();
+  String toString();
+}

--- a/test/harness/jpype/functional/ExtendsFunctional.java
+++ b/test/harness/jpype/functional/ExtendsFunctional.java
@@ -1,0 +1,20 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+public interface ExtendsFunctional extends NonAnnotated
+{
+}

--- a/test/harness/jpype/functional/ExtendsNonFunctional.java
+++ b/test/harness/jpype/functional/ExtendsNonFunctional.java
@@ -1,0 +1,21 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+public interface ExtendsNonFunctional extends NonAnnotated
+{
+  boolean test();
+}

--- a/test/harness/jpype/functional/NonAnnotated.java
+++ b/test/harness/jpype/functional/NonAnnotated.java
@@ -1,0 +1,21 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+public interface NonAnnotated
+{
+  int call(int i);
+}

--- a/test/harness/jpype/functional/NonAnnotatedWithObjectMethods.java
+++ b/test/harness/jpype/functional/NonAnnotatedWithObjectMethods.java
@@ -1,0 +1,24 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+public interface NonAnnotatedWithObjectMethods
+{
+  int call(int i);
+  boolean equals(Object o);
+  int hashCode();
+  String toString();
+}

--- a/test/harness/jpype/functional/RedeclaresAnnotated.java
+++ b/test/harness/jpype/functional/RedeclaresAnnotated.java
@@ -1,0 +1,21 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+public interface RedeclaresAnnotated extends Annotated
+{
+  int call(int i);
+}

--- a/test/harness/jpype/functional/RedeclaresNonAnnotated.java
+++ b/test/harness/jpype/functional/RedeclaresNonAnnotated.java
@@ -1,0 +1,21 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.functional;
+
+public interface RedeclaresNonAnnotated extends NonAnnotated
+{
+  int call(int i);
+}

--- a/test/jpypetest/test_functional.py
+++ b/test/jpypetest/test_functional.py
@@ -1,0 +1,67 @@
+# *****************************************************************************
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#   See NOTICE file for details.
+#
+# *****************************************************************************
+import jpype
+import common
+
+
+def callFunctional(cls, i):
+    fun = lambda x: x
+    fun = cls._cast(fun)
+    return fun.call(i)
+
+
+class FunctionalTestCase(common.JPypeTestCase):
+    
+    def _checkValidFunctional(self, name, value):
+        cls = jpype.JClass("jpype.functional." + name)
+        self.assertEqual(callFunctional(cls, value), value)
+    
+    def testAnnotated(self):
+        self._checkValidFunctional("Annotated", 0)
+
+    def testNonAnnotated(self):
+        JPypeUtilities = jpype.JClass("org.jpype.JPypeUtilities")
+        NonAnnotated = jpype.JClass("jpype.functional.NonAnnotated")
+        m = JPypeUtilities.getFunctionalInterfaceMethod(NonAnnotated)
+        self.assertIsNotNone(m)
+        self._checkValidFunctional("NonAnnotated", 1)
+
+    def testExtendsFunctional(self):
+        self._checkValidFunctional("ExtendsFunctional", 2)
+
+    def testExtendsNonFunctional(self):
+        with self.assertRaises(TypeError):
+            self._checkValidFunctional("ExtendsNonFunctional", 3)
+    
+    def testAnnotatedWithObjectMethods(self):
+        self._checkValidFunctional("AnnotatedWithObjectMethods", 4)
+
+    def testNonAnnotatedWithObjectMethods(self):
+        self._checkValidFunctional("NonAnnotatedWithObjectMethods", 5)
+
+    def testRedeclaresAnnotated(self):
+        self._checkValidFunctional("RedeclaresAnnotated", 6)
+
+    def testRedeclaresNonAnnotated(self):
+        self._checkValidFunctional("RedeclaresNonAnnotated", 7)
+
+    def testStaticDefaultMethods(self):
+        # Predicate has both static and default methods
+        Predicate = jpype.JClass("java.util.function.Predicate")
+        fun = Predicate @ (lambda x: True)
+        self.assertTrue(fun.test(fun))

--- a/test/jpypetest/test_functional.py
+++ b/test/jpypetest/test_functional.py
@@ -20,8 +20,7 @@ import common
 
 
 def callFunctional(cls, i):
-    fun = lambda x: x
-    fun = cls._cast(fun)
+    fun = cls @(lambda x: x)
     return fun.call(i)
 
 
@@ -35,10 +34,6 @@ class FunctionalTestCase(common.JPypeTestCase):
         self._checkValidFunctional("Annotated", 0)
 
     def testNonAnnotated(self):
-        JPypeUtilities = jpype.JClass("org.jpype.JPypeUtilities")
-        NonAnnotated = jpype.JClass("jpype.functional.NonAnnotated")
-        m = JPypeUtilities.getFunctionalInterfaceMethod(NonAnnotated)
-        self.assertIsNotNone(m)
         self._checkValidFunctional("NonAnnotated", 1)
 
     def testExtendsFunctional(self):

--- a/test/jpypetest/test_lambdas.py
+++ b/test/jpypetest/test_lambdas.py
@@ -16,9 +16,6 @@
 #
 # *****************************************************************************
 import jpype
-import sys
-import logging
-import time
 import common
 
 


### PR DESCRIPTION
I will have a look at the current tests tomorrow and see what I can add to throw the kitchen sink at this.

I tried to follow the formatting as close as possible.

Fixes #1107