### PR TITLE
prevent misuse of PyTuple_Pack

### DIFF
--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -176,6 +176,11 @@ struct _object;
 using PyObject = _object;
 #endif
 
+template <typename... T>
+static inline constexpr PyObject *JPPyTuple_Pack(T... args) {
+	return PyTuple_Pack(sizeof...(T), args...);
+}
+
 // Base utility headers
 #include "jp_javaframe.h"
 #include "jp_context.h"

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -176,9 +176,11 @@ struct _object;
 using PyObject = _object;
 #endif
 
+#include "jp_pythontypes.h"
+
 template <typename... T>
-static inline constexpr PyObject *JPPyTuple_Pack(T... args) {
-	return PyTuple_Pack(sizeof...(T), args...);
+static inline JPPyObject JPPyTuple_Pack(T... args) {
+	return JPPyObject::call(PyTuple_Pack(sizeof...(T), args...));
 }
 
 // Base utility headers
@@ -186,7 +188,6 @@ static inline constexpr PyObject *JPPyTuple_Pack(T... args) {
 #include "jp_context.h"
 #include "jp_exception.h"
 #include "jp_tracer.h"
-#include "jp_pythontypes.h"
 #include "jp_typemanager.h"
 #include "jp_encoding.h"
 #include "jp_modifier.h"

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -372,15 +372,15 @@ JPPyObject JPClass::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool
 			jstring m = frame.getMessage((jthrowable) value.l);
 			if (m != nullptr)
 			{
-				tuple0 = JPPyObject::call(PyTuple_Pack(1,
+				tuple0 = JPPyObject::call(JPPyTuple_Pack(
 						JPPyString::fromStringUTF8(frame.toStringUTF8(m)).get()));
 			} else
 			{
-				tuple0 = JPPyObject::call(PyTuple_Pack(1,
+				tuple0 = JPPyObject::call(JPPyTuple_Pack(
 						JPPyString::fromStringUTF8(frame.toString(value.l)).get()));
 			}
 		}
-		JPPyObject tuple1 = JPPyObject::call(PyTuple_Pack(2,
+		JPPyObject tuple1 = JPPyObject::call(JPPyTuple_Pack(
 				_JObjectKey, tuple0.get()));
 		// Exceptions need new and init
 		obj = JPPyObject::call(PyObject_Call(wrapper.get(), tuple1.get(), nullptr));

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -372,16 +372,15 @@ JPPyObject JPClass::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool
 			jstring m = frame.getMessage((jthrowable) value.l);
 			if (m != nullptr)
 			{
-				tuple0 = JPPyObject::call(JPPyTuple_Pack(
-						JPPyString::fromStringUTF8(frame.toStringUTF8(m)).get()));
+				tuple0 = JPPyTuple_Pack(
+						JPPyString::fromStringUTF8(frame.toStringUTF8(m)).get());
 			} else
 			{
-				tuple0 = JPPyObject::call(JPPyTuple_Pack(
-						JPPyString::fromStringUTF8(frame.toString(value.l)).get()));
+				tuple0 = JPPyTuple_Pack(
+						JPPyString::fromStringUTF8(frame.toString(value.l)).get());
 			}
 		}
-		JPPyObject tuple1 = JPPyObject::call(JPPyTuple_Pack(
-				_JObjectKey, tuple0.get()));
+		JPPyObject tuple1 = JPPyTuple_Pack(_JObjectKey, tuple0.get());
 		// Exceptions need new and init
 		obj = JPPyObject::call(PyObject_Call(wrapper.get(), tuple1.get(), nullptr));
 	} else

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -146,7 +146,7 @@ public:
 	{
 		JP_TRACE_IN("JPPythonConversion::convert");
 		JPClass *cls = ((JPClass*) match.closure);
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(2,
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
 				cls->getHost(), match.object));
 		JPPyObject ret = JPPyObject::call(PyObject_Call(method_.get(), args.get(), nullptr));
 		JPValue *value = PyJPValue_getJavaSlot(ret.get());

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -146,8 +146,7 @@ public:
 	{
 		JP_TRACE_IN("JPPythonConversion::convert");
 		JPClass *cls = ((JPClass*) match.closure);
-		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
-				cls->getHost(), match.object));
+		JPPyObject args = JPPyTuple_Pack(cls->getHost(), match.object);
 		JPPyObject ret = JPPyObject::call(PyObject_Call(method_.get(), args.get(), nullptr));
 		JPValue *value = PyJPValue_getJavaSlot(ret.get());
 		if (value != nullptr)

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -512,7 +512,7 @@ PyObject *tb_create(
 	JPPyObject lasti = JPPyObject::claim(PyLong_FromLong(PyFrame_GetLasti(pframe)));
 #endif
 	JPPyObject linenuma = JPPyObject::claim(PyLong_FromLong(linenum));
-	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(Py_None, frame.get(), lasti.get(), linenuma.get()));
+	JPPyObject tuple = JPPyTuple_Pack(Py_None, frame.get(), lasti.get(), linenuma.get());
 	JPPyObject traceback = JPPyObject::accept(PyObject_Call((PyObject*) &PyTraceBack_Type, tuple.get(), NULL));
 
 	// We could fail in process

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -512,7 +512,7 @@ PyObject *tb_create(
 	JPPyObject lasti = JPPyObject::claim(PyLong_FromLong(PyFrame_GetLasti(pframe)));
 #endif
 	JPPyObject linenuma = JPPyObject::claim(PyLong_FromLong(linenum));
-	JPPyObject tuple = JPPyObject::call(PyTuple_Pack(4, Py_None, frame.get(), lasti.get(), linenuma.get()));
+	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(Py_None, frame.get(), lasti.get(), linenuma.get()));
 	JPPyObject traceback = JPPyObject::accept(PyObject_Call((PyObject*) &PyTraceBack_Type, tuple.get(), NULL));
 
 	// We could fail in process

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -483,7 +483,7 @@ void JPPyErrFrame::normalize()
 	// we have forced it to realize the exception.
 	if (!PyExceptionInstance_Check(m_ExceptionValue.get()))
 	{
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(1, m_ExceptionValue.get()));
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(m_ExceptionValue.get()));
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
 		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -483,7 +483,7 @@ void JPPyErrFrame::normalize()
 	// we have forced it to realize the exception.
 	if (!PyExceptionInstance_Check(m_ExceptionValue.get()))
 	{
-		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(m_ExceptionValue.get()));
+		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
 		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -484,7 +484,7 @@ static PyType_Spec arrayPrimSpec = {
 
 void PyJPArray_initType(PyObject * module)
 {
-	JPPyObject tuple = JPPyObject::call(PyTuple_Pack(1, PyJPObject_Type));
+	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(PyJPObject_Type));
 	PyJPArray_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&arraySpec, tuple.get());
 	JP_PY_CHECK();
 #if PY_VERSION_HEX < 0x03090000
@@ -493,7 +493,7 @@ void PyJPArray_initType(PyObject * module)
 	PyModule_AddObject(module, "_JArray", (PyObject*) PyJPArray_Type);
 	JP_PY_CHECK();
 
-	tuple = JPPyObject::call(PyTuple_Pack(1, PyJPArray_Type));
+	tuple = JPPyObject::call(JPPyTuple_Pack(PyJPArray_Type));
 	PyJPArrayPrimitive_Type = (PyTypeObject*)
 			PyJPClass_FromSpecWithBases(&arrayPrimSpec, tuple.get());
 #if PY_VERSION_HEX < 0x03090000

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -484,7 +484,7 @@ static PyType_Spec arrayPrimSpec = {
 
 void PyJPArray_initType(PyObject * module)
 {
-	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(PyJPObject_Type));
+	JPPyObject tuple = JPPyTuple_Pack(PyJPObject_Type);
 	PyJPArray_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&arraySpec, tuple.get());
 	JP_PY_CHECK();
 #if PY_VERSION_HEX < 0x03090000
@@ -493,7 +493,7 @@ void PyJPArray_initType(PyObject * module)
 	PyModule_AddObject(module, "_JArray", (PyObject*) PyJPArray_Type);
 	JP_PY_CHECK();
 
-	tuple = JPPyObject::call(JPPyTuple_Pack(PyJPArray_Type));
+	tuple = JPPyTuple_Pack(PyJPArray_Type);
 	PyJPArrayPrimitive_Type = (PyTypeObject*)
 			PyJPClass_FromSpecWithBases(&arrayPrimSpec, tuple.get());
 #if PY_VERSION_HEX < 0x03090000

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -143,7 +143,7 @@ static PyType_Spec bufferSpec = {
 
 void PyJPBuffer_initType(PyObject * module)
 {
-	JPPyObject tuple = JPPyObject::call(PyTuple_Pack(1, PyJPObject_Type));
+	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(PyJPObject_Type));
 	PyJPBuffer_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&bufferSpec, tuple.get());
 #if PY_VERSION_HEX < 0x03090000
 	PyJPBuffer_Type->tp_as_buffer = &directBuffer;

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -143,7 +143,7 @@ static PyType_Spec bufferSpec = {
 
 void PyJPBuffer_initType(PyObject * module)
 {
-	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(PyJPObject_Type));
+	JPPyObject tuple = JPPyTuple_Pack(PyJPObject_Type);
 	PyJPBuffer_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&bufferSpec, tuple.get());
 #if PY_VERSION_HEX < 0x03090000
 	PyJPBuffer_Type->tp_as_buffer = &directBuffer;

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -212,7 +212,7 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 	if (cv != (Py_UCS4) - 1)
 	{
 		JPPyObject v = JPPyObject::call(PyLong_FromLong(cv));
-		JPPyObject args0 = JPPyObject::call(JPPyTuple_Pack(v.get()));
+		JPPyObject args0 = JPPyTuple_Pack(v.get());
 		JPPyObjectVector args(args0.get());
 		jv = cls->newInstance(frame, args);
 	} else if (PyIndex_Check(in))
@@ -222,7 +222,7 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 	} else if (PyFloat_Check(in))
 	{
 		JPPyObject v = JPPyObject::call(PyNumber_Long(in));
-		JPPyObject args0 = JPPyObject::call(JPPyTuple_Pack(v.get()));
+		JPPyObject args0 = JPPyTuple_Pack(v.get());
 		JPPyObjectVector args(args0.get());
 		jv = cls->newInstance(frame, args);
 	} else
@@ -655,9 +655,8 @@ static PyType_Spec charSpec = {
 void PyJPChar_initType(PyObject* module)
 {
 	// We will inherit from str and JObject
-	PyObject *bases = JPPyTuple_Pack(&PyUnicode_Type, PyJPObject_Type);
-	PyJPChar_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&charSpec, bases);
-	Py_DECREF(bases);
+	JPPyObject bases = JPPyTuple_Pack(&PyUnicode_Type, PyJPObject_Type);
+	PyJPChar_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&charSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JChar", (PyObject*) PyJPChar_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -91,7 +91,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 	self->m_Data[3] = 0;
 
 	// Values taken from internal/cpython/unicode.h
-	
+
 	// Mark the type in unicode
 	_PyUnicode_LENGTH(self) = 1;
 	_PyUnicode_HASH(self) = -1;
@@ -120,7 +120,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		char *data = (char*) ( ((PyCompactUnicodeObject*) self) + 1);
 		data[0] = (char) p;
 		data[1] = 0;
-	
+
 #if PY_VERSION_HEX < 0x030c0000
 		_PyUnicode_WSTR_LENGTH(self) = 0;
 		_PyUnicode_WSTR(self) = nullptr;
@@ -212,7 +212,7 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 	if (cv != (Py_UCS4) - 1)
 	{
 		JPPyObject v = JPPyObject::call(PyLong_FromLong(cv));
-		JPPyObject args0 = JPPyObject::call(PyTuple_Pack(1, v.get()));
+		JPPyObject args0 = JPPyObject::call(JPPyTuple_Pack(v.get()));
 		JPPyObjectVector args(args0.get());
 		jv = cls->newInstance(frame, args);
 	} else if (PyIndex_Check(in))
@@ -222,7 +222,7 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 	} else if (PyFloat_Check(in))
 	{
 		JPPyObject v = JPPyObject::call(PyNumber_Long(in));
-		JPPyObject args0 = JPPyObject::call(PyTuple_Pack(1, v.get()));
+		JPPyObject args0 = JPPyObject::call(JPPyTuple_Pack(v.get()));
 		JPPyObjectVector args(args0.get());
 		jv = cls->newInstance(frame, args);
 	} else
@@ -325,7 +325,7 @@ static PyObject *apply(PyObject *first, PyObject *second, PyObject* (*func)(PyOb
 	JPValue *slot0 = PyJPValue_getJavaSlot(first);
 	JPValue *slot1 = PyJPValue_getJavaSlot(second);
 	if (slot0 != nullptr && slot1 != nullptr)
-	{	
+	{
 		if (assertNotNull(slot0))
 			return nullptr;
 		if (assertNotNull(slot1))
@@ -385,7 +385,7 @@ static  PyObject *PyJPChar_add(PyObject *first, PyObject *second)
 	JPValue *slot0 = PyJPValue_getJavaSlot(first);
 	JPValue *slot1 = PyJPValue_getJavaSlot(second);
 	if (slot1 != nullptr && slot0 != nullptr)
-	{	
+	{
 		if (assertNotNull(slot0))
 			return nullptr;
 		if (assertNotNull(slot1))
@@ -655,7 +655,7 @@ static PyType_Spec charSpec = {
 void PyJPChar_initType(PyObject* module)
 {
 	// We will inherit from str and JObject
-	PyObject *bases = PyTuple_Pack(2, &PyUnicode_Type, PyJPObject_Type);
+	PyObject *bases = JPPyTuple_Pack(&PyUnicode_Type, PyJPObject_Type);
 	PyJPChar_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&charSpec, bases);
 	Py_DECREF(bases);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -148,7 +148,7 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 	heap->ht_name = heap->ht_qualname;
 	Py_INCREF(heap->ht_name);
 	if (bases == nullptr)
-		type->tp_bases = PyTuple_Pack(1, (PyObject*) & PyBaseObject_Type);
+		type->tp_bases = JPPyTuple_Pack((PyObject*) & PyBaseObject_Type);
 	else
 	{
 		type->tp_bases = bases;
@@ -935,7 +935,7 @@ static PyObject *PyJPClass_getDoc(PyJPClass *self, void *ctxt)
 	// Pack the arguments
 	{
 		JP_TRACE("Pack arguments");
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(1, self));
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(self));
 		JP_TRACE("Call Python");
 		self->m_Doc = PyObject_Call(_JClassDoc, args.get(), nullptr);
 		Py_XINCREF(self->m_Doc);
@@ -1021,7 +1021,7 @@ static PyType_Spec classSpec = {
 
 void PyJPClass_initType(PyObject* module)
 {
-	PyObject *bases = PyTuple_Pack(1, &PyType_Type);
+	PyObject *bases = JPPyTuple_Pack(&PyType_Type);
 	PyJPClass_Type = (PyTypeObject*) PyType_FromSpecWithBases(&classSpec, bases);
 	Py_DECREF(bases);
 	JP_PY_CHECK();
@@ -1160,7 +1160,7 @@ void PyJPClass_hook(JPJavaFrame &frame, JPClass* cls)
 
 
 	JPPyObject members = JPPyObject::call(PyDict_New());
-	JPPyObject args = JPPyObject::call(PyTuple_Pack(3,
+	JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
 			JPPyString::fromStringUTF8(cls->getCanonicalName()).get(),
 			PyJPClass_getBases(frame, cls).get(),
 			members.get()));
@@ -1216,6 +1216,6 @@ void PyJPClass_hook(JPJavaFrame &frame, JPClass* cls)
 
 	// Call the post load routine to attach inner classes
 	JP_TRACE("call post");
-	args = JPPyObject::call(PyTuple_Pack(1, self));
+	args = JPPyObject::call(JPPyTuple_Pack(self));
 	JPPyObject rc2 = JPPyObject::call(PyObject_Call(_JClassPost, args.get(), nullptr));
 }

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -216,7 +216,7 @@ static PyObject *PyJPMethod_getDoc(PyJPMethod *self, void *ctxt)
 		jvalue v;
 		v.l = (jobject) self->m_Method->getClass()->getJavaClass();
 		JPPyObject obj(context->_java_lang_Class->convertToPythonObject(frame, v, true));
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(3,
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
 				self, obj.get(), ov.get()));
 		JP_TRACE("Call Python");
 		self->m_Doc = PyObject_Call(_JMethodDoc, args.get(), nullptr);
@@ -268,7 +268,7 @@ PyObject *PyJPMethod_getAnnotations(PyJPMethod *self, void *ctxt)
 		jvalue v;
 		v.l = (jobject) self->m_Method->getClass()->getJavaClass();
 		JPPyObject obj(context->_java_lang_Class->convertToPythonObject(frame, v, true));
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(3,
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
 				self, obj.get(), ov.get()));
 		JP_TRACE("Call Python");
 		self->m_Annotations = PyObject_Call(_JMethodAnnotations, args.get(), nullptr);
@@ -293,7 +293,7 @@ PyObject *PyJPMethod_getCodeAttr(PyJPMethod *self, void *ctx, const char *attr)
 	PyJPModule_getContext();
 	if (self->m_CodeRep == nullptr)
 	{
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(1, self));
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(self));
 		JP_TRACE("Call Python");
 		self->m_CodeRep = PyObject_Call(_JMethodCode, args.get(), nullptr);
 	}
@@ -396,7 +396,7 @@ void PyJPMethod_initType(PyObject* module)
 	// We inherit from PyFunction_Type just so we are an instance
 	// for purposes of inspect and tab completion tools.  But
 	// we will just ignore their memory layout as we have our own.
-	JPPyObject tuple = JPPyObject::call(PyTuple_Pack(1, &PyFunction_Type));
+	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(&PyFunction_Type));
 	unsigned long flags = PyFunction_Type.tp_flags;
 	PyFunction_Type.tp_flags |= Py_TPFLAGS_BASETYPE;
 	PyJPMethod_Type = (PyTypeObject*) PyType_FromSpecWithBases(&methodSpec, tuple.get());

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -216,8 +216,7 @@ static PyObject *PyJPMethod_getDoc(PyJPMethod *self, void *ctxt)
 		jvalue v;
 		v.l = (jobject) self->m_Method->getClass()->getJavaClass();
 		JPPyObject obj(context->_java_lang_Class->convertToPythonObject(frame, v, true));
-		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
-				self, obj.get(), ov.get()));
+		JPPyObject args = JPPyTuple_Pack(self, obj.get(), ov.get());
 		JP_TRACE("Call Python");
 		self->m_Doc = PyObject_Call(_JMethodDoc, args.get(), nullptr);
 		Py_XINCREF(self->m_Doc);
@@ -268,8 +267,7 @@ PyObject *PyJPMethod_getAnnotations(PyJPMethod *self, void *ctxt)
 		jvalue v;
 		v.l = (jobject) self->m_Method->getClass()->getJavaClass();
 		JPPyObject obj(context->_java_lang_Class->convertToPythonObject(frame, v, true));
-		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(
-				self, obj.get(), ov.get()));
+		JPPyObject args = JPPyTuple_Pack(self, obj.get(), ov.get());
 		JP_TRACE("Call Python");
 		self->m_Annotations = PyObject_Call(_JMethodAnnotations, args.get(), nullptr);
 	}
@@ -293,7 +291,7 @@ PyObject *PyJPMethod_getCodeAttr(PyJPMethod *self, void *ctx, const char *attr)
 	PyJPModule_getContext();
 	if (self->m_CodeRep == nullptr)
 	{
-		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(self));
+		JPPyObject args = JPPyTuple_Pack(self);
 		JP_TRACE("Call Python");
 		self->m_CodeRep = PyObject_Call(_JMethodCode, args.get(), nullptr);
 	}
