### PR TITLE
Fix for GC on windows

### DIFF
--- a/native/common/include/jp_gc.h
+++ b/native/common/include/jp_gc.h
@@ -56,7 +56,14 @@ private:
 	bool java_triggered;
 	PyObject *python_gc;
 	jclass _SystemClass;
+	jclass _ContextClass;
 	jmethodID _gcMethodID;
+
+	jmethodID _totalMemoryID;
+	jmethodID _freeMemoryID;
+	jmethodID _maxMemoryID;
+	jmethodID _usedMemoryID;
+	jmethodID _heapMemoryID;
 
 	size_t last_python;
 	size_t last_java;

--- a/native/common/jp_gc.cpp
+++ b/native/common/jp_gc.cpp
@@ -154,8 +154,8 @@ void JPGarbageCollection::init(JPJavaFrame& frame)
 	_SystemClass = (jclass) frame.NewGlobalRef(frame.FindClass("java/lang/System"));
 	_gcMethodID = frame.GetStaticMethodID(_SystemClass, "gc", "()V");
 
-    jclass ctxt = frame.getContext()->m_ContextClass.get();
-    _ContextClass = ctxt;
+	jclass ctxt = frame.getContext()->m_ContextClass.get();
+	_ContextClass = ctxt;
 	_totalMemoryID = frame.GetStaticMethodID(ctxt, "getTotalMemory", "()J");
 	_freeMemoryID = frame.GetStaticMethodID(ctxt, "getFreeMemory", "()J");
 	_maxMemoryID = frame.GetStaticMethodID(ctxt, "getMaxMemory", "()J");
@@ -247,21 +247,21 @@ void JPGarbageCollection::onEnd()
 		if ((Py_ssize_t) pred > (Py_ssize_t) limit)
 		{
 			run_gc = 2;
-            limit = high_water + (high_water>>3) + 8 * (current - last);
-        }
+			limit = high_water + (high_water>>3) + 8 * (current - last);
+		}
 
 #if 0
-        {
+		{
 			JPJavaFrame frame = JPJavaFrame::outer(m_Context);
-		    jlong totalMemory = frame.CallStaticLongMethodA(_ContextClass, _totalMemoryID, nullptr);
-		    jlong freeMemory = frame.CallStaticLongMethodA(_ContextClass, _freeMemoryID, nullptr);
-		    jlong maxMemory = frame.CallStaticLongMethodA(_ContextClass, _maxMemoryID, nullptr);
-		    jlong usedMemory = frame.CallStaticLongMethodA(_ContextClass, _usedMemoryID, nullptr);
-		    jlong heapMemory = frame.CallStaticLongMethodA(_ContextClass, _heapMemoryID, nullptr);
+			jlong totalMemory = frame.CallStaticLongMethodA(_ContextClass, _totalMemoryID, nullptr);
+			jlong freeMemory = frame.CallStaticLongMethodA(_ContextClass, _freeMemoryID, nullptr);
+			jlong maxMemory = frame.CallStaticLongMethodA(_ContextClass, _maxMemoryID, nullptr);
+			jlong usedMemory = frame.CallStaticLongMethodA(_ContextClass, _usedMemoryID, nullptr);
+			jlong heapMemory = frame.CallStaticLongMethodA(_ContextClass, _heapMemoryID, nullptr);
 			printf("consider gc run=%d (current=%ld, low=%ld, high=%ld, limit=%ld) %ld\n", run_gc,
-					current, low_water, high_water, limit, limit - pred);
-            printf(" java total=%ld free=%ld max=%ld used=%ld heap=%ld\n", totalMemory, freeMemory, maxMemory, usedMemory, heapMemory);
-        }
+				current, low_water, high_water, limit, limit - pred);
+			printf(" java total=%ld free=%ld max=%ld used=%ld heap=%ld\n", totalMemory, freeMemory, maxMemory, usedMemory, heapMemory);
+		}
 #endif
 
 		if (run_gc > 0)

--- a/native/java/org/jpype/JPypeContext.java
+++ b/native/java/org/jpype/JPypeContext.java
@@ -637,4 +637,29 @@ public class JPypeContext
     }
   }
 
+  private static long getTotalMemory() 
+  {
+    return Runtime.getRuntime().totalMemory();
+  }
+
+  private static long getFreeMemory() 
+  {
+    return Runtime.getRuntime().freeMemory();
+  }
+
+  private static long getMaxMemory() 
+  {
+    return Runtime.getRuntime().maxMemory();
+  }
+
+  private static long getUsedMemory() 
+  {
+    return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+  }
+
+  private static long getHeapMemory()
+  {
+    java.lang.management.MemoryMXBean memoryBean = java.lang.management.ManagementFactory.getMemoryMXBean();
+    return memoryBean.getHeapMemoryUsage().getUsed();
+  }
 }


### PR DESCRIPTION
The issue appears to be with the Python bookkeeping.   When the Python memory is growing faster than the Java GC can execute the Java GC gets triggered many times resulting in a serious slow down.   I upped the limit after a forced Java trigger.   I also added some instrumentation to make diagnosis easier.   It is not a 100% but does address the issue.

Fixes #1197