### PR TITLE
Warnings in GCC and VC

### DIFF
--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -103,6 +103,7 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		loadEntryPoints(vmPath);
 	} catch (JPypeException& ex)
 	{
+		(void) ex;
 		throw;
 	}
 

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -224,6 +224,7 @@ void JPypeException::convertJavaToPython()
 		PyException_SetCause(pyvalue.get(), cause.keep());
 	}	catch (JPypeException& ex)
 	{
+		(void) ex;
 		JP_TRACE("FAILURE IN CAUSE");
 		// Any failures in this optional action should be ignored.
 		// worst case we don't print as much diagnostics.

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -59,6 +59,7 @@ extern "C" JNIEXPORT jobject JNICALL Java_org_jpype_proxy_JPypeProxy_hostInvoke(
 
 	// We need the resources to be held for the full duration of the proxy.
 	JPPyCallAcquire callback;
+	try
 	{
 		JP_TRACE_IN("JPype_InvocationHandler_hostInvoke");
 		JP_TRACE("context", context);
@@ -151,6 +152,9 @@ extern "C" JNIEXPORT jobject JNICALL Java_org_jpype_proxy_JPypeProxy_hostInvoke(
 		return nullptr;
 		JP_TRACE_OUT;  // GCOVR_EXCL_LINE
 	}
+	catch (...) // JP_TRACE_OUT implies a throw but that is not allowed. 
+	{}
+	return NULL;
 }
 
 JPProxy::JPProxy(JPContext* context, PyJPProxy* inst, JPClassList& intf)

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -340,7 +340,7 @@ jlong JPPySequence::size()
 
 JPPyObject JPPySequence::operator[](jlong i)
 {
-	return JPPyObject::call(PySequence_GetItem(m_Sequence.get(), i)); // new reference
+	return JPPyObject::call(PySequence_GetItem(m_Sequence.get(), (Py_ssize_t) i)); // new reference
 }
 
 JPPyObjectVector::JPPyObjectVector(PyObject* sequence)

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -295,6 +295,7 @@ int PyJPArray_getBuffer(PyJPArray *self, Py_buffer *view, int flags)
 	} catch (JPypeException &ex)
 	{
 		// No matter what happens we are only allowed to throw BufferError
+		(void) ex;
 		PyErr_SetString(PyExc_BufferError, "Problem in Java buffer extraction");
 		return -1;
 	}
@@ -332,6 +333,7 @@ int PyJPArray_getBuffer(PyJPArray *self, Py_buffer *view, int flags)
 		return 0;
 	} catch (JPypeException &ex) // GCOVR_EXCL_LINE
 	{
+		(void) ex;
 		// GCOVR_EXCL_START
 		// Release the partial buffer so we don't leak
 		PyJPArray_releaseBuffer(self, view);
@@ -393,6 +395,7 @@ int PyJPArrayPrimitive_getBuffer(PyJPArray *self, Py_buffer *view, int flags)
 		return 0;
 	} catch (JPypeException &ex)
 	{
+		(void) ex;
 		PyJPArray_releaseBuffer(self, view);
 
 		// We are only allowed to raise BufferError

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -99,6 +99,7 @@ int PyJPBuffer_getBuffer(PyJPBuffer *self, Py_buffer *view, int flags)
 		return 0;
 	} catch (JPypeException &ex)  // GCOVR_EXCL_LINE
 	{
+		(void) ex;
 		// GCOVR_EXCL_START
 		PyJPBuffer_releaseBuffer(self, view);
 

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -110,7 +110,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		_PyUnicode_STATE(self).kind = PyUnicode_1BYTE_KIND;
 
 		char *data = (char*) (((PyASCIIObject*) self) + 1);
-		data[0] = p;
+		data[0] = (char) p;
 		data[1] = 0;
 	} else if (p < 256)
 	{
@@ -118,7 +118,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		_PyUnicode_STATE(self).kind = PyUnicode_1BYTE_KIND;
 
 		char *data = (char*) ( ((PyCompactUnicodeObject*) self) + 1);
-		data[0] = p;
+		data[0] = (char) p;
 		data[1] = 0;
 	
 #if PY_VERSION_HEX < 0x030c0000

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -545,17 +545,17 @@ PyObject *PyJPModule_gcStats(PyObject* module, PyObject *obj)
 	context->m_GC->getStats(stats);
 	PyObject *out = PyDict_New();
 	PyObject *res;
-	PyDict_SetItemString(out, "current", res = PyLong_FromSsize_t(stats.current_rss));
+	PyDict_SetItemString(out, "current", res = PyLong_FromSsize_t((Py_ssize_t)(stats.current_rss)));
 	Py_DECREF(res);
-	PyDict_SetItemString(out, "java", res = PyLong_FromSsize_t(stats.java_rss));
+	PyDict_SetItemString(out, "java", res = PyLong_FromSsize_t((Py_ssize_t)(stats.java_rss)));
 	Py_DECREF(res);
-	PyDict_SetItemString(out, "python", res = PyLong_FromSsize_t(stats.python_rss));
+	PyDict_SetItemString(out, "python", res = PyLong_FromSsize_t((Py_ssize_t)(stats.python_rss)));
 	Py_DECREF(res);
-	PyDict_SetItemString(out, "max", res = PyLong_FromSsize_t(stats.max_rss));
+	PyDict_SetItemString(out, "max", res = PyLong_FromSsize_t((Py_ssize_t)(stats.max_rss)));
 	Py_DECREF(res);
-	PyDict_SetItemString(out, "min", res = PyLong_FromSsize_t(stats.min_rss));
+	PyDict_SetItemString(out, "min", res = PyLong_FromSsize_t((Py_ssize_t)(stats.min_rss)));
 	Py_DECREF(res);
-	PyDict_SetItemString(out, "triggered", res = PyLong_FromSsize_t(stats.python_triggered));
+	PyDict_SetItemString(out, "triggered", res = PyLong_FromSsize_t((Py_ssize_t)(stats.python_triggered)));
 	Py_DECREF(res);
 	return out;
 }


### PR DESCRIPTION
This PR deals with warnings that are currently triggering in VC and GCC.

- Local variables not used on exception catches
- Mismatched types between primitives requiring casts
- A throw path on extern "C" that must not be allowed to propagate or it will trigger a segfault.