@@ -396,7 +394,7 @@ void PyJPMethod_initType(PyObject* module)
 	// We inherit from PyFunction_Type just so we are an instance
 	// for purposes of inspect and tab completion tools.  But
 	// we will just ignore their memory layout as we have our own.
-	JPPyObject tuple = JPPyObject::call(JPPyTuple_Pack(&PyFunction_Type));
+	JPPyObject tuple = JPPyTuple_Pack(&PyFunction_Type);
 	unsigned long flags = PyFunction_Type.tp_flags;
 	PyFunction_Type.tp_flags |= Py_TPFLAGS_BASETYPE;
 	PyJPMethod_Type = (PyTypeObject*) PyType_FromSpecWithBases(&methodSpec, tuple.get());

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -270,9 +270,8 @@ static PyObject *PyJPBoolean_new(PyTypeObject *type, PyObject *args, PyObject *k
 		return nullptr;
 	}
 	int i = PyObject_IsTrue(PyTuple_GetItem(args, 0));
-	PyObject *args2 = JPPyTuple_Pack(PyLong_FromLong(i));
-	self = JPPyObject::call(PyLong_Type.tp_new(type, args2, kwargs));
-	Py_DECREF(args2);
+	JPPyObject args2 = JPPyTuple_Pack(PyLong_FromLong(i));
+	self = JPPyObject::call(PyLong_Type.tp_new(type, args2.get(), kwargs));
 	JPClass *cls = PyJPClass_getJPClass((PyObject*) type);
 	if (cls == nullptr)
 	{
@@ -371,25 +370,21 @@ PyType_Spec numberBooleanSpec = {
 
 void PyJPNumber_initType(PyObject* module)
 {
-	PyObject *bases;
 
-	bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
-	PyJPNumberLong_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberLongSpec, bases);
-	Py_DECREF(bases);
+	JPPyObject bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
+	PyJPNumberLong_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberLongSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JNumberLong", (PyObject*) PyJPNumberLong_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
 	bases = JPPyTuple_Pack(&PyFloat_Type, PyJPObject_Type);
-	PyJPNumberFloat_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberFloatSpec, bases);
-	Py_DECREF(bases);
+	PyJPNumberFloat_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberFloatSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JNumberFloat", (PyObject*) PyJPNumberFloat_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
 	bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
-	PyJPNumberBool_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberBooleanSpec, bases);
-	Py_DECREF(bases);
+	PyJPNumberBool_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberBooleanSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JBoolean", (PyObject*) PyJPNumberBool_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
@@ -404,8 +399,8 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 		jlong l = 0;
 		if (value.getValue().l != nullptr)
 			l = frame.CallBooleanMethodA(value.getJavaObject(), context->_java_lang_Boolean->m_BooleanValueID, nullptr);
