### PR TITLE
fix pyinstaller   get_hook_dirs error

### DIFF
--- a/jpype/_pyinstaller/entry_points.py
+++ b/jpype/_pyinstaller/entry_points.py
@@ -9,7 +9,7 @@ _pyinstaller_path = Path(__file__).parent
 
 
 def get_hook_dirs():
-    return [fspath(_pyinstaller_path)]
+    return [fspath(str(_pyinstaller_path))]
 
 
 def get_PyInstaller_tests():


### PR DESCRIPTION
pyinstall:4.5.1
pyinstaller-hooks-contrib 2023.7

discover_hook_directories: Failed to process hook entry point 'hook-dirs = jpype._pyinstaller.entry_points:get_hook_dirs': expected str, bytes or os.PathLike object, not PosixPath