### PR TITLE
Test cleanups

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,8 @@ coverage:
       python:
         target: 85%
         threshold: 1%
-        paths: "jpype/"
+        paths:
+        - "jpype/"
       cpp:
         target: 80%
         threshold: 1%
@@ -21,7 +22,8 @@ coverage:
       java:
         target: 75%
         threshold: 2%
-        paths: "native/java/"
+        paths:
+        - "native/java/"
 
 parsers:
   gcov:

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -136,10 +136,11 @@ class JPypeTestCase(unittest.TestCase):
         for i in range(len(a)):
             self.assertEqual(a[i], b[i])
 
-    def assertElementsAlmostEqual(self, a, b):
+    def assertElementsAlmostEqual(self, a, b, places=None, msg=None,
+                          delta=None):
         self.assertEqual(len(a), len(b))
         for i in range(len(a)):
-            self.assertAlmostEqual(a[i], b[i])
+            self.assertAlmostEqual(a[i], b[i], places, msg, delta)
 
     def useEqualityFunc(self, func):
         return UseFunc(self, func, 'assertEqual')
@@ -153,4 +154,5 @@ def java_version():
                           "import jpype; jpype.startJVM(); "
                           "print(jpype.java.lang.System.getProperty('java.version'))"]),
                        encoding='ascii')
+    # todo: make this robust for version "numbers" containing strings (e.g.) 22.1-internal
     return tuple(map(int, java_version.split(".")))

--- a/test/jpypetest/test_jdouble.py
+++ b/test/jpypetest/test_jdouble.py
@@ -15,12 +15,12 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
-import sys
+from unittest.util import safe_repr
+
 import jpype
 import common
 import random
 import _jpype
-import jpype
 from jpype import java
 from jpype.types import *
 try:
@@ -49,8 +49,8 @@ class JDoubleTestCase(common.JPypeTestCase):
             b = -b
         if b < a * 1e-14:
             return
-        msg = self._formatMessage(msg, '%s == %s' % (safe_repr(first),
-                                                     safe_repr(second)))
+        msg = self._formatMessage(msg, '%s == %s' % (safe_repr(x),
+                                                     safe_repr(y)))
         raise self.failureException(msg)
 
     @common.requireInstrumentation

--- a/test/jpypetest/test_jfloat.py
+++ b/test/jpypetest/test_jfloat.py
@@ -15,11 +15,12 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
-import sys
-import jpype
-import common
 import random
+from unittest.util import safe_repr
+
 import _jpype
+
+import common
 import jpype
 from jpype import java
 from jpype.types import *
@@ -49,8 +50,8 @@ class JFloatTestCase(common.JPypeTestCase):
             b = -b
         if b < a * 1e-7:
             return
-        msg = self._formatMessage(msg, '%s == %s' % (safe_repr(first),
-                                                     safe_repr(second)))
+        msg = self._formatMessage(msg, '%s == %s' % (safe_repr(x),
+                                                     safe_repr(y)))
         raise self.failureException(msg)
 
     @common.requireInstrumentation
@@ -385,7 +386,7 @@ class JFloatTestCase(common.JPypeTestCase):
     def testArrayInitFromNPFloat16(self):
         a = np.random.random(100).astype(np.float16)
         jarr = JArray(JFloat)(a)
-        self.assertElementsAlmostEqual(a, jarr)
+        self.assertElementsAlmostEqual(a, jarr, places=5)
 
     @common.requireNumpy
     def testArrayInitFromNPFloat32(self):

--- a/test/jpypetest/test_jobject.py
+++ b/test/jpypetest/test_jobject.py
@@ -17,7 +17,6 @@
 # *****************************************************************************
 import _jpype
 import jpype
-import _jpype
 from jpype.types import *
 from jpype import java
 import common
@@ -292,7 +291,8 @@ class JClassTestCase(common.JPypeTestCase):
     def testDeprecated(self):
         # this one should issue a warning
         jo = JClass("java.lang.Object")
-        self.assertIsInstance(JObject(None, object), jo)
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsInstance(JObject(None, object), jo)
 
     def testGetSetBad(self):
         JS = JClass("java.lang.String")


### PR DESCRIPTION
I just noticed that we have undefined references at some places in our code base. In this case the "first" and "second" argument in the overridden method were undefined.

This should also fix the float16 test failure which occurred every once in a while.