-		PyObject *args = JPPyTuple_Pack(PyLong_FromLongLong(l));
-		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args, nullptr));
+		JPPyObject args = JPPyTuple_Pack(PyLong_FromLongLong(l));
+		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args.get(), nullptr));
 	}
 	if (PyObject_IsSubclass(wrapper.get(), (PyObject*) & PyLong_Type))
 	{
@@ -415,8 +410,8 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 			auto* jb = dynamic_cast<JPBoxedType*>( value.getClass());
 			l = frame.CallLongMethodA(value.getJavaObject(), jb->m_LongValueID, nullptr);
 		}
-		PyObject *args = JPPyTuple_Pack(PyLong_FromLongLong(l));
-		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args, nullptr));
+		JPPyObject args = JPPyTuple_Pack(PyLong_FromLongLong(l));
+		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args.get(), nullptr));
 	}
 	if (PyObject_IsSubclass(wrapper.get(), (PyObject*) & PyFloat_Type))
 	{
@@ -426,8 +421,8 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 			auto* jb = dynamic_cast<JPBoxedType*>( value.getClass());
 			l = frame.CallDoubleMethodA(value.getJavaObject(), jb->m_DoubleValueID, nullptr);
 		}
-		PyObject *args = JPPyTuple_Pack(PyFloat_FromDouble(l));
-		return JPPyObject::call(PyFloat_Type.tp_new((PyTypeObject*) wrapper.get(), args, nullptr));
+		JPPyObject args = JPPyTuple_Pack(PyFloat_FromDouble(l));
+		return JPPyObject::call(PyFloat_Type.tp_new((PyTypeObject*) wrapper.get(), args.get(), nullptr));
 	}
 	JP_RAISE(PyExc_TypeError, "unable to convert");  //GCOVR_EXCL_LINE
 }

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -270,7 +270,7 @@ static PyObject *PyJPBoolean_new(PyTypeObject *type, PyObject *args, PyObject *k
 		return nullptr;
 	}
 	int i = PyObject_IsTrue(PyTuple_GetItem(args, 0));
