### PR TITLE
Fix error in 3.12 during exception handling

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -6,6 +6,7 @@ This changelog *only* contains changes from the *first* pypi release (0.5.4.3) o
 Latest Changes:
 
 - **1.5.1_dev0 - 2023-12-15**
+  - Fixed uncaught exception while setting traceback causing issues in Python 3.11/3.12.
   - Use PEP-518 and PEP-660 configuration for the package, allowing editable and
     configurable builds using modern Python packaging tooling.
     Where before ``python setup.py --enable-tracing develop``, now can be done with

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -220,7 +220,8 @@ void JPypeException::convertJavaToPython()
 			PyJPException_normalize(frame, prev, jcause, th);
 			PyException_SetCause(cause.get(), prev.keep());
 		}
-		PyException_SetTraceback(cause.get(), trace.get());
+		if (trace.get() != nullptr)
+			PyException_SetTraceback(cause.get(), trace.get());
 		PyException_SetCause(pyvalue.get(), cause.keep());
 	}	catch (JPypeException& ex)
 	{

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -390,7 +390,7 @@ void PyJPException_normalize(JPJavaFrame frame, JPPyObject exc, jthrowable th, j
 	{
 		// Attach the frame to first
 		JPPyObject trace = PyTrace_FromJavaException(frame, th, enclosing);
-		if (trace.get()!=nullptr)
+		if (trace.get() != nullptr)
 			PyException_SetTraceback(exc.get(), trace.get());
 
 		// Check for the next in the cause list

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -390,7 +390,8 @@ void PyJPException_normalize(JPJavaFrame frame, JPPyObject exc, jthrowable th, j
 	{
 		// Attach the frame to first
 		JPPyObject trace = PyTrace_FromJavaException(frame, th, enclosing);
-		PyException_SetTraceback(exc.get(), trace.get());
+		if (trace.get()!=nullptr)
+			PyException_SetTraceback(exc.get(), trace.get());
 
 		// Check for the next in the cause list
 		enclosing = th;


### PR DESCRIPTION
While trying to examine user reported issue #1178, I found that exception handling was getting caught on an unhandled exception.   The root source of the issue it that if we don't set a traceback then it produced NULL to the PyExeception_SetTraceback.   The exception was meaningless and (mostly) harmless, but due to other changes in Python it was not cleared by the PyErr_SetString method and thus remained set through to a PyObject_IsInstance call which then through a SystemError.   

To fix this error I added an "if" statement to avoid setting the traceback if there is nothing meaningful to set.  We should technically be checking every single return value from Python CAPI calls, rather than blindly plowing forward.   But that would be a huge modification.

The underlying Python code that triggered the exception is odd....
```
static int
BaseException_set_tb(PyBaseExceptionObject *self, PyObject *tb)
{
    if (tb == NULL) {
        PyErr_SetString(PyExc_TypeError, "__traceback__ may not be deleted");
        return -1;
    }
    else if (!(tb == Py_None || PyTraceBack_Check(tb))) {
        PyErr_SetString(PyExc_TypeError,
                        "__traceback__ must be a traceback or None");
        return -1;
    }

    Py_XINCREF(tb);
    Py_XDECREF(self->traceback);
    self->traceback = tb;
    return 0;
}
```

If tb is NULL then it is an invalid input, but the message "may not be deleted" doesn't really tell the user anything about what has gone wrong.

It is unclear if this is the same problem the user was reporting as I wasn't able to replicate the exact issue reported.   Though given it was down the same code path I suspect it will be addressed.