### PR TITLE
Fixes float16 subnormal numbers

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -8,6 +8,8 @@ Latest Changes:
   
   - JArray is now registered as a Sequence.
 
+  - Fixed conversion of float16 for subnormal numbers.
+
   - Fixed bugs with java.util.List concat and repeat methods.
 
 - **1.5.2 - 2025-01-20**

--- a/native/common/jp_convert.cpp
+++ b/native/common/jp_convert.cpp
@@ -28,34 +28,35 @@ public:
     {
         uint16_t i = *(uint16_t*) c;
 		uint32_t sign = (i&0x8000)>>15;
-		uint32_t man  = (i&0x7C00)>>10;
+		uint32_t exp  = (i&0x7C00)>>10;
 		uint32_t frac = (i&0x03ff);
 		uint32_t k = sign<<31;
+		uint32_t count = (i&0x03ff);
 
-		if (man == 0)
+		if (exp == 0)
 		{
 			// subnormal numbers
 			if (frac != 0)
 			{
-				frac = frac | (frac >> 1);
-				frac = frac | (frac >> 2);
-				frac = frac | (frac >> 4);
-				frac = frac | (frac >> 8);
-				int zeros = std::bitset<32>(~frac).count();
-				man = 127-zeros+7;
-				man <<= 23;
+				count = count | (count >> 1);
+				count = count | (count >> 2);
+				count = count | (count >> 4);
+				count = count | (count >> 8);
+				int zeros = std::bitset<32>(~count).count();
+				exp = 127-zeros+7;
+				exp <<= 23;
 				frac <<= zeros-8;
 				frac &= 0x7fffff;
-				k |= man | frac;
+				k |= exp | frac;
 			}
 		}
-		else if (man < 31)
+		else if (exp < 31)
 		{
 			// normal numbers
-			man = man-15+127;
-			man <<= 23;
+			exp = exp-15+127;
+			exp <<= 23;
 			frac <<= 13;
-			k |= man | frac;
+			k |= exp | frac;
 		}
 		else
 		{

--- a/test/jpypetest/test_jfloat.py
+++ b/test/jpypetest/test_jfloat.py
@@ -384,9 +384,9 @@ class JFloatTestCase(common.JPypeTestCase):
 
     @common.requireNumpy
     def testArrayInitFromNPFloat16(self):
-        a = np.random.random(100).astype(np.float16)
+        a = np.random.random(1000).astype(np.float16)
         jarr = JArray(JFloat)(a)
-        self.assertElementsAlmostEqual(a, jarr, places=5)
+        self.assertElementsEqual(a, jarr)
 
     @common.requireNumpy
     def testArrayInitFromNPFloat32(self):


### PR DESCRIPTION
Found the issue that was causing tests to occasionally fail.  The subnormal number conversion had a bug causing subnormal numbers to get extra bits set.  