-	PyObject *args2 = PyTuple_Pack(1, PyLong_FromLong(i));
+	PyObject *args2 = JPPyTuple_Pack(PyLong_FromLong(i));
 	self = JPPyObject::call(PyLong_Type.tp_new(type, args2, kwargs));
 	Py_DECREF(args2);
 	JPClass *cls = PyJPClass_getJPClass((PyObject*) type);
@@ -373,21 +373,21 @@ void PyJPNumber_initType(PyObject* module)
 {
 	PyObject *bases;
 
-	bases = PyTuple_Pack(2, &PyLong_Type, PyJPObject_Type);
+	bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
 	PyJPNumberLong_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberLongSpec, bases);
 	Py_DECREF(bases);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JNumberLong", (PyObject*) PyJPNumberLong_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
-	bases = PyTuple_Pack(2, &PyFloat_Type, PyJPObject_Type);
+	bases = JPPyTuple_Pack(&PyFloat_Type, PyJPObject_Type);
 	PyJPNumberFloat_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberFloatSpec, bases);
 	Py_DECREF(bases);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JNumberFloat", (PyObject*) PyJPNumberFloat_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
-	bases = PyTuple_Pack(1, &PyLong_Type, PyJPObject_Type);
+	bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
 	PyJPNumberBool_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberBooleanSpec, bases);
 	Py_DECREF(bases);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
