### PR TITLE
free threaded build

### DIFF
--- a/native/common/jp_tracer.cpp
+++ b/native/common/jp_tracer.cpp
@@ -150,7 +150,7 @@ void JPypeTracer::tracePythonObject(const char* msg, PyObject* ref)
 	if (ref != nullptr)
 	{
 		std::stringstream str;
-		str << msg << " " << (void*) ref << " " << ref->ob_refcnt << " " << Py_TYPE(ref)->tp_name;
+		str << msg << " " << (void*) ref << " " << Py_REFCNT(ref) << " " << Py_TYPE(ref)->tp_name;
 		JPypeTracer::trace1("PY", str.str().c_str());
 
 	} else

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -22,7 +22,7 @@
 
 static void assertValid(PyObject *obj)
 {
-	if (obj->ob_refcnt >= 1)
+	if (Py_REFCNT(obj) >= 1)
 		return;
 
 	// GCOVR_EXCL_START

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -180,7 +180,7 @@ PyObject* PyJP_GetAttrDescriptor(PyTypeObject *type, PyObject *attr_name)
 	for (Py_ssize_t i = 0; i < n; ++i)
 	{
 		auto *type2 = (PyTypeObject*) PyTuple_GetItem(mro, i);
-		
+
 		// Skip objects without a functioning dictionary
 		if (type2->tp_dict == NULL)
 			continue;
@@ -730,8 +730,11 @@ PyMODINIT_FUNC PyInit__jpype()
 	// PyJPModule = module;
 	Py_INCREF(module);
 	PyJPModule = module;
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
 	PyModule_AddStringConstant(module, "__version__", "1.5.1_dev0");
-	
+
 	// Our module will be used for PyFrame object and it is a requirement that
 	// we have a builtins in our dictionary.
 	PyObject *builtins = PyEval_GetBuiltins();

--- a/setupext/platform.py
+++ b/setupext/platform.py
@@ -68,6 +68,11 @@ def Platform(*, include_dirs: typing.Sequence[Path], sources: typing.Sequence[Pa
                 '/Zi', '/EHsc', f'/std:c++14']
         else:
             platform_specific['extra_compile_args'] = ['/Zi', '/EHsc']
+        if hasattr(sys, "_is_gil_enabled") and not sys._is_gil_enabled():
+            # running in free threaded build means build the free threaded one
+            # this is only neecessary for windows
+            platform_specific['define_macros'].append(('Py_GIL_DISABLED', '1'))
+
         jni_md_platform = 'win32'
 
     elif platform == 'darwin':
@@ -92,7 +97,7 @@ def Platform(*, include_dirs: typing.Sequence[Path], sources: typing.Sequence[Pa
     elif platform.startswith('freebsd'):
         distutils.log.info("Add freebsd settings")
         jni_md_platform = 'freebsd'
-     
+
     elif platform.startswith('openbsd'):
         distutils.log.info("Add openbsd settings")
         jni_md_platform = 'openbsd'


### PR DESCRIPTION
As far as I can tell, jpype is already thread safe as it was necessary since Java is a normal programming that isn't scared of more than one thread.

Anyone looking to use the experimental free threaded build of python should be anticipating to encounter some, uh, problems anyway. [problem example](https://github.com/python/cpython/issues/125139)

@marscher I'm a complete dinosaur when it comes to ci/cd stuff so I didn't touch any of it. In order to build the free threaded version on windows I needed to do `python3.13t -m pip install -e .`, so I'm assuming it's a similar situation with the other operating systems.