### PR TITLE
fix: Python 3.12 support; remove usage of wstr and use updated PyLong ob_digit location

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -65,6 +65,9 @@ jobs:
       linux-3.11:
         imageName: "ubuntu-latest"
         python.version: '3.11'
+      linux-3.12:
+        imageName: "ubuntu-latest"
+        python.version: '3.12'
       windows-3.7:
         imageName: "windows-2019"
         python.version: '3.7'
@@ -81,6 +84,9 @@ jobs:
       windows-3.11:
         imageName: "windows-2019"
         python.version: '3.11'
+      windows-3.12:
+        imageName: "windows-2019"
+        python.version: '3.12'
       mac-3.9:
         imageName: "macos-11"
         python.version: '3.9'

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -9,6 +9,7 @@ steps:
     version: 11
 
 - script: |
+    python -m pip install --upgrade pytest setuptools
     python setup.py build_ext --inplace
   displayName: 'Build module'
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -9,7 +9,7 @@ steps:
     version: 11
 
 - script: |
-    python -m pip install --upgrade pytest setuptools
+    python -m pip install --upgrade pytest-xdist setuptools
     python setup.py build_ext --inplace
   displayName: 'Build module'
 
@@ -24,7 +24,8 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni
+    # run tests in two workers.
+    python -m pytest -v -n 2 --junit-xml=build/test/test.xml test/jpypetest --checkjni
   displayName: 'Test JDK 11'
   condition: eq(variables['jpypetest.fast'], 'false')
 

--- a/native/common/jp_primitivetype.cpp
+++ b/native/common/jp_primitivetype.cpp
@@ -47,7 +47,11 @@ PyObject *JPPrimitiveType::convertLong(PyTypeObject* wrapper, PyLongObject* tmp)
 	((PyVarObject*) newobj)->ob_size = Py_SIZE(tmp);
 	for (Py_ssize_t i = 0; i < n; i++)
 	{
+        #if PY_VERSION_HEX<0x030C0000
+        newobj->ob_digit[i] = tmp->ob_digit[i];
+        #else
         ((PyLongObject*)newobj)->long_value.ob_digit[i] = ((PyLongObject*)tmp)->long_value.ob_digit[i];
+        #endif
 	}
 	return (PyObject*) newobj;
 }

--- a/native/common/jp_primitivetype.cpp
+++ b/native/common/jp_primitivetype.cpp
@@ -47,7 +47,7 @@ PyObject *JPPrimitiveType::convertLong(PyTypeObject* wrapper, PyLongObject* tmp)
 	((PyVarObject*) newobj)->ob_size = Py_SIZE(tmp);
 	for (Py_ssize_t i = 0; i < n; i++)
 	{
-		newobj->ob_digit[i] = tmp->ob_digit[i];
+        ((PyLongObject*)newobj)->long_value.ob_digit[i] = ((PyLongObject*)tmp)->long_value.ob_digit[i];
 	}
 	return (PyObject*) newobj;
 }

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -34,8 +34,6 @@ struct PyJPChar
 #define _PyUnicode_LENGTH(op) (((PyASCIIObject *)(op))->length)
 #define _PyUnicode_STATE(op) (((PyASCIIObject *)(op))->state)
 #define _PyUnicode_HASH(op) (((PyASCIIObject *)(op))->hash)
-#define _PyUnicode_WSTR(op) (((PyASCIIObject*)(op))->wstr)
-#define _PyUnicode_WSTR_LENGTH(op)  (((PyCompactUnicodeObject*)(op))->wstr_length)
 
 static Py_UCS4 ord(PyObject *c)
 {
@@ -92,7 +90,6 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 	_PyUnicode_STATE(self).kind = PyUnicode_1BYTE_KIND;
 
 	_PyUnicode_STATE(self).ascii = 0;
-	_PyUnicode_STATE(self).ready = 1;
 	_PyUnicode_STATE(self).interned = 0;
 	_PyUnicode_STATE(self).compact = 1;
 
@@ -108,8 +105,6 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		char *data = (char*) ( ((PyCompactUnicodeObject*) self) + 1);
 		data[0] = p;
 		data[1] = 0;
-		_PyUnicode_WSTR_LENGTH(self) = 0;
-		_PyUnicode_WSTR(self) = NULL;
 		self->m_Obj.utf8 = NULL;
 		self->m_Obj.utf8_length = 0;
 	} else
@@ -119,15 +114,6 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		data[0] = p;
 		data[1] = 0;
 		_PyUnicode_STATE(self).kind = PyUnicode_2BYTE_KIND;