@@ -404,7 +404,7 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 		jlong l = 0;
 		if (value.getValue().l != nullptr)
 			l = frame.CallBooleanMethodA(value.getJavaObject(), context->_java_lang_Boolean->m_BooleanValueID, nullptr);
-		PyObject *args = PyTuple_Pack(1, PyLong_FromLongLong(l));
+		PyObject *args = JPPyTuple_Pack(PyLong_FromLongLong(l));
 		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args, nullptr));
 	}
 	if (PyObject_IsSubclass(wrapper.get(), (PyObject*) & PyLong_Type))
@@ -415,7 +415,7 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 			auto* jb = dynamic_cast<JPBoxedType*>( value.getClass());
 			l = frame.CallLongMethodA(value.getJavaObject(), jb->m_LongValueID, nullptr);
 		}
-		PyObject *args = PyTuple_Pack(1, PyLong_FromLongLong(l));
+		PyObject *args = JPPyTuple_Pack(PyLong_FromLongLong(l));
 		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args, nullptr));
 	}
 	if (PyObject_IsSubclass(wrapper.get(), (PyObject*) & PyFloat_Type))
@@ -426,7 +426,7 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 			auto* jb = dynamic_cast<JPBoxedType*>( value.getClass());
 			l = frame.CallDoubleMethodA(value.getJavaObject(), jb->m_DoubleValueID, nullptr);
 		}
