### PR TITLE
[doc] RTD config renamed to proper file ending.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,9 +20,9 @@ python:
         - docs
 
 build:
-  tools: python
+  tools:
+    python: "3.8"
   os: ubuntu-22.04
-  python: 3.8
   apt_packages:
     - openjdk-8-jdk
 


### PR DESCRIPTION
The config format changed a little bit. Needed to specify a builder image name and specify the python version in another section.