-		if (sizeof (wchar_t) == 2)
-		{
-			_PyUnicode_WSTR_LENGTH(self) = 1;
-			_PyUnicode_WSTR(self) = (wchar_t *) data;
-		} else
-		{
-			_PyUnicode_WSTR_LENGTH(self) = 0;
-			_PyUnicode_WSTR(self) = NULL;
-		}
 		self->m_Obj.utf8 = NULL;
 		self->m_Obj.utf8_length = 0;
 	}

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -295,7 +295,11 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 		JP_RAISE_PYTHON();
 	}
 	PyType_Ready(type);
-	PyDict_SetItemString(type->tp_dict, "__module__", PyUnicode_FromString("_jpype"));
+    #if PY_VERSION_HEX<0x030C0000
+    PyDict_SetItemString(type->tp_dict, "__module__", PyUnicode_FromString("_jpype"));
+    #else
+	PyDict_SetItemString(PyType_GetDict(type), "__module__", PyUnicode_FromString("_jpype"));
+    #endif
 	return (PyObject*) type;
 	JP_PY_CATCH(NULL); // GCOVR_EXCL_LINE
 }

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -174,26 +174,22 @@ PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 	for (Py_ssize_t i = 0; i < n; ++i)
 	{
 		PyTypeObject *type2 = (PyTypeObject*) PyTuple_GetItem(mro, i);
-        if (type2->tp_dict != NULL) {
-            PyObject *res = PyDict_GetItem(type2->tp_dict, attr_name);
-            if (res)
-            {
-                Py_INCREF(res);
-                return res;
-            }
-        }
+		PyObject *res = PyDict_GetItem(PyType_GetDict(type2), attr_name);
+		if (res)
+		{
+			Py_INCREF(res);
+			return res;
+		}
 	}
 
 	// Last check is id in the parent
 	{
-        if (Py_TYPE(type)->tp_dict != NULL) {
-            PyObject *res = PyDict_GetItem(Py_TYPE(type)->tp_dict, attr_name);
-            if (res)
-            {
-                Py_INCREF(res);
-                return res;
-            }
-        }
+		PyObject *res = PyDict_GetItem(PyType_GetDict(Py_TYPE(type)), attr_name);
+		if (res)
+		{
+			Py_INCREF(res);
+			return res;
+		}
 	}
 
 	return NULL;

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -174,22 +174,26 @@ PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 	for (Py_ssize_t i = 0; i < n; ++i)
 	{
 		PyTypeObject *type2 = (PyTypeObject*) PyTuple_GetItem(mro, i);
-		PyObject *res = PyDict_GetItem(type2->tp_dict, attr_name);
-		if (res)
-		{
-			Py_INCREF(res);
-			return res;
-		}
+        if (type2->tp_dict != NULL) {
+            PyObject *res = PyDict_GetItem(type2->tp_dict, attr_name);
+            if (res)
+            {
+                Py_INCREF(res);
+                return res;
+            }
+        }
 	}
 
 	// Last check is id in the parent
 	{
-		PyObject *res = PyDict_GetItem(Py_TYPE(type)->tp_dict, attr_name);
-		if (res)
-		{
-			Py_INCREF(res);
-			return res;
-		}
+        if (Py_TYPE(type)->tp_dict != NULL) {
+            PyObject *res = PyDict_GetItem(Py_TYPE(type)->tp_dict, attr_name);
+            if (res)
+            {
+                Py_INCREF(res);
+                return res;
+            }
+        }
 	}
 
 	return NULL;

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -174,7 +174,11 @@ PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 	for (Py_ssize_t i = 0; i < n; ++i)
 	{
 		PyTypeObject *type2 = (PyTypeObject*) PyTuple_GetItem(mro, i);
+        #if PY_VERSION_HEX<0x030C0000
+        PyObject *res = PyDict_GetItem(type2->tp_dict, attr_name);
+        #else
 		PyObject *res = PyDict_GetItem(PyType_GetDict(type2), attr_name);
+        #endif
 		if (res)
 		{
 			Py_INCREF(res);
@@ -184,7 +188,11 @@ PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 
 	// Last check is id in the parent
 	{
+        #if PY_VERSION_HEX<0x030C0000
+        PyObject *res = PyDict_GetItem(Py_TYPE(type)->tp_dict, attr_name);
+        #else
 		PyObject *res = PyDict_GetItem(PyType_GetDict(Py_TYPE(type)), attr_name);
+        #endif
 		if (res)
 		{
 			Py_INCREF(res);


### PR DESCRIPTION
- wstr was removed in CPython 3.12: https://www.python.org/dev/peps/pep-0623
- ob_digit was moved from PyObject to PyLongObject, which is accessible from long_value on PyObject

Investigating a segmentation fault with PyJP_GetAttrDescriptor

```
C  [libpython3.12.so.1.0+0x1f2882]  PyDict_GetItem+0x22
C  [_jpype.cpython-312-x86_64-linux-gnu.so+0x8df43]  PyJP_GetAttrDescriptor+0x73
C  [_jpype.cpython-312-x86_64-linux-gnu.so+0x87758]  PyJPClass_setattro+0x98
```