-		PyObject *args = PyTuple_Pack(1, PyFloat_FromDouble(l));
+		PyObject *args = JPPyTuple_Pack(PyFloat_FromDouble(l));
 		return JPPyObject::call(PyFloat_Type.tp_new((PyTypeObject*) wrapper.get(), args, nullptr));
 	}
 	JP_RAISE(PyExc_TypeError, "unable to convert");  //GCOVR_EXCL_LINE

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -366,13 +366,13 @@ void PyJPObject_initType(PyObject* module)
 	PyModule_AddObject(module, "_JObject", (PyObject*) PyJPObject_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
-	JPPyObject bases = JPPyObject::call(PyTuple_Pack(2, PyExc_Exception, PyJPObject_Type));
+	JPPyObject bases = JPPyObject::call(JPPyTuple_Pack(PyExc_Exception, PyJPObject_Type));
 	PyJPException_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&excSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JException", (PyObject*) PyJPException_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
-	bases = JPPyObject::call(PyTuple_Pack(1, PyJPObject_Type));
+	bases = JPPyObject::call(JPPyTuple_Pack(PyJPObject_Type));
 	PyJPComparable_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&comparableSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JComparable", (PyObject*) PyJPComparable_Type);

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -366,13 +366,13 @@ void PyJPObject_initType(PyObject* module)
 	PyModule_AddObject(module, "_JObject", (PyObject*) PyJPObject_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
-	JPPyObject bases = JPPyObject::call(JPPyTuple_Pack(PyExc_Exception, PyJPObject_Type));
+	JPPyObject bases = JPPyTuple_Pack(PyExc_Exception, PyJPObject_Type);
 	PyJPException_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&excSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JException", (PyObject*) PyJPException_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
-	bases = JPPyObject::call(JPPyTuple_Pack(PyJPObject_Type));
+	bases = JPPyTuple_Pack(PyJPObject_Type);
 	PyJPComparable_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&comparableSpec, bases.get());
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JComparable", (PyObject*) PyJPComparable_Type);

--- a/native/python/pyjp_package.cpp
+++ b/native/python/pyjp_package.cpp
@@ -163,7 +163,7 @@ static PyObject *PyJPPackage_getattro(PyObject *self, PyObject *attr)
 			JPPyErrFrame err;
 			err.normalize();
 			err.clear();
-			JPPyObject tuple0 = JPPyObject::call(PyTuple_Pack(3, self, attr, err.m_ExceptionValue.get()));
+			JPPyObject tuple0 = JPPyObject::call(JPPyTuple_Pack(self, attr, err.m_ExceptionValue.get()));
 			PyObject *rc = PyObject_Call(h.get(), tuple0.get(), nullptr);
 			if (rc == nullptr)
 				return nullptr;
@@ -182,7 +182,7 @@ static PyObject *PyJPPackage_getattro(PyObject *self, PyObject *attr)
 	{
 		JPPyObject u = JPPyObject::call(PyUnicode_FromFormat("%s.%U",
 				PyModule_GetName(self), attr));
-		JPPyObject args = JPPyObject::call(PyTuple_Pack(1, u.get()));
+		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(u.get()));
 		out = JPPyObject::call(PyObject_Call((PyObject*) PyJPPackage_Type, args.get(), nullptr));
 	} else
 	{
@@ -284,7 +284,7 @@ static PyObject *PyJPPackage_cast(PyObject *self, PyObject *other)
 	PyObject* matmul = PyDict_GetItemString(dict, "__matmul__");
 	if (matmul == nullptr)
 		Py_RETURN_NOTIMPLEMENTED;
-	JPPyObject args = JPPyObject::call(PyTuple_Pack(2, self, other));
+	JPPyObject args = JPPyObject::call(JPPyTuple_Pack(self, other));
 	return PyObject_Call(matmul, args.get(), nullptr);
 	JP_PY_CATCH(nullptr);
 }
