### PR TITLE
Changes for numpy 2.0 to fix test matrix.

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -19,6 +19,11 @@ Latest Changes:
     For editable installs, ``python setup.py --enable-tracing develop``
     must now be done with ``python setup.py develop --enable-tracing``.
 
+  - Update for tests for numpy 2.0.
+
+  - Support of np.float16 conversion with arrays.
+
+
 - **1.5.0 - 2023-04-03**
 
   - Support for Python 3.12

--- a/test/jpypetest/test_buffer.py
+++ b/test/jpypetest/test_buffer.py
@@ -315,11 +315,11 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JByte[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -328,11 +328,12 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JInt[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
+            print(dtype)
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -341,11 +342,11 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JShort[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -354,11 +355,11 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JLong[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -367,11 +368,11 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JFloat[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -380,11 +381,11 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JDouble[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -393,11 +394,11 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JBoolean[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "f", "d", "n", "N"):
+        for dtype in "c?bBhHiIlLqQfdnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 
-        for dtype in ("s", "p", "P", "e"):
+        for dtype in "spP":
             with self.assertRaises(Exception):
                 jtype(mv.cast(dtype))
 
@@ -406,7 +407,7 @@ class BufferTestCase(common.JPypeTestCase):
         jtype = jpype.JChar[:]
 
         # Simple checks
-        for dtype in ("c", "?", "b", "B", "h", "H", "i", "I", "l", "L", "q", "Q", "n", "N"):
+        for dtype in "c?bBhHiIlLqQnN":
             jtype(mv.cast(dtype))
             jtype(mv.cast("@" + dtype))
 

--- a/test/jpypetest/test_conversionInt.py
+++ b/test/jpypetest/test_conversionInt.py
@@ -73,10 +73,10 @@ class ConversionIntTestCase(common.JPypeTestCase):
             self.Test.callInt(float(2))
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testIntFromNPFloat(self):
+    def testIntFromNPFloat16(self):
         import numpy as np
         with self.assertRaises(TypeError):
-            self.Test.callInt(np.float_(2))
+            self.Test.callInt(np.float16(2))
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testIntFromNPFloat32(self):

--- a/test/jpypetest/test_conversionLong.py
+++ b/test/jpypetest/test_conversionLong.py
@@ -73,10 +73,10 @@ class ConversionLongTestCase(common.JPypeTestCase):
             self.Test.callLong(float(2))
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testLongFromNPFloat(self):
+    def testLongFromNPFloat16(self):
         import numpy as np
         with self.assertRaises(TypeError):
-            self.Test.callLong(np.float_(2))
+            self.Test.callLong(np.float16(2))
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testLongFromNPFloat32(self):

--- a/test/jpypetest/test_conversionShort.py
+++ b/test/jpypetest/test_conversionShort.py
@@ -73,10 +73,10 @@ class ConversionShortTestCase(common.JPypeTestCase):
             self.Test.callShort(float(2))
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
-    def testShortFromNPFloat(self):
+    def testShortFromNPFloat16(self):
         import numpy as np
         with self.assertRaises(TypeError):
-            self.Test.callShort(np.float_(2))
+            self.Test.callShort(np.float16(2))
 
     @common.unittest.skipUnless(haveNumpy(), "numpy not available")
     def testShortFromNPFloat32(self):

--- a/test/jpypetest/test_jboolean.py
+++ b/test/jpypetest/test_jboolean.py
@@ -100,10 +100,10 @@ class JBooleanTestCase(common.JPypeTestCase):
             self.Test.callBoolean(float(2))
 
     @common.requireNumpy
-    def testBooleanFromNPFloat(self):
+    def testBooleanFromNPFloat16(self):
         import numpy as np
         with self.assertRaises(TypeError):
-            self.Test.callBoolean(np.float_(2))
+            self.Test.callBoolean(np.float16(2))
 
     @common.requireNumpy
     def testBooleanFromNPFloat32(self):

--- a/test/jpypetest/test_jbyte.py
+++ b/test/jpypetest/test_jbyte.py
@@ -108,10 +108,10 @@ class JByteTestCase(common.JPypeTestCase):
             self.fixture.callByte(float(2))
 
     @common.requireNumpy
-    def testByteFromNPFloat(self):
+    def testByteFromNPFloat16(self):
         import numpy as np
         with self.assertRaises(TypeError):
-            self.fixture.callByte(np.float_(2))
+            self.fixture.callByte(np.float16(2))
 
     @common.requireNumpy
     def testByteFromNPFloat32(self):

--- a/test/jpypetest/test_jdouble.py
+++ b/test/jpypetest/test_jdouble.py
@@ -374,8 +374,8 @@ class JDoubleTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(a, jarr)
 
     @common.requireNumpy
-    def testArrayInitFromNPFloat(self):
-        a = np.random.random(100).astype(np.float_)
+    def testArrayInitFromNPFloat16(self):
+        a = np.random.random(100).astype(np.float16)
         jarr = JArray(JDouble)(a)
         self.assertElementsAlmostEqual(a, jarr)
 
@@ -436,3 +436,15 @@ class JDoubleTestCase(common.JPypeTestCase):
 
     def testCastBoolean(self):
         self.assertEqual(JDouble._canConvertToJava(JBoolean(True)), "none")
+
+    @common.requireNumpy
+    def testNPFloat16(self):
+        v= [0.000000e+00, 5.960464e-08, 1.788139e-07, 1.788139e-07, 4.172325e-07, 8.940697e-07, 1.847744e-06, 3.755093e-06, 7.569790e-06, 1.519918e-05, 3.045797e-05, 6.097555e-05, 6.103516e-05, 3.332520e-01, 1.000000e+00, 6.550400e+04, np.inf, -np.inf]
+        a = np.array(v, dtype=np.float16)
+        jarr = JArray(JDouble)(a)
+        for v1,v2 in zip(a, jarr):
+            self.assertEqual(v1,v2)
+        a = np.array([np.nan], dtype=np.float16)
+        jarr = JArray(JDouble)(a)
+        self.assertTrue(np.isnan(jarr[0]))
+

--- a/test/jpypetest/test_jfloat.py
+++ b/test/jpypetest/test_jfloat.py
@@ -382,8 +382,8 @@ class JFloatTestCase(common.JPypeTestCase):
         self.assertElementsAlmostEqual(a, jarr)
 
     @common.requireNumpy
-    def testArrayInitFromNPFloat(self):
-        a = np.random.random(100).astype(np.float_)
+    def testArrayInitFromNPFloat16(self):
+        a = np.random.random(100).astype(np.float16)
         jarr = JArray(JFloat)(a)
         self.assertElementsAlmostEqual(a, jarr)
 
@@ -441,3 +441,15 @@ class JFloatTestCase(common.JPypeTestCase):
             ja[:] = [1, 2, 3]
         with self.assertRaisesRegex(ValueError, "mismatch"):
             ja[:] = a
+
+    @common.requireNumpy
+    def testNPFloat16(self):
+        v= [0.000000e+00, 5.960464e-08, 1.788139e-07, 1.788139e-07, 4.172325e-07, 8.940697e-07, 1.847744e-06, 3.755093e-06, 7.569790e-06, 1.519918e-05, 3.045797e-05, 6.097555e-05, 6.103516e-05, 3.332520e-01, 1.000000e+00, 6.550400e+04, np.inf, -np.inf]
+        a = np.array(v, dtype=np.float16)
+        jarr = JArray(JFloat)(a)
+        for v1,v2 in zip(a, jarr):
+            self.assertEqual(v1,v2)
+        a = np.array([np.nan], dtype=np.float16)
+        jarr = JArray(JFloat)(a)
+        self.assertTrue(np.isnan(jarr[0]))
+


### PR DESCRIPTION
This PR deals with the broken test matrix following the removal for ``float_``.   I replaced it with ``float16`` though that is actually a different test.   I dealt with the required alterations to support ``half`` type for array conversion, though I can't find a good pattern to deal with byte reversed arrays so that may be untested.   