### PR TITLE
Windows locale

### DIFF
--- a/native/common/jp_platform.cpp
+++ b/native/common/jp_platform.cpp
@@ -64,7 +64,13 @@ public:
 	virtual void loadLibrary(const char* path) override
 	{
 		JP_TRACE_IN("Win32PlatformAdapter::loadLibrary");
-		jvmLibrary = LoadLibrary(path);
+        wchar_t *wpath = Py_DecodeLocale(path, NULL);
+        if (wpath == NULL)
+        {
+            JP_RAISE(PyExc_SystemError, "Unable to get JVM path with locale.");
+        }
+		jvmLibrary = LoadLibraryW(wpath);
+        PyMem_RawFree(wpath);
 		if (jvmLibrary == NULL)
 		{
 			JP_RAISE_OS_ERROR_WINDOWS( GetLastError(), path);

--- a/native/common/jp_platform.cpp
+++ b/native/common/jp_platform.cpp
@@ -64,13 +64,13 @@ public:
 	virtual void loadLibrary(const char* path) override
 	{
 		JP_TRACE_IN("Win32PlatformAdapter::loadLibrary");
-        wchar_t *wpath = Py_DecodeLocale(path, NULL);
-        if (wpath == NULL)
-        {
-            JP_RAISE(PyExc_SystemError, "Unable to get JVM path with locale.");
-        }
+		wchar_t *wpath = Py_DecodeLocale(path, NULL);
+		if (wpath == NULL)
+		{
+			JP_RAISE(PyExc_SystemError, "Unable to get JVM path with locale.");
+		}
 		jvmLibrary = LoadLibraryW(wpath);
-        PyMem_RawFree(wpath);
+		PyMem_RawFree(wpath);
 		if (jvmLibrary == NULL)
 		{
 			JP_RAISE_OS_ERROR_WINDOWS( GetLastError(), path);


### PR DESCRIPTION
This is an attempt to make JPype work when there are international characters in the path name.   Currently does not appear to make a significant difference because the JVM itself does not support it on the tested system.