@@ -338,7 +338,7 @@ static PyType_Spec packageSpec = {
 void PyJPPackage_initType(PyObject* module)
 {
 	// Inherit from module.
-	JPPyObject bases = JPPyObject::call(PyTuple_Pack(1, &PyModule_Type));
+	JPPyObject bases = JPPyObject::call(JPPyTuple_Pack(&PyModule_Type));
 	packageSpec.basicsize = PyModule_Type.tp_basicsize;
 	PyJPPackage_Type = (PyTypeObject*) PyType_FromSpecWithBases(&packageSpec, bases.get());
 	JP_PY_CHECK();

--- a/native/python/pyjp_package.cpp
+++ b/native/python/pyjp_package.cpp
@@ -163,7 +163,7 @@ static PyObject *PyJPPackage_getattro(PyObject *self, PyObject *attr)
 			JPPyErrFrame err;
 			err.normalize();
 			err.clear();
-			JPPyObject tuple0 = JPPyObject::call(JPPyTuple_Pack(self, attr, err.m_ExceptionValue.get()));
+			JPPyObject tuple0 = JPPyTuple_Pack(self, attr, err.m_ExceptionValue.get());
 			PyObject *rc = PyObject_Call(h.get(), tuple0.get(), nullptr);
 			if (rc == nullptr)
 				return nullptr;
@@ -182,7 +182,7 @@ static PyObject *PyJPPackage_getattro(PyObject *self, PyObject *attr)
 	{
 		JPPyObject u = JPPyObject::call(PyUnicode_FromFormat("%s.%U",
 				PyModule_GetName(self), attr));
-		JPPyObject args = JPPyObject::call(JPPyTuple_Pack(u.get()));
+		JPPyObject args = JPPyTuple_Pack(u.get());
 		out = JPPyObject::call(PyObject_Call((PyObject*) PyJPPackage_Type, args.get(), nullptr));
 	} else
 	{
@@ -284,7 +284,7 @@ static PyObject *PyJPPackage_cast(PyObject *self, PyObject *other)
 	PyObject* matmul = PyDict_GetItemString(dict, "__matmul__");
 	if (matmul == nullptr)
 		Py_RETURN_NOTIMPLEMENTED;
-	JPPyObject args = JPPyObject::call(JPPyTuple_Pack(self, other));
+	JPPyObject args = JPPyTuple_Pack(self, other);
 	return PyObject_Call(matmul, args.get(), nullptr);
 	JP_PY_CATCH(nullptr);
 }
@@ -338,7 +338,7 @@ static PyType_Spec packageSpec = {
 void PyJPPackage_initType(PyObject* module)
 {
 	// Inherit from module.
-	JPPyObject bases = JPPyObject::call(JPPyTuple_Pack(&PyModule_Type));
+	JPPyObject bases = JPPyTuple_Pack(&PyModule_Type);
 	packageSpec.basicsize = PyModule_Type.tp_basicsize;
 	PyJPPackage_Type = (PyTypeObject*) PyType_FromSpecWithBases(&packageSpec, bases.get());
 	JP_PY_CHECK();

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -173,7 +173,7 @@ PyType_Spec PyJPProxySpec = {
 
 void PyJPProxy_initType(PyObject* module)
 {
-	JPPyObject bases = JPPyObject::call(PyTuple_Pack(1, &PyBaseObject_Type));
+	JPPyObject bases = JPPyObject::call(JPPyTuple_Pack(&PyBaseObject_Type));
 	PyJPProxy_Type = (PyTypeObject*) PyType_FromSpecWithBases(&PyJPProxySpec, bases.get());
 	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JProxy", (PyObject*) PyJPProxy_Type);

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -173,7 +173,7 @@ PyType_Spec PyJPProxySpec = {
 
 void PyJPProxy_initType(PyObject* module)
 {
-	JPPyObject bases = JPPyObject::call(JPPyTuple_Pack(&PyBaseObject_Type));
+	JPPyObject bases = JPPyTuple_Pack(&PyBaseObject_Type);
 	PyJPProxy_Type = (PyTypeObject*) PyType_FromSpecWithBases(&PyJPProxySpec, bases.get());
 	JP_PY_CHECK();
 	PyModule_AddObject(module, "_JProxy", (PyObject*) PyJPProxy_Type);


### PR DESCRIPTION
This prevents simple mistakes such as the following

https://github.com/jpype-project/jpype/blob/66f8c6c07e051eb430326418798736004b0f833b/native%2Fpython%2Fpyjp_number.cpp#L390