### PR TITLE
Context

### DIFF
--- a/native/common/include/jp_array.h
+++ b/native/common/include/jp_array.h
@@ -28,7 +28,6 @@ public:
 	~JPArrayView();
 	void reference();
 	bool unreference();
-	JPContext *getContext() const;
 public:
 	JPArray *m_Array;
 	void *m_Memory{};

--- a/native/common/include/jp_booleantype.h
+++ b/native/common/include/jp_booleantype.h
@@ -36,15 +36,11 @@ public:
 		return v.z;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Boolean;
-	}
-
-	JPMatch::Type findJavaConversion(JPMatch& match) override;
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
+	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
 	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -72,12 +68,12 @@ public:
 
 	jlong getAsLong(jvalue v) override
 	{
-		return field(v);
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
 
 	jdouble getAsDouble(jvalue v) override
 	{
-		return field(v);
+		return (jdouble) field(v);
 	}
 	// GCOVR_EXCL_STOP
 

--- a/native/common/include/jp_bytetype.h
+++ b/native/common/include/jp_bytetype.h
@@ -23,7 +23,6 @@ public:
 	JPByteType();
 	~JPByteType() override;
 
-public:
 	using type_t = jbyte;
 	using array_t = jbyteArray;
 
@@ -37,15 +36,11 @@ public:
 		return v.b;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Byte;
-	}
-
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
 	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
-	JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -56,13 +51,28 @@ public:
 	void        setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* val) override;
 
 	jarray      newArrayOf(JPJavaFrame& frame, jsize size) override;
-	void        setArrayRange(JPJavaFrame& frame, jarray, jsize start, jsize length, jsize step, PyObject*) override;
+	void        setArrayRange(JPJavaFrame& frame, jarray,
+			jsize start, jsize length, jsize step,
+			PyObject *sequence) override;
 	JPPyObject  getArrayItem(JPJavaFrame& frame, jarray, jsize ndx) override;
 	void        setArrayItem(JPJavaFrame& frame, jarray, jsize ndx, PyObject* val) override;
 
 	char getTypeCode() override
 	{
 		return 'B';
+	}
+
+	// GCOVR_EXCL_START
+	// Required but not exercised currently
+	jlong getAsLong(jvalue v) override
+	{
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
+	}
+	// GCOVR_EXCL_STOP
+
+	jdouble getAsDouble(jvalue v) override
+	{
+		return (jdouble) field(v);
 	}
 
 	template <class T> static T assertRange(const T& l)
@@ -72,16 +82,6 @@ public:
 			JP_RAISE(PyExc_OverflowError, "Cannot convert value to Java byte");
 		}
 		return l;
-	}
-
-	jlong getAsLong(jvalue v) override
-	{
-		return field(v);
-	}
-
-	jdouble getAsDouble(jvalue v) override
-	{
-		return field(v);
 	}
 
 	void getView(JPArrayView& view) override;
@@ -94,10 +94,6 @@ public:
 
 	PyObject *newMultiArray(JPJavaFrame &frame,
 			JPPyBuffer &buffer, int subs, int base, jobject dims) override;
-
-private:
-	static const jlong _Byte_Min = 127;
-	static const jlong _Byte_Max = -128;
 } ;
 
 #endif // _JPBYTE_TYPE_H_

--- a/native/common/include/jp_chartype.h
+++ b/native/common/include/jp_chartype.h
@@ -23,7 +23,7 @@ public:
 	JPCharType();
 	~JPCharType() override;
 
-public:
+
 	using type_t = jchar;
 	using array_t = jcharArray;
 
@@ -39,15 +39,11 @@ public:
 		return v.c;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Character;
-	}
-
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
 	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
 	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -58,7 +54,9 @@ public:
 	void        setField(JPJavaFrame& frame, jobject c, jfieldID fid, PyObject* val) override;
 
 	jarray      newArrayOf(JPJavaFrame& frame, jsize size) override;
-	void        setArrayRange(JPJavaFrame& frame, jarray, jsize start, jsize length, jsize step, PyObject*) override;
+	void        setArrayRange(JPJavaFrame& frame, jarray,
+			jsize start, jsize length, jsize step,
+			PyObject *sequence) override;
 	JPPyObject  getArrayItem(JPJavaFrame& frame, jarray, jsize ndx) override;
 	void        setArrayItem(JPJavaFrame& frame, jarray, jsize ndx, PyObject* val) override;
 
@@ -67,14 +65,17 @@ public:
 		return 'C';
 	}
 
+	// GCOVR_EXCL_START
+	// Required but not exercised currently
 	jlong getAsLong(jvalue v) override
 	{
-		return field(v);
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
+	// GCOVR_EXCL_STOP
 
 	jdouble getAsDouble(jvalue v) override
 	{
-		return field(v);
+		return (jdouble) field(v);
 	}
 
 	void getView(JPArrayView& view) override;

--- a/native/common/include/jp_class.h
+++ b/native/common/include/jp_class.h
@@ -146,7 +146,7 @@ public:
 	 *
 	 * @return a java value with class.
 	 */
-	virtual JPValue getValueFromObject(const JPValue& obj);
+	virtual JPValue getValueFromObject(JPJavaFrame& frame, const JPValue& obj);
 
 	/**
 	 * Call a static method that returns this type of object.
@@ -198,10 +198,7 @@ public:
 		return m_Interfaces;
 	}
 
-	JPContext* getContext() const;
-
 protected:
-	JPContext*           m_Context;
 	JPClassRef           m_Class;
 	JPClass*             m_SuperClass;
 	JPClassList          m_Interfaces;

--- a/native/common/include/jp_classloader.h
+++ b/native/common/include/jp_classloader.h
@@ -46,7 +46,6 @@ public:
 	jobject getBootLoader();
 
 private:
-	JPContext* m_Context;
 	JPClassRef m_ClassClass;
 	JPObjectRef m_SystemClassLoader;
 	JPObjectRef m_BootLoader;

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -26,31 +26,25 @@ template <class jref>
 class JPRef
 {
 private:
-	JPContext* m_Context;
 	jref m_Ref;
 
 public:
 
 	JPRef()
 	{
-		m_Context = nullptr;
 		m_Ref = 0;
 	}
 
-	JPRef(JPContext* context, jref obj)
+	JPRef(jref obj)
 	{
-		m_Context = context;
 		m_Ref = 0;
-		if (context == nullptr)
-			return;
-		JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+		JPJavaFrame frame = JPJavaFrame::outer();
 		m_Ref = (jref) frame.NewGlobalRef((jobject) obj);
 	}
 
 	JPRef(JPJavaFrame& frame, jref obj)
 	{
 
-		m_Context = frame.getContext();
 		m_Ref = 0;
 		m_Ref = (jref) frame.NewGlobalRef((jobject) obj);
 	}
@@ -271,6 +265,8 @@ public:
 	std::list<JPResource*> m_Resources;
 } ;
 
+extern "C" JPContext* JPContext_global;
+
 extern void JPRef_failed();
 
 // GCOVR_EXCL_START
@@ -279,10 +275,9 @@ extern void JPRef_failed();
 template<class jref>
 JPRef<jref>::JPRef(const JPRef& other)
 {
-	m_Context = other.m_Context;
-	if (m_Context != nullptr)
+	if (JPContext_global != nullptr)
 	{
-		JPJavaFrame frame = JPJavaFrame::external(m_Context, m_Context->getEnv());
+		JPJavaFrame frame = JPJavaFrame::external(JPContext_global->getEnv());
 		m_Ref = (jref) frame.NewGlobalRef((jobject) other.m_Ref);
 	} else
 	{
@@ -294,9 +289,9 @@ JPRef<jref>::JPRef(const JPRef& other)
 template<class jref>
 JPRef<jref>::~JPRef()
 {
-	if (m_Ref != 0 && m_Context != nullptr)
+	if (m_Ref != 0)
 	{
-		m_Context->ReleaseGlobalRef((jobject) m_Ref);
+		JPContext_global->ReleaseGlobalRef((jobject) m_Ref);
 	}
 }
 
@@ -307,18 +302,17 @@ JPRef<jref>& JPRef<jref>::operator=(const JPRef<jref>& other)
 		return *this;
 	// m_Context may or may not be set up here, so we need to use a
 	// different frame for unreferencing and referencing
-	if (m_Context != nullptr && m_Ref != 0)
+	if (JPContext_global != nullptr && m_Ref != 0)
 	{  // GCOVR_EXCL_START
 		// This code is not currently used.
-		JPJavaFrame frame = JPJavaFrame::external(m_Context, m_Context->getEnv());
+		JPJavaFrame frame = JPJavaFrame::external(JPContext_global->getEnv());
 		if (m_Ref != 0)
 			frame.DeleteGlobalRef((jobject) m_Ref);
 	}  // GCOVR_EXCL_STOP
-	m_Context = other.m_Context;
 	m_Ref = other.m_Ref;
-	if (m_Context != nullptr && m_Ref != 0)
+	if (JPContext_global != nullptr && m_Ref != 0)
 	{
-		JPJavaFrame frame = JPJavaFrame::external(m_Context, m_Context->getEnv());
+		JPJavaFrame frame = JPJavaFrame::external(JPContext_global->getEnv());
 		m_Ref = (jref) frame.NewGlobalRef((jobject) m_Ref);
 	}
 	return *this;

--- a/native/common/include/jp_doubletype.h
+++ b/native/common/include/jp_doubletype.h
@@ -23,7 +23,6 @@ public:
 	JPDoubleType();
 	~JPDoubleType() override = default;
 
-public:
 	using type_t = jdouble;
 	using array_t = jdoubleArray;
 
@@ -37,18 +36,14 @@ public:
 		return v.d;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Double;
-	}
-
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
 	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
-	JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
-	JPPyObject  invokeStatic(JPJavaFrame &frame, jclass, jmethodID, jvalue*) override;
-	JPPyObject  invoke(JPJavaFrame &frame, jobject, jclass, jmethodID, jvalue*) override;
+	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
+	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
 
 	JPPyObject  getStaticField(JPJavaFrame& frame, jclass c, jfieldID fid) override;
 	void        setStaticField(JPJavaFrame& frame, jclass c, jfieldID fid, PyObject* val) override;
@@ -57,7 +52,8 @@ public:
 
 	jarray      newArrayOf(JPJavaFrame& frame, jsize size) override;
 	void        setArrayRange(JPJavaFrame& frame, jarray,
-			jsize start, jsize length, jsize step, PyObject*) override;
+			jsize start, jsize length, jsize step,
+			PyObject *sequence) override;
 	JPPyObject  getArrayItem(JPJavaFrame& frame, jarray, jsize ndx) override;
 	void        setArrayItem(JPJavaFrame& frame, jarray, jsize ndx, PyObject* val) override;
 
@@ -66,13 +62,11 @@ public:
 		return 'D';
 	}
 
-	// GCOV_EXCL_START
-	// These are required for primitives, but converters for do not currently
-	// use them.
-
+	// GCOVR_EXCL_START
+	// Required but not exercised currently
 	jlong getAsLong(jvalue v) override
 	{
-		return (jlong) field(v);
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
 
 	jdouble getAsDouble(jvalue v) override
@@ -90,7 +84,7 @@ public:
 			void* memory, int offset) override;
 
 	PyObject *newMultiArray(JPJavaFrame &frame,
-			JPPyBuffer& view, int subs, int base, jobject dims) override;
+			JPPyBuffer &buffer, int subs, int base, jobject dims) override;
 } ;
 
 #endif // _JP_DOUBLE_TYPE_H_

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -134,7 +134,7 @@ public:
 	void from(const JPStackInfo& info);
 
 	void convertJavaToPython();
-	void convertPythonToJava(JPContext* context);
+	void convertPythonToJava();
 
 	/** Transfer handling of this exception to python.
 	 *
@@ -144,7 +144,7 @@ public:
 	void toPython();
 
 	/** Transfer handling of this exception to java. */
-	void toJava(JPContext* context);
+	void toJava();
 
 	int getExceptionType() const
 	{
@@ -157,7 +157,6 @@ public:
 	}
 
 private:
-	JPContext* m_Context{};
 	int m_Type;
 	JPErrorUnion m_Error{};
 	JPStackTrace m_Trace;

--- a/native/common/include/jp_field.h
+++ b/native/common/include/jp_field.h
@@ -47,11 +47,6 @@ public:
 		return this->m_Field.get();
 	}
 
-	JPContext* getContext()
-	{
-		return m_Class->getContext();
-	}
-
 	const string& getName() const
 	{
 		return m_Name;

--- a/native/common/include/jp_floattype.h
+++ b/native/common/include/jp_floattype.h
@@ -23,7 +23,6 @@ public:
 	JPFloatType();
 	~JPFloatType() override;
 
-public:
 	using type_t = jfloat;
 	using array_t = jfloatArray;
 
@@ -37,15 +36,11 @@ public:
 		return v.f;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Float;
-	}
-
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
 	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
-	JPPyObject  convertToPythonObject(JPJavaFrame &frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -58,7 +53,7 @@ public:
 	jarray      newArrayOf(JPJavaFrame& frame, jsize size) override;
 	void        setArrayRange(JPJavaFrame& frame, jarray,
 			jsize start, jsize length, jsize step,
-			PyObject* sequence) override;
+			PyObject *sequence) override;
 	JPPyObject  getArrayItem(JPJavaFrame& frame, jarray, jsize ndx) override;
 	void        setArrayItem(JPJavaFrame& frame, jarray, jsize ndx, PyObject* val) override;
 
@@ -72,7 +67,7 @@ public:
 
 	jlong getAsLong(jvalue v) override
 	{
-		return (jlong) field(v);
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
 	// GCOVR_EXCL_STOP
 

--- a/native/common/include/jp_gc.h
+++ b/native/common/include/jp_gc.h
@@ -30,7 +30,7 @@ class JPGarbageCollection
 {
 public:
 
-	explicit JPGarbageCollection(JPContext *context);
+	explicit JPGarbageCollection();
 
 	void init(JPJavaFrame& frame);
 
@@ -50,7 +50,6 @@ public:
 	void getStats(JPGCStats& stats);
 
 private:
-	JPContext *m_Context;
 	bool running;
 	bool in_python_gc;
 	bool java_triggered;

--- a/native/common/include/jp_inttype.h
+++ b/native/common/include/jp_inttype.h
@@ -23,7 +23,6 @@ public:
 	JPIntType();
 	~JPIntType() override;
 
-public:
 	using type_t = jint;
 	using array_t = jintArray;
 
@@ -37,15 +36,11 @@ public:
 		return v.i;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Integer;
-	}
-
-	JPMatch::Type findJavaConversion(JPMatch& match) override;
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
+	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
 	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -58,7 +53,7 @@ public:
 	jarray      newArrayOf(JPJavaFrame& frame, jsize size) override;
 	void        setArrayRange(JPJavaFrame& frame, jarray,
 			jsize start, jsize length, jsize step,
-			PyObject* sequence) override;
+			PyObject *sequence) override;
 	JPPyObject  getArrayItem(JPJavaFrame& frame, jarray, jsize ndx) override;
 	void        setArrayItem(JPJavaFrame& frame, jarray, jsize ndx, PyObject* val) override;
 
@@ -67,14 +62,17 @@ public:
 		return 'I';
 	}
 
-	jlong getAsLong(jvalue v) override  // GCOVR_EXCL_LINE
+	// GCOVR_EXCL_START
+	// Required but not exercised currently
+	jlong getAsLong(jvalue v) override
 	{
-		return field(v);  // GCOVR_EXCL_LINE
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
+	// GCOVR_EXCL_STOP
 
 	jdouble getAsDouble(jvalue v) override
 	{
-		return field(v);
+		return (jdouble) field(v);
 	}
 
 	static jlong assertRange(const jlong& l)

--- a/native/common/include/jp_javaframe.h
+++ b/native/common/include/jp_javaframe.h
@@ -43,17 +43,14 @@
  */
 static const int LOCAL_FRAME_DEFAULT = 8;
 
-class JPContext;
-
 class JPJavaFrame
 {
-	JPContext* m_Context;
 	JNIEnv* m_Env;
 	bool m_Popped;
 	bool m_Outer;
 
 private:
-	JPJavaFrame(JPContext* context, JNIEnv* env, int size, bool outer);
+	JPJavaFrame(JNIEnv* env, int size, bool outer);
 
 public:
 
@@ -68,9 +65,9 @@ public:
 	 * @throws JPypeException if the jpype cannot
 	 * acquire an env handle to work with jvm.
 	 */
-	static JPJavaFrame outer(JPContext* context, int size = LOCAL_FRAME_DEFAULT)
+	static JPJavaFrame outer(int size = LOCAL_FRAME_DEFAULT)
 	{
-		return {context, nullptr, size, true};
+		return {nullptr, size, true};
 	}
 
 	/** Create a new JavaFrame when called internal when
@@ -82,9 +79,9 @@ public:
 	 * @throws JPypeException if the jpype cannot
 	 * acquire an env handle to work with jvm.
 	 */
-	static JPJavaFrame inner(JPContext* context, int size = LOCAL_FRAME_DEFAULT)
+	static JPJavaFrame inner(int size = LOCAL_FRAME_DEFAULT)
 	{
-		return {context, nullptr, size, false};
+		return {nullptr, size, false};
 	}
 
 	/** Create a new JavaFrame when called from Java.
@@ -97,9 +94,9 @@ public:
 	 * @throws JPypeException if the jpype cannot
 	 * acquire an env handle to work with jvm.
 	 */
-	static JPJavaFrame external(JPContext* context, JNIEnv* env, int size = LOCAL_FRAME_DEFAULT)
+	static JPJavaFrame external(JNIEnv* env, int size = LOCAL_FRAME_DEFAULT)
 	{
-		return {context, env, size, false};
+		return {env, size, false};
 	}
 
 	JPJavaFrame(const JPJavaFrame& frame);
@@ -111,6 +108,8 @@ public:
 	 * by the keep method will be kept alive.
 	 */
 	~JPJavaFrame();
+
+	JPContext* getContext();
 
 	void check();
 
@@ -158,11 +157,6 @@ public:
 	JNIEnv* getEnv() const
 	{
 		return m_Env;
-	}
-
-	JPContext* getContext() const
-	{
-		return m_Context;
 	}
 
 	string toString(jobject o);

--- a/native/common/include/jp_longtype.h
+++ b/native/common/include/jp_longtype.h
@@ -36,15 +36,11 @@ public:
 		return v.j;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Long;
-	}
-
-	JPMatch::Type findJavaConversion(JPMatch& match) override;
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
+	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
 	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -68,10 +64,9 @@ public:
 
 	// GCOVR_EXCL_START
 	// Required but not exercised currently
-
 	jlong getAsLong(jvalue v) override
 	{
-		return (jlong) field(v);
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
 	// GCOVR_EXCL_STOP
 

--- a/native/common/include/jp_match.h
+++ b/native/common/include/jp_match.h
@@ -35,13 +35,6 @@ public:
 	JPMatch();
 	JPMatch(JPJavaFrame *frame, PyObject *object);
 
-	JPContext *getContext() const
-	{
-		if (frame == nullptr)
-			return nullptr;
-		return frame->getContext();
-	}
-
 	/**
 	 * Get the Java slot associated with the Python object.
 	 *

--- a/native/common/include/jp_methoddispatch.h
+++ b/native/common/include/jp_methoddispatch.h
@@ -41,11 +41,6 @@ public:
 		return m_Class;
 	}
 
-	JPContext* getContext()
-	{
-		return m_Class->getContext();
-	}
-
 	const string& getName() const;
 
 	bool hasStatic() const

--- a/native/common/include/jp_monitor.h
+++ b/native/common/include/jp_monitor.h
@@ -19,19 +19,13 @@
 class JPMonitor
 {
 public:
-	JPMonitor(JPContext* context, jobject obj);
+	JPMonitor(jobject obj);
 	virtual ~JPMonitor();
 
 	void enter();
 	void exit();
 
-	JPContext* getContext()
-	{
-		return m_Context;
-	}
-
 private:
-	JPContext* m_Context;
 	JPObjectRef m_Value;
 } ;
 

--- a/native/common/include/jp_primitivetype.h
+++ b/native/common/include/jp_primitivetype.h
@@ -26,7 +26,7 @@ protected:
 public:
 	bool isPrimitive() const override;
 
-	virtual JPClass* getBoxedClass(JPContext *context) const = 0;
+	virtual JPClass* getBoxedClass(JPJavaFrame& frame) const = 0;
 
 	virtual char getTypeCode() = 0;
 	virtual jlong getAsLong(jvalue v) = 0;
@@ -34,7 +34,6 @@ public:
 
 	void setClass(JPJavaFrame& frame, jclass o)
 	{
-		m_Context = frame.getContext();
 		m_Class = JPClassRef(frame, o);
 	}
 

--- a/native/common/include/jp_proxy.h
+++ b/native/common/include/jp_proxy.h
@@ -24,7 +24,7 @@ class JPProxy
 {
 public:
 	friend class JPProxyType;
-	JPProxy(JPContext* context, PyJPProxy* inst, JPClassList& intf);
+	JPProxy(PyJPProxy* inst, JPClassList& intf);
 	virtual ~JPProxy();
 
 	const JPClassList& getInterfaces() const
@@ -47,7 +47,6 @@ public:
 		return m_Instance;
 	}
 
-	JPContext*    m_Context;
 	PyJPProxy*    m_Instance;
 	JPObjectRef   m_Proxy;
 	JPClassList   m_InterfaceClasses;
@@ -57,7 +56,7 @@ public:
 class JPProxyDirect : public JPProxy
 {
 public:
-	JPProxyDirect(JPContext* context, PyJPProxy* inst, JPClassList& intf);
+	JPProxyDirect(PyJPProxy* inst, JPClassList& intf);
 	~JPProxyDirect() override;
 	JPPyObject getCallable(const string& cname, int& addSelf) override;
 } ;
@@ -65,7 +64,7 @@ public:
 class JPProxyIndirect : public JPProxy
 {
 public:
-	JPProxyIndirect(JPContext* context, PyJPProxy* inst, JPClassList& intf);
+	JPProxyIndirect(PyJPProxy* inst, JPClassList& intf);
 	~JPProxyIndirect() override;
 	JPPyObject getCallable(const string& cname, int& addSelf) override;
 } ;
@@ -73,7 +72,7 @@ public:
 class JPProxyFunctional : public JPProxy
 {
 public:
-	JPProxyFunctional(JPContext* context, PyJPProxy* inst, JPClassList& intf);
+	JPProxyFunctional(PyJPProxy* inst, JPClassList& intf);
 	~JPProxyFunctional() override;
 	JPPyObject getCallable(const string& cname, int& addSelf) override;
 private:

--- a/native/common/include/jp_proxy.h
+++ b/native/common/include/jp_proxy.h
@@ -34,11 +34,6 @@ public:
 
 	jvalue getProxy();
 
-	JPContext* getContext()
-	{
-		return m_Context;
-	}
-
 	virtual JPPyObject getCallable(const string& cname, int& addSelf) = 0;
 	static void releaseProxyPython(void* host);
 

--- a/native/common/include/jp_shorttype.h
+++ b/native/common/include/jp_shorttype.h
@@ -36,15 +36,11 @@ public:
 		return v.s;
 	}
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Short;
-	}
-
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
 	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	void getConversionInfo(JPConversionInfo &info) override;
 	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -66,15 +62,18 @@ public:
 		return 'S';
 	}
 
+	// GCOVR_EXCL_START
+	// Required but not exercised currently
 	jlong getAsLong(jvalue v) override
 	{
-		return field(v);
+		return (jlong) field(v);  // GCOVR_EXCL_LINE
 	}
 
 	jdouble getAsDouble(jvalue v) override
 	{
-		return field(v);
+		return (jdouble) field(v);
 	}
+	// GCOV_EXCL_STOP
 
 	template <class T> static T assertRange(const T& l)
 	{
@@ -95,7 +94,6 @@ public:
 
 	PyObject *newMultiArray(JPJavaFrame &frame,
 			JPPyBuffer &buffer, int subs, int base, jobject dims) override;
-
 } ;
 
 #endif // _JP_SHORT_TYPE_H_

--- a/native/common/include/jp_typemanager.h
+++ b/native/common/include/jp_typemanager.h
@@ -44,7 +44,6 @@ public:
     int interfaceParameterCount(JPClass* cls);
 
 private:
-	JPContext* m_Context;
 	JPObjectRef m_JavaTypeManager;
 	jmethodID m_FindClass;
 	jmethodID m_FindClassByName;

--- a/native/common/include/jp_voidtype.h
+++ b/native/common/include/jp_voidtype.h
@@ -23,13 +23,10 @@ public:
 	JPVoidType();
 	~JPVoidType() override;
 
-	JPClass* getBoxedClass(JPContext *context) const override
-	{
-		return context->_java_lang_Void;
-	}
-
+	JPClass* getBoxedClass(JPJavaFrame& frame) const override;
 	JPMatch::Type findJavaConversion(JPMatch &match) override;
 	JPPyObject  convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast) override;
+	JPValue     getValueFromObject(JPJavaFrame& frame, const JPValue& obj) override;
 
 	JPPyObject  invokeStatic(JPJavaFrame& frame, jclass, jmethodID, jvalue*) override;
 	JPPyObject  invoke(JPJavaFrame& frame, jobject, jclass, jmethodID, jvalue*) override;
@@ -45,7 +42,6 @@ public:
 			PyObject *sequence) override;
 	JPPyObject  getArrayItem(JPJavaFrame& frame, jarray, jsize ndx) override;
 	void        setArrayItem(JPJavaFrame& frame, jarray, jsize ndx, PyObject* val) override;
-	JPValue     getValueFromObject(const JPValue& obj) override;
 
 	char getTypeCode() override;
 	jlong getAsLong(jvalue v) override;
@@ -58,8 +54,9 @@ public:
 	void copyElements(JPJavaFrame &frame,
 			jarray a, jsize start, jsize len,
 			void* memory, int offset) override;
+
 	PyObject *newMultiArray(JPJavaFrame &frame,
-			JPPyBuffer& view, int subs, int base, jobject dims) override;
+			JPPyBuffer &buffer, int subs, int base, jobject dims) override;
 } ;
 
 #endif // _JP_VOID_TYPE_H_

--- a/native/common/jp_array.cpp
+++ b/native/common/jp_array.cpp
@@ -24,10 +24,10 @@
 // carry them around so that we can match types.
 
 JPArray::JPArray(const JPValue &value)
-: m_Object(value.getClass()->getContext(), (jarray) value.getValue().l)
+: m_Object((jarray) value.getValue().l)
 {
 	m_Class = dynamic_cast<JPArrayClass*>( value.getClass());
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JP_TRACE_IN("JPArray::JPArray");
 	ASSERT_NOT_NULL(m_Class);
 	JP_TRACE(m_Class->toString());
@@ -46,7 +46,7 @@ JPArray::JPArray(const JPValue &value)
 }
 
 JPArray::JPArray(JPArray* instance, jsize start, jsize stop, jsize step)
-: m_Object(instance->m_Class->getContext(), (jarray) instance->getJava())
+: m_Object((jarray) instance->getJava())
 {
 	JP_TRACE_IN("JPArray::JPArraySlice");
 	m_Class = instance->m_Class;
@@ -78,7 +78,7 @@ void JPArray::setRange(jsize start, jsize length, jsize step, PyObject* val)
 	if (!PySequence_Check(val))
 		JP_RAISE(PyExc_TypeError, "can only assign a sequence");
 
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass* compType = m_Class->getComponentType();
 	JPPySequence seq = JPPySequence::use(val);
 	long plength = (long) seq.size();
@@ -101,7 +101,7 @@ void JPArray::setRange(jsize start, jsize length, jsize step, PyObject* val)
 
 void JPArray::setItem(jsize ndx, PyObject* val)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass* compType = m_Class->getComponentType();
 
 	if (ndx < 0)
@@ -115,7 +115,7 @@ void JPArray::setItem(jsize ndx, PyObject* val)
 
 JPPyObject JPArray::getItem(jsize ndx)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass* compType = m_Class->getComponentType();
 
 	if (ndx < 0)
@@ -140,7 +140,7 @@ jarray JPArray::clone(JPJavaFrame& frame, PyObject* obj)
 
 JPArrayView::JPArrayView(JPArray* array)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(array->m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	m_Array = array;
 	m_RefCount = 0;
 	m_Buffer.obj = nullptr;
@@ -162,7 +162,7 @@ JPArrayView::JPArrayView(JPArray* array, jobject collection)
 {
 	JP_TRACE_IN("JPArrayView::JPArrayView");
 	// All of the work has already been done by org.jpype.Utilities
-	JPJavaFrame frame = JPJavaFrame::outer(array->m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	m_Array = array;
 
 	jint len = frame.GetArrayLength((jarray) collection);
@@ -233,11 +233,6 @@ JPArrayView::~JPArrayView()
 {
 	if (m_Owned)
 		delete [] (char*) m_Memory;
-}
-
-JPContext *JPArrayView::getContext() const
-{
-	return m_Array->getClass()->getContext();
 }
 
 void JPArrayView::reference()

--- a/native/common/jp_arrayclass.cpp
+++ b/native/common/jp_arrayclass.cpp
@@ -52,7 +52,7 @@ JPMatch::Type JPArrayClass::findJavaConversion(JPMatch &match)
 
 void JPArrayClass::getConversionInfo(JPConversionInfo &info)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	objectConversion->getInfo(this, info);
 	charArrayConversion->getInfo(this, info);
 	byteArrayConversion->getInfo(this, info);

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -28,17 +28,20 @@ JPBooleanType::JPBooleanType()
 JPBooleanType::~JPBooleanType()
 = default;
 
+JPClass* JPBooleanType::getBoxedClass(JPJavaFrame& frame) const
+{
+	return frame.getContext()->_java_lang_Boolean;
+}
+
 JPPyObject JPBooleanType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
 	return JPPyObject::call(PyBool_FromLong(val.z));
 }
 
-JPValue JPBooleanType::getValueFromObject(const JPValue& obj)
+JPValue JPBooleanType::getValueFromObject(JPJavaFrame& frame, const JPValue& obj)
 {
-	JPContext *context = obj.getClass()->getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
 	jvalue v;
-	field(v) = frame.CallBooleanMethodA(obj.getValue().l, context->_java_lang_Boolean->m_BooleanValueID, nullptr) != 0;
+	field(v) = frame.CallBooleanMethodA(obj.getValue().l, frame.getContext()->_java_lang_Boolean->m_BooleanValueID, nullptr) != 0;
 	return JPValue(this, v);
 }
 
@@ -92,7 +95,7 @@ public:
 
 	void getInfo(JPClass *cls, JPConversionInfo &info) override
 	{
-		JPContext *context = cls->getContext();
+		JPContext *context = JPContext_global;
 		PyList_Append(info.exact, (PyObject*) context->_boolean->getHost());
 		unboxConversion->getInfo(cls, info);
 	}
@@ -161,7 +164,7 @@ JPMatch::Type JPBooleanType::findJavaConversion(JPMatch &match)
 
 void JPBooleanType::getConversionInfo(JPConversionInfo &info)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	asBooleanExact.getInfo(this, info);
 	asBooleanJBool.getInfo(this, info);
 	asBooleanLong.getInfo(this, info);
@@ -306,7 +309,7 @@ void JPBooleanType::setArrayItem(JPJavaFrame& frame, jarray a, jsize ndx, PyObje
 
 void JPBooleanType::getView(JPArrayView& view)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	view.m_Memory = (void*) frame.GetBooleanArrayElements(
 			(jbooleanArray) view.m_Array->getJava(), &view.m_IsCopy);
 	view.m_Buffer.format = "?";
@@ -317,7 +320,7 @@ void JPBooleanType::releaseView(JPArrayView& view)
 {
 	try
 	{
-		JPJavaFrame frame = JPJavaFrame::outer(view.getContext());
+		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseBooleanArrayElements((jbooleanArray) view.m_Array->getJava(),
 				(jboolean*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
 	}	catch (JPypeException&)

--- a/native/common/jp_boxedtype.cpp
+++ b/native/common/jp_boxedtype.cpp
@@ -84,7 +84,7 @@ JPMatch::Type JPBoxedType::findJavaConversion(JPMatch &match)
 void JPBoxedType::getConversionInfo(JPConversionInfo &info)
 {
 	JP_TRACE_IN("JPBoxedType::getConversionInfo");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	m_PrimitiveType->getConversionInfo(info);
 	JPPyObject::call(PyObject_CallMethod(info.expl, "extend", "O", info.implicit));
 	JPPyObject::call(PyObject_CallMethod(info.implicit, "clear", ""));
@@ -117,13 +117,13 @@ JPPyObject JPBoxedType::convertToPythonObject(JPJavaFrame& frame, jvalue value, 
 
 	JPPyObject wrapper = PyJPClass_create(frame, cls);
 	JPPyObject obj;
-	JPContext *context = frame.getContext();
+	JPContext *context = JPContext_global;
 	if (this->getPrimitive() == context->_char)
 	{
 		jchar value2 = 0;
 		// Not null get the char value
 		if (value.l != nullptr)
-			value2 = context->_char->getValueFromObject(JPValue(this, value)).getValue().c;
+			value2 = context->_char->getValueFromObject(frame, JPValue(this, value)).getValue().c;
 		// Create a char string object
 		obj = JPPyObject::call(PyJPChar_Create((PyTypeObject*) wrapper.get(), value2));
 	} else

--- a/native/common/jp_buffer.cpp
+++ b/native/common/jp_buffer.cpp
@@ -20,10 +20,10 @@
 #include "jp_buffertype.h"
 
 JPBuffer::JPBuffer(const JPValue &value)
-: m_Object(value.getClass()->getContext(), value.getValue().l)
+: m_Object(value.getValue().l)
 {
 	m_Class = dynamic_cast<JPBufferType*>( value.getClass());
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JP_TRACE_IN("JPBuffer::JPBuffer");
 	m_Address = frame.GetDirectBufferAddress(m_Object.get());
 	m_Capacity = (Py_ssize_t) frame.GetDirectBufferCapacity(m_Object.get());

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -23,7 +23,6 @@ JPClass::JPClass(
 		const string& name,
 		jint modifiers)
 {
-	m_Context = nullptr;
 	m_CanonicalName = name;
 	m_SuperClass = nullptr;
 	m_Interfaces = JPClassList();
@@ -38,7 +37,6 @@ JPClass::JPClass(JPJavaFrame& frame,
 		jint modifiers)
 : m_Class(frame, clss)
 {
-	m_Context = frame.getContext();
 	m_CanonicalName = name;
 	m_SuperClass = super;
 	m_Interfaces = interfaces;
@@ -68,7 +66,7 @@ jclass JPClass::getJavaClass() const
 
 void JPClass::ensureMembers(JPJavaFrame& frame)
 {
-	JPContext* context = frame.getContext();
+	JPContext* context = JPContext_global;
 	JPTypeManager* typeManager = context->getTypeManager();
 	typeManager->populateMembers(this);
 }
@@ -97,14 +95,6 @@ JPValue JPClass::newInstance(JPJavaFrame& frame, JPPyObjectVector& args)
 		}
 	}
 	return m_Constructors->invokeConstructor(frame, args);
-}
-
-JPContext* JPClass::getContext() const
-{
-	// This sanity check is for during shutdown.
-	if (m_Context == nullptr)
-		JP_RAISE(PyExc_RuntimeError, "Null context"); // GCOVR_EXCL_LINE
-	return m_Context;
 }
 
 JPClass* JPClass::newArrayType(JPJavaFrame &frame, long d)
@@ -136,9 +126,9 @@ jarray JPClass::newArrayOf(JPJavaFrame& frame, jsize sz)
 string JPClass::toString() const
 {
 	// This sanity check will not be hit in normal operation
-	if (m_Context == nullptr)
+	if (JPContext_global == nullptr)
 		return m_CanonicalName;  // GCOVR_EXCL_LINE
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	return frame.toString(m_Class.get());
 }
 // GCOVR_EXCL_STOP
@@ -146,11 +136,11 @@ string JPClass::toString() const
 string JPClass::getName() const
 {
 	// This sanity check will not be hit in normal operation
-	if (m_Context == nullptr)
+	if (JPContext_global == nullptr)
 		return m_CanonicalName;  // GCOVR_EXCL_LINE
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	return frame.toString(frame.CallObjectMethodA(
-			(jobject) m_Class.get(), m_Context->m_Class_GetNameID, nullptr));
+			(jobject) m_Class.get(), JPContext_global->m_Class_GetNameID, nullptr));
 }
 
 //</editor-fold>
@@ -320,7 +310,7 @@ JPPyObject JPClass::getArrayItem(JPJavaFrame& frame, jarray a, jsize ndx)
 //</editor-fold>
 //<editor-fold desc="conversion" defaultstate="collapsed">
 
-JPValue JPClass::getValueFromObject(const JPValue& obj)
+JPValue JPClass::getValueFromObject(JPJavaFrame& frame, const JPValue& obj)
 {
 	JP_TRACE_IN("JPClass::getValueFromObject");
 	return JPValue(this, obj.getJavaObject());
@@ -417,7 +407,7 @@ PyObject* JPClass::getHints()
 	if (out != nullptr)
 		return out;
 	// Force creation
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	PyJPClass_create(frame, this);
 	return m_Hints.get();
 }
@@ -425,7 +415,7 @@ PyObject* JPClass::getHints()
 void JPClass::getConversionInfo(JPConversionInfo &info)
 {
 	JP_TRACE_IN("JPClass::getConversionInfo");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	objectConversion->getInfo(this, info);
 	hintsConversion->getInfo(this, info);
 	PyList_Append(info.ret, PyJPClass_create(frame, this).get());

--- a/native/common/jp_classloader.cpp
+++ b/native/common/jp_classloader.cpp
@@ -26,7 +26,6 @@ jobject JPClassLoader::getBootLoader()
 JPClassLoader::JPClassLoader(JPJavaFrame& frame)
 {
 	JP_TRACE_IN("JPClassLoader::JPClassLoader");
-	m_Context = frame.getContext();
 
 	// Define the class loader
 	m_ClassClass = JPClassRef(frame, frame.FindClass("java/lang/Class"));

--- a/native/common/jp_classtype.cpp
+++ b/native/common/jp_classtype.cpp
@@ -46,7 +46,7 @@ JPMatch::Type JPClassType::findJavaConversion(JPMatch& match)
 
 void JPClassType::getConversionInfo(JPConversionInfo &info)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	nullConversion->getInfo(this, info);
 	objectConversion->getInfo(this, info);
 	classConversion->getInfo(this, info);

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -462,8 +462,6 @@ JNIEnv* JPContext::getEnv()
 		res = m_JavaVM->AttachCurrentThreadAsDaemon((void**) &env, nullptr);
 		if (res != JNI_OK)
 		{
-			int *i = 0;
-			*i = 0;
 			JP_RAISE(PyExc_RuntimeError, "Unable to attach to local thread");
 		}
 	}

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -48,7 +48,7 @@ JPContext::JPContext()
 {
 	m_Embedded = false;
 
-	m_GC = new JPGarbageCollection(this);
+	m_GC = new JPGarbageCollection();
 }
 
 JPContext::~JPContext()
@@ -172,6 +172,8 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 		JP_RAISE(PyExc_RuntimeError, "Unable to start JVM");
 	}
 
+	// Mark running for assert
+	m_Running = true;
 	initializeResources(env, interrupt);
 	JP_TRACE_OUT;
 }
@@ -217,7 +219,7 @@ std::string getShared()
 
 void JPContext::initializeResources(JNIEnv* env, bool interrupt)
 {
-	JPJavaFrame frame = JPJavaFrame::external(this, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	// This is the only frame that we can use until the system
 	// is initialized.  Any other frame creation will result in an error.
 
@@ -353,7 +355,6 @@ void JPContext::initializeResources(JNIEnv* env, bool interrupt)
 	// FIXME find a way to call this from instrumentation.
 	// throw std::runtime_error("Failed");
 	// Everything is started.
-	m_Running = true;
 }
 
 void JPContext::onShutdown()
@@ -460,7 +461,11 @@ JNIEnv* JPContext::getEnv()
 		// not deadlock the shutdown.  The user can convert later if they want.
 		res = m_JavaVM->AttachCurrentThreadAsDaemon((void**) &env, nullptr);
 		if (res != JNI_OK)
+		{
+			int *i = 0;
+			*i = 0;
 			JP_RAISE(PyExc_RuntimeError, "Unable to attach to local thread");
+		}
 	}
 	return env;
 }

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -27,7 +27,6 @@ PyObject* PyTrace_FromJPStackTrace(JPStackTrace& trace);
 
 JPypeException::JPypeException(JPJavaFrame &frame, jthrowable th, const JPStackInfo& stackInfo)
 : std::runtime_error(frame.toString(th)),
-  m_Context(frame.getContext()),
   m_Type(JPError::_java_error),
   m_Throwable(frame, th)
 {
@@ -65,7 +64,7 @@ JPypeException::JPypeException(int type,  const string& msn, int errType, const 
 }
 
 JPypeException::JPypeException(const JPypeException &ex) noexcept
-        : runtime_error(ex.what()), m_Context(ex.m_Context),  m_Type(ex.m_Type),  m_Error(ex.m_Error),
+        : runtime_error(ex.what()), m_Type(ex.m_Type),  m_Error(ex.m_Error),
         m_Trace(ex.m_Trace), m_Throwable(ex.m_Throwable)
 {
 }
@@ -76,7 +75,6 @@ JPypeException& JPypeException::operator = (const JPypeException& ex)
 	{
 		return *this;
 	}
-	m_Context = ex.m_Context;
 	m_Type = ex.m_Type;
 	m_Trace = ex.m_Trace;
 	m_Throwable = ex.m_Throwable;
@@ -104,7 +102,8 @@ void JPypeException::convertJavaToPython()
 	// Welcome to paranoia land, where they really are out to get you!
 	JP_TRACE_IN("JPypeException::convertJavaToPython");
 	// GCOVR_EXCL_START
-	if (m_Context == nullptr)
+	JPContext* context = JPContext_global;
+	if (context == nullptr)
 	{
 		PyErr_SetString(PyExc_RuntimeError, "Unable to convert java error, context is null.");
 		return;
@@ -112,28 +111,28 @@ void JPypeException::convertJavaToPython()
 	// GCOVR_EXCL_STOP
 
 	// Okay we can get to a frame to talk to the object
-	JPJavaFrame frame = JPJavaFrame::external(m_Context, m_Context->getEnv());
+	JPJavaFrame frame = JPJavaFrame::external(context->getEnv());
 	jthrowable th = m_Throwable.get();
 	jvalue v;
 	v.l = th;
 	// GCOVR_EXCL_START
 	// This is condition is only hit if something fails during the initial boot
-	if (m_Context->getJavaContext() == nullptr || m_Context->m_Context_GetExcClassID == nullptr)
+	if (context->getJavaContext() == nullptr || context->m_Context_GetExcClassID == nullptr)
 	{
 		PyErr_SetString(PyExc_SystemError, frame.toString(th).c_str());
 		return;
 	}
 	// GCOVR_EXCL_STOP
-	jlong pycls = frame.CallLongMethodA(m_Context->getJavaContext(), m_Context->m_Context_GetExcClassID, &v);
+	jlong pycls = frame.CallLongMethodA(context->getJavaContext(), context->m_Context_GetExcClassID, &v);
 	if (pycls != 0)
 	{
-		jlong value = frame.CallLongMethodA(m_Context->getJavaContext(), m_Context->m_Context_GetExcValueID, &v);
+		jlong value = frame.CallLongMethodA(context->getJavaContext(), context->m_Context_GetExcValueID, &v);
 		PyErr_SetObject((PyObject*) pycls, (PyObject*) value);
 		return;
 	}
 	JP_TRACE("Check typemanager");
 	// GCOVR_EXCL_START
-	if (!m_Context->isRunning())
+	if (!context->isRunning())
 	{
 		PyErr_SetString(PyExc_RuntimeError, frame.toString((jobject) th).c_str());
 		return;
@@ -185,7 +184,7 @@ void JPypeException::convertJavaToPython()
 		{
 			jvalue a;
 			a.l = (jobject) jcause;
-			JPPyObject prev = frame.getContext()->_java_lang_Object->convertToPythonObject(frame, a, false);
+			JPPyObject prev = context->_java_lang_Object->convertToPythonObject(frame, a, false);
 			PyJPException_normalize(frame, prev, jcause, th);
 			PyException_SetCause(cause.get(), prev.keep());
 		}
@@ -205,10 +204,11 @@ void JPypeException::convertJavaToPython()
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
-void JPypeException::convertPythonToJava(JPContext* context)
+void JPypeException::convertPythonToJava()
 {
 	JP_TRACE_IN("JPypeException::convertPythonToJava");
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
+	JPContext *context = frame.getContext();
 	jthrowable th;
 	JPPyErrFrame eframe;
 	if (eframe.good && isJavaThrowable(eframe.m_ExceptionClass.get()))
@@ -372,13 +372,14 @@ void JPypeException::toPython()
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
-void JPypeException::toJava(JPContext *context)
+void JPypeException::toJava()
 {
 	JP_TRACE_IN("JPypeException::toJava");
+	JPContext* context = JPContext_global;
 	try
 	{
 		const char* mesg = what();
-		JPJavaFrame frame = JPJavaFrame::external(context, context->getEnv());
+		JPJavaFrame frame = JPJavaFrame::external(context->getEnv());
 		if (m_Type == JPError::_java_error)
 		{
 			JP_TRACE("Java exception");
@@ -396,7 +397,7 @@ void JPypeException::toJava(JPContext *context)
 		{
 			JPPyCallAcquire callback;
 			JP_TRACE("Python exception");
-			convertPythonToJava(context);
+			convertPythonToJava();
 			return;
 		}
 
@@ -406,7 +407,7 @@ void JPypeException::toJava(JPContext *context)
 			// All others are Python errors
 			JP_TRACE(Py_TYPE(m_Error.l)->tp_name);
 			PyErr_SetString((PyObject*) m_Error.l, mesg);
-			convertPythonToJava(context);
+			convertPythonToJava();
 			return;
 		}
 

--- a/native/common/jp_field.cpp
+++ b/native/common/jp_field.cpp
@@ -38,7 +38,7 @@ JPField::~JPField()
 JPPyObject JPField::getStaticField()
 {
 	JP_TRACE_IN("JPField::getStaticAttribute");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	return m_Type->getStaticField(frame, m_Class->getJavaClass(), m_FieldID);
 	JP_TRACE_OUT;
 }
@@ -46,7 +46,7 @@ JPPyObject JPField::getStaticField()
 void JPField::setStaticField(PyObject *pyobj)
 {
 	JP_TRACE_IN("JPField::setStaticAttribute");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	m_Type->setStaticField(frame, m_Class->getJavaClass(), m_FieldID, pyobj);
 	JP_TRACE_OUT;
 }
@@ -54,7 +54,7 @@ void JPField::setStaticField(PyObject *pyobj)
 JPPyObject JPField::getField(jobject inst)
 {
 	JP_TRACE_IN("JPField::getAttribute");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	ASSERT_NOT_NULL(m_Type);
 	JP_TRACE("field type", m_Type->getCanonicalName());
 	return m_Type->getField(frame, inst, m_FieldID);
@@ -64,7 +64,7 @@ JPPyObject JPField::getField(jobject inst)
 void JPField::setField(jobject inst, PyObject *pyobj)
 {
 	JP_TRACE_IN("JPField::setAttribute");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Class->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	m_Type->setField(frame, inst, m_FieldID, pyobj);
 	JP_TRACE_OUT;
 }

--- a/native/common/jp_functional.cpp
+++ b/native/common/jp_functional.cpp
@@ -61,7 +61,7 @@ public:
 			JPPyObject defaults = JPPyObject::accept(PyObject_GetAttrString(func, "__defaults__"));
 			if (!defaults.isNull() && defaults.get() != Py_None)
 				optional = PyTuple_Size(defaults.get());
-			const int jargs = cls->getContext()->getTypeManager()->interfaceParameterCount(cls);
+			const int jargs = JPContext_global->getTypeManager()->interfaceParameterCount(cls);
 			// Too few arguments
 			if (!is_varargs && args < jargs)
 				return match.type = JPMatch::_none;
@@ -79,7 +79,7 @@ public:
 			JPPyObject defaults = JPPyObject::accept(PyObject_GetAttrString(func, "__defaults__"));
 			if (!defaults.isNull() && defaults.get() != Py_None)
 				optional = PyTuple_Size(defaults.get());
-			const int jargs = cls->getContext()->getTypeManager()->interfaceParameterCount(cls);
+			const int jargs = JPContext_global->getTypeManager()->interfaceParameterCount(cls);
 			// Bound self argument removes one argument
 			if ((PyMethod_Self(match.object))!=nullptr) // borrowed
 				args--;
@@ -106,13 +106,12 @@ public:
 	{
 		auto *cls = (JPFunctional*) match.closure;
 		JP_TRACE_IN("JPConversionFunctional::convert");
-		JPContext *context = PyJPModule_getContext();
-		JPJavaFrame frame = JPJavaFrame::inner(context);
+		JPJavaFrame frame = JPJavaFrame::inner();
 		auto *self = (PyJPProxy*) PyJPProxy_Type->tp_alloc(PyJPProxy_Type, 0);
 		JP_PY_CHECK();
 		JPClassList cl;
 		cl.push_back(cls);
-		self->m_Proxy = new JPProxyFunctional(context, self, cl);
+		self->m_Proxy = new JPProxyFunctional(self, cl);
 		self->m_Target = match.object;
 		self->m_Dispatch = match.object;
 		self->m_Convert = true;

--- a/native/common/jp_gc.cpp
+++ b/native/common/jp_gc.cpp
@@ -111,9 +111,8 @@ void JPGarbageCollection::triggered()
 	}
 }
 
-JPGarbageCollection::JPGarbageCollection(JPContext *context)
+JPGarbageCollection::JPGarbageCollection()
 {
-	m_Context = context;
 	running = false;
 	in_python_gc = false;
 	java_triggered = false;
@@ -154,7 +153,7 @@ void JPGarbageCollection::init(JPJavaFrame& frame)
 	_SystemClass = (jclass) frame.NewGlobalRef(frame.FindClass("java/lang/System"));
 	_gcMethodID = frame.GetStaticMethodID(_SystemClass, "gc", "()V");
 
-	jclass ctxt = frame.getContext()->m_ContextClass.get();
+	jclass ctxt = JPContext_global->m_ContextClass.get();
 	_ContextClass = ctxt;
 	_totalMemoryID = frame.GetStaticMethodID(ctxt, "getTotalMemory", "()J");
 	_freeMemoryID = frame.GetStaticMethodID(ctxt, "getFreeMemory", "()J");
@@ -252,7 +251,7 @@ void JPGarbageCollection::onEnd()
 
 #if 0
 		{
-			JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+			JPJavaFrame frame = JPJavaFrame::outer();
 			jlong totalMemory = frame.CallStaticLongMethodA(_ContextClass, _totalMemoryID, nullptr);
 			jlong freeMemory = frame.CallStaticLongMethodA(_ContextClass, _freeMemoryID, nullptr);
 			jlong maxMemory = frame.CallStaticLongMethodA(_ContextClass, _maxMemoryID, nullptr);
@@ -269,7 +268,7 @@ void JPGarbageCollection::onEnd()
 			// Move up the low water
 			low_water = (low_water + high_water) / 2;
 			// Don't reset the limit if it was count triggered
-			JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+			JPJavaFrame frame = JPJavaFrame::outer();
 			frame.CallStaticVoidMethodA(_SystemClass, _gcMethodID, nullptr);
 			python_triggered++;
 		}

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -34,11 +34,22 @@ static void jpype_frame_check(int popped)
 #define JP_FRAME_CHECK() if (false) while (false)
 #endif
 
-JPJavaFrame::JPJavaFrame(JPContext* context, JNIEnv* p_env, int size, bool outer)
-: m_Context(context), m_Env(p_env), m_Popped(false), m_Outer(outer)
+JPJavaFrame::JPJavaFrame(JNIEnv* p_env, int size, bool outer)
+: m_Env(p_env), m_Popped(false), m_Outer(outer)
 {
+	JPContext* context = JPContext_global;
+
 	if (p_env == nullptr)
+	{
+		if (outer)
+		{
+#ifdef JP_INSTRUMENTATION
+			PyJPModuleFault_throw(compile_hash("PyJPModule_getContext"));
+#endif
+			assertJVMRunning((JPContext*)context, JP_STACKINFO());
+		}
 		m_Env = context->getEnv();
+	}
 
 	// Create a memory management frame to live in
 	m_Env->PushLocalFrame(size);
@@ -46,11 +57,17 @@ JPJavaFrame::JPJavaFrame(JPContext* context, JNIEnv* p_env, int size, bool outer
 }
 
 JPJavaFrame::JPJavaFrame(const JPJavaFrame& frame)
-: m_Context(frame.m_Context), m_Env(frame.m_Env), m_Popped(false), m_Outer(false)
+: m_Env(frame.m_Env), m_Popped(false), m_Outer(false)
 {
 	// Create a memory management frame to live in
 	m_Env->PushLocalFrame(LOCAL_FRAME_DEFAULT);
 	JP_TRACE_JAVA("JavaFrame (copy)", (jobject) - 1);
+}
+
+JPContext* JPJavaFrame::getContext()
+{
+	// We can add guard statements here.
+	return JPContext_global;
 }
 
 jobject JPJavaFrame::keep(jobject obj)
@@ -1022,15 +1039,16 @@ jlong JPJavaFrame::GetDirectBufferCapacity(jobject obj)
 
 jboolean JPJavaFrame::isBufferReadOnly(jobject obj)
 {
-	return CallBooleanMethodA(obj, m_Context->m_Buffer_IsReadOnlyID, nullptr);
+	return CallBooleanMethodA(obj, getContext()->m_Buffer_IsReadOnlyID, nullptr);
 }
 
 jboolean JPJavaFrame::orderBuffer(jobject obj)
 {
 	jvalue arg;
 	arg.l = obj;
-	return CallBooleanMethodA(m_Context->m_JavaContext.get(),
-			m_Context->m_Context_OrderID, &arg);
+	JPContext *context = getContext();
+	return CallBooleanMethodA(context->m_JavaContext.get(),
+			context->m_Context_OrderID, &arg);
 }
 
 // GCOVR_EXCL_START
@@ -1038,7 +1056,7 @@ jboolean JPJavaFrame::orderBuffer(jobject obj)
 
 jclass JPJavaFrame::getClass(jobject obj)
 {
-	return (jclass) CallObjectMethodA(obj, m_Context->m_Object_GetClassID, nullptr);
+	return (jclass) CallObjectMethodA(obj, getContext()->m_Object_GetClassID, nullptr);
 }
 // GCOVR_EXCL_STOP
 
@@ -1075,7 +1093,7 @@ public:
 
 string JPJavaFrame::toString(jobject o)
 {
-	auto str = (jstring) CallObjectMethodA(o, m_Context->m_Object_ToStringID, nullptr);
+	auto str = (jstring) CallObjectMethodA(o, getContext()->m_Object_ToStringID, nullptr);
 	return toStringUTF8(str);
 }
 
@@ -1101,100 +1119,105 @@ jstring JPJavaFrame::fromStringUTF8(const string& str)
 
 jobject JPJavaFrame::toCharArray(jstring jstr)
 {
-	return CallObjectMethodA(jstr, m_Context->m_String_ToCharArrayID, nullptr);
+	return CallObjectMethodA(jstr, getContext()->m_String_ToCharArrayID, nullptr);
 }
 
 bool JPJavaFrame::equals(jobject o1, jobject o2 )
 {
 	jvalue args;
 	args.l = o2;
-	return CallBooleanMethodA(o1, m_Context->m_Object_EqualsID, &args) != 0;
+	return CallBooleanMethodA(o1, getContext()->m_Object_EqualsID, &args) != 0;
 }
 
 jint JPJavaFrame::hashCode(jobject o)
 {
-	return CallIntMethodA(o, m_Context->m_Object_HashCodeID, nullptr);
+	return CallIntMethodA(o, getContext()->m_Object_HashCodeID, nullptr);
 }
 
 jobject JPJavaFrame::collectRectangular(jarray obj)
 {
-	if (m_Context->m_Context_collectRectangularID == nullptr)
+	JPContext* context = getContext();
+	if (context->m_Context_collectRectangularID == nullptr)
 		return nullptr;
 	jvalue v;
 	v.l = (jobject) obj;
 	JAVA_RETURN(jobject, "JPJavaFrame::collectRectangular",
 			CallObjectMethodA(
-			m_Context->m_JavaContext.get(),
-			m_Context->m_Context_collectRectangularID, &v));
+			context->m_JavaContext.get(),
+			context->m_Context_collectRectangularID, &v));
 }
 
 jobject JPJavaFrame::assemble(jobject dims, jobject parts)
 {
-	if (m_Context->m_Context_collectRectangularID == nullptr)
+	JPContext* context = getContext();
+	if (context->m_Context_collectRectangularID == nullptr)
 		return nullptr;
 	jvalue v[2];
 	v[0].l = (jobject) dims;
 	v[1].l = (jobject) parts;
 	JAVA_RETURN(jobject, "JPJavaFrame::assemble",
 			CallObjectMethodA(
-			m_Context->m_JavaContext.get(),
-			m_Context->m_Context_assembleID, v));
+			context->m_JavaContext.get(),
+			context->m_Context_assembleID, v));
 }
 
 jobject JPJavaFrame::newArrayInstance(jclass c, jintArray dims)
 {
+	JPContext* context = getContext();
 	jvalue v[2];
 	v[0].l = (jobject) c;
 	v[1].l = (jobject) dims;
 	JAVA_RETURN(jobject, "JPJavaFrame::newArrayInstance",
 			CallStaticObjectMethodA(
-			m_Context->m_Array.get(),
-			m_Context->m_Array_NewInstanceID, v));
+			context->m_Array.get(),
+			context->m_Array_NewInstanceID, v));
 }
 
 jobject JPJavaFrame::callMethod(jobject method, jobject obj, jobject args)
 {
 	JP_TRACE_IN("JPJavaFrame::callMethod");
-	if (m_Context->m_CallMethodID == nullptr)
+	JPContext* context = getContext();
+	if (context->m_CallMethodID == nullptr)
 		return nullptr;
 	JPJavaFrame frame(*this);
 	jvalue v[3];
 	v[0].l = method;
 	v[1].l = obj;
 	v[2].l = args;
-	return frame.keep(frame.CallObjectMethodA(m_Context->m_Reflector.get(), m_Context->m_CallMethodID, v));
+	return frame.keep(frame.CallObjectMethodA(context->m_Reflector.get(), context->m_CallMethodID, v));
 	JP_TRACE_OUT;
 }
 
 string JPJavaFrame::getFunctional(jclass c)
 {
+	JPContext* context = getContext();
 	jvalue v;
 	v.l = (jobject) c;
 	return toStringUTF8((jstring) CallStaticObjectMethodA(
-			m_Context->m_ContextClass.get(),
-			m_Context->m_Context_GetFunctionalID, &v));
+			context->m_ContextClass.get(),
+			context->m_Context_GetFunctionalID, &v));
 }
 
 JPClass *JPJavaFrame::findClass(jclass obj)
 {
-	return m_Context->getTypeManager()->findClass(obj);
+	return getContext()->getTypeManager()->findClass(obj);
 }
 
 JPClass *JPJavaFrame::findClassByName(const string& name)
 {
-	return m_Context->getTypeManager()->findClassByName(name);
+	return getContext()->getTypeManager()->findClassByName(name);
 }
 
 JPClass *JPJavaFrame::findClassForObject(jobject obj)
 {
-	return m_Context->getTypeManager()->findClassForObject(obj);
+	return getContext()->getTypeManager()->findClassForObject(obj);
 }
 
 jint JPJavaFrame::compareTo(jobject obj, jobject obj2)
 {
 	jvalue v;
 	v.l = obj2;
-	jint ret = m_Env->CallIntMethodA(obj, m_Context->m_CompareToID, &v);
+	jint ret = m_Env->CallIntMethodA(obj, getContext()->m_CompareToID, &v);
 	if (m_Env->ExceptionOccurred())
 	{
 		m_Env->ExceptionClear();
@@ -1205,28 +1228,30 @@ jint JPJavaFrame::compareTo(jobject obj, jobject obj2)
 
 jthrowable JPJavaFrame::getCause(jthrowable th)
 {
-	return (jthrowable) CallObjectMethodA((jobject) th, m_Context->m_Throwable_GetCauseID, nullptr);
+	return (jthrowable) CallObjectMethodA((jobject) th, getContext()->m_Throwable_GetCauseID, nullptr);
 }
 
 jstring JPJavaFrame::getMessage(jthrowable th)
 {
-	return (jstring) CallObjectMethodA((jobject) th, m_Context->m_Throwable_GetMessageID, nullptr);
+	return (jstring) CallObjectMethodA((jobject) th, getContext()->m_Throwable_GetMessageID, nullptr);
 }
 
 jboolean JPJavaFrame::isPackage(const string& str)
 {
+	JPContext* context = getContext();
 	jvalue v;
 	v.l = fromStringUTF8(str);
 	JAVA_RETURN(jboolean, "JPJavaFrame::isPackage",
-			CallBooleanMethodA(m_Context->m_JavaContext.get(), m_Context->m_Context_IsPackageID, &v));
+			CallBooleanMethodA(context->m_JavaContext.get(), context->m_Context_IsPackageID, &v));
 }
 
 jobject JPJavaFrame::getPackage(const string& str)
 {
+	JPContext* context = getContext();
 	jvalue v;
 	v.l = fromStringUTF8(str);
 	JAVA_RETURN(jobject, "JPJavaFrame::getPackage",
-			CallObjectMethodA(m_Context->m_JavaContext.get(), m_Context->m_Context_GetPackageID, &v));
+			CallObjectMethodA(context->m_JavaContext.get(), context->m_Context_GetPackageID, &v));
 }
 
 jobject JPJavaFrame::getPackageObject(jobject pkg, const string& str)
@@ -1234,23 +1259,24 @@ jobject JPJavaFrame::getPackageObject(jobject pkg, const string& str)
 	jvalue v;
 	v.l = fromStringUTF8(str);
 	JAVA_RETURN(jobject, "JPJavaFrame::getPackageObject",
-			CallObjectMethodA(pkg, m_Context->m_Package_GetObjectID, &v));
+			CallObjectMethodA(pkg, getContext()->m_Package_GetObjectID, &v));
 }
 
 jarray JPJavaFrame::getPackageContents(jobject pkg)
 {
 	jvalue v;
 	JAVA_RETURN(auto, "JPJavaFrame::getPackageContents",
-			(jarray) CallObjectMethodA(pkg, m_Context->m_Package_GetContentsID, &v));
+			(jarray) CallObjectMethodA(pkg, getContext()->m_Package_GetContentsID, &v));
 }
 
 void JPJavaFrame::newWrapper(JPClass* cls)
 {
+	JPContext* context = getContext();
 	JPPyCallRelease call;
 	jvalue jv;
 	jv.j = (jlong) cls;
-	CallVoidMethodA(m_Context->getJavaContext(),
-			m_Context->m_Context_NewWrapperID, &jv);
+	CallVoidMethodA(context->getJavaContext(),
+			context->m_Context_NewWrapperID, &jv);
 }
 
 void JPJavaFrame::registerRef(jobject obj, PyObject* hostRef)
@@ -1265,9 +1291,10 @@ void JPJavaFrame::registerRef(jobject obj, void* ref, JCleanupHook cleanup)
 
 void JPJavaFrame::clearInterrupt(bool throws)
 {
+	JPContext* context = getContext();
 	JPPyCallRelease call;
 	jvalue jv;
 	jv.z = throws;
-	CallVoidMethodA(m_Context->m_ContextClass.get(),
-			m_Context->m_Context_ClearInterruptID, &jv);
+	CallVoidMethodA(context->m_ContextClass.get(),
+			context->m_Context_ClearInterruptID, &jv);
 }

--- a/native/common/jp_monitor.cpp
+++ b/native/common/jp_monitor.cpp
@@ -16,9 +16,8 @@
 #include "jpype.h"
 #include "jp_monitor.h"
 
-JPMonitor::JPMonitor(JPContext* context, jobject value) : m_Value(context, value)
+JPMonitor::JPMonitor(jobject value) : m_Value(value)
 {
-	m_Context = context;
 }
 
 JPMonitor::~JPMonitor()
@@ -29,13 +28,13 @@ void JPMonitor::enter()
 	// This can hold off for a while so we need to release resource
 	// so that we don't dead lock.
 	JPPyCallRelease call;
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	frame.MonitorEnter(m_Value.get());
 }
 
 void JPMonitor::exit()
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	frame.MonitorExit(m_Value.get());
 }
 

--- a/native/common/jp_numbertype.cpp
+++ b/native/common/jp_numbertype.cpp
@@ -48,7 +48,7 @@ JPMatch::Type JPNumberType::findJavaConversion(JPMatch& match)
 void JPNumberType::getConversionInfo(JPConversionInfo &info)
 {
 	JP_TRACE_IN("JPNumberType::getConversionInfo");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	javaNumberAnyConversion->getInfo(this, info);
 	boxLongConversion->getInfo(this, info);
 	boxDoubleConversion->getInfo(this, info);

--- a/native/common/jp_objecttype.cpp
+++ b/native/common/jp_objecttype.cpp
@@ -52,7 +52,7 @@ JPMatch::Type JPObjectType::findJavaConversion(JPMatch& match)
 void JPObjectType::getConversionInfo(JPConversionInfo &info)
 {
 	JP_TRACE_IN("JPObjectType::getConversionInfo");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	nullConversion->getInfo(this, info);
 	objectConversion->getInfo(this, info);
 	stringConversion->getInfo(this, info);

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -22,7 +22,7 @@
 #include "jp_boxedtype.h"
 #include "jp_functional.h"
 
-JPPyObject getArgs(JPContext* context, jlongArray parameterTypePtrs,
+JPPyObject getArgs(jlongArray parameterTypePtrs,
 		jobjectArray args, PyObject* self, int addSelf)
 {
 	JP_TRACE_IN("JProxy::getArgs");

--- a/native/common/jp_reference_queue.cpp
+++ b/native/common/jp_reference_queue.cpp
@@ -47,11 +47,10 @@ JNIEXPORT void JNICALL Java_org_jpype_ref_JPypeReferenceNative_init
 JNIEXPORT void JNICALL Java_org_jpype_ref_JPypeReferenceNative_removeHostReference
 (JNIEnv *env, jclass, jlong host, jlong cleanup)
 {
-	JPContext* context = JPContext_global;
 	// Exceptions are not allowed here
 	try
 	{
-		JPJavaFrame frame = JPJavaFrame::external((JPContext*) context, env);
+		JPJavaFrame frame = JPJavaFrame::external(env);
 		JPPyCallAcquire callback;
 		if (cleanup != 0)
 		{

--- a/native/common/jp_stringtype.cpp
+++ b/native/common/jp_stringtype.cpp
@@ -69,11 +69,12 @@ JPMatch::Type JPStringType::findJavaConversion(JPMatch& match)
 
 void JPStringType::getConversionInfo(JPConversionInfo &info)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
+	JPContext* context = frame.getContext();
 	objectConversion->getInfo(this, info);
 	stringConversion->getInfo(this, info);
 	hintsConversion->getInfo(this, info);
-	if (m_Context->getConvertStrings())
+	if (context->getConvertStrings())
 		PyList_Append(info.ret, (PyObject*) & PyUnicode_Type); // GCOVR_EXCL_LINE
 	else
 		PyList_Append(info.ret, (PyObject*) getHost());

--- a/native/common/jp_typefactory.cpp
+++ b/native/common/jp_typefactory.cpp
@@ -47,7 +47,7 @@ void JPTypeFactory_rethrow(JPJavaFrame& frame)
 		throw;
 	} catch (JPypeException& ex)
 	{
-		ex.toJava(frame.getContext());
+		ex.toJava();
 	} catch (...)  // GCOVR_EXCL_LINE
 	{
 		// GCOVR_EXCL_START
@@ -90,8 +90,7 @@ extern "C"
 JNIEXPORT void JNICALL Java_org_jpype_manager_TypeFactoryNative_newWrapper(
 		JNIEnv *env, jobject self, jlong contextPtr, jlong jcls)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_newWrapper");
 	JPPyCallAcquire callback;
 	auto* cls = (JPClass*) jcls;
@@ -104,8 +103,8 @@ JNIEXPORT void JNICALL Java_org_jpype_manager_TypeFactoryNative_destroy(
 		jlongArray resources,
 		jint sz)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
+	auto* context = frame.getContext();
 	JP_JAVA_TRY("JPTypeFactory_destroy");
 	JPPrimitiveArrayAccessor<jlongArray, jlong*> accessor(frame, resources,
 			&JPJavaFrame::GetLongArrayElements, &JPJavaFrame::ReleaseLongArrayElements);
@@ -125,8 +124,7 @@ JNIEXPORT jlong JNICALL Java_org_jpype_manager_TypeFactoryNative_defineMethodDis
 		jlongArray overloadPtrs,
 		jint modifiers)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_defineMethodDispatch");
 	auto* cls = (JPClass*) clsPtr;
 	JPMethodList overloadList;
@@ -146,8 +144,7 @@ JNIEXPORT jlong JNICALL Java_org_jpype_manager_TypeFactoryNative_defineArrayClas
 		jlong componentClass,
 		jint modifiers)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_defineArrayClass");
 	string cname = frame.toStringUTF8(name);
 	JP_TRACE(cname);
@@ -169,8 +166,8 @@ JNIEXPORT jlong JNICALL Java_org_jpype_manager_TypeFactoryNative_defineObjectCla
 		jint modifiers)
 {
 	// All resources are created here are owned by Java and deleted by Java shutdown routine
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
+	auto* context = frame.getContext();
 	JP_JAVA_TRY("JPTypeFactory_defineObjectClass");
 	string className = frame.toStringUTF8(name);
 	JP_TRACE(className);
@@ -304,8 +301,8 @@ JNIEXPORT jlong JNICALL Java_org_jpype_manager_TypeFactoryNative_definePrimitive
 		jint modifiers)
 {
 	// These resources are created by the boxed types
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
+	auto* context = frame.getContext();
 	JP_JAVA_TRY("JPTypeFactory_definePrimitive");
 	string cname = frame.toStringUTF8(name);
 	JP_TRACE(cname);
@@ -366,8 +363,7 @@ JNIEXPORT void JNICALL Java_org_jpype_manager_TypeFactoryNative_assignMembers(
 		jlongArray methodPtrs,
 		jlongArray fieldPtrs)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_assignMembers");
 	auto* cls = (JPClass*) clsPtr;
 	JPMethodDispatchList methodList;
@@ -391,8 +387,7 @@ JNIEXPORT jlong JNICALL Java_org_jpype_manager_TypeFactoryNative_defineField(
 		jlong fieldType,
 		jint modifiers)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_defineField");
 	string cname = frame.toStringUTF8(name);
 	JP_TRACE("class", cls);
@@ -414,8 +409,7 @@ JNIEXPORT jlong JNICALL Java_org_jpype_manager_TypeFactoryNative_defineMethod(
 		jobject method,
 		jlongArray overloadList, jint modifiers)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_defineMethod");
 	jmethodID mid = frame.FromReflectedMethod(method);
 	JPMethodList cover;
@@ -439,8 +433,7 @@ JNIEXPORT void JNICALL Java_org_jpype_manager_TypeFactoryNative_populateMethod(
 		jlongArray argumentTypes
 		)
 {
-	auto* context = (JPContext*) contextPtr;
-	JPJavaFrame frame = JPJavaFrame::external(context, env);
+	JPJavaFrame frame = JPJavaFrame::external(env);
 	JP_JAVA_TRY("JPTypeFactory_populateMethod");
 	JPClassList cargs;
 	convert(frame, argumentTypes, cargs);

--- a/native/common/jp_typemanager.cpp
+++ b/native/common/jp_typemanager.cpp
@@ -19,9 +19,7 @@
 JPTypeManager::JPTypeManager(JPJavaFrame& frame)
 {
 	JP_TRACE_IN("JPTypeManager::init");
-	m_Context = frame.getContext();
-
-	jclass cls = m_Context->getClassLoader()->findClass(frame, "org.jpype.manager.TypeManager");
+	jclass cls = frame.getContext()->getClassLoader()->findClass(frame, "org.jpype.manager.TypeManager");
 	m_FindClass = frame.GetMethodID(cls, "findClass", "(Ljava/lang/Class;)J");
 	m_FindClassByName = frame.GetMethodID(cls, "findClassByName", "(Ljava/lang/String;)J");
 	m_FindClassForObject = frame.GetMethodID(cls, "findClassForObject", "(Ljava/lang/Object;)J");
@@ -36,7 +34,7 @@ JPTypeManager::JPTypeManager(JPJavaFrame& frame)
 JPClass* JPTypeManager::findClass(jclass obj)
 {
 	JP_TRACE_IN("JPTypeManager::findClass");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val;
 	val.l = obj;
 	return (JPClass*) (frame.CallLongMethodA(m_JavaTypeManager.get(), m_FindClass, &val));
@@ -46,7 +44,7 @@ JPClass* JPTypeManager::findClass(jclass obj)
 JPClass* JPTypeManager::findClassByName(const string& name)
 {
 	JP_TRACE_IN("JPTypeManager::findClassByName");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val;
 	val.l = (jobject) frame.fromStringUTF8(name);
 	auto* out = (JPClass*) (frame.CallLongMethodA(m_JavaTypeManager.get(), m_FindClassByName, &val));
@@ -63,7 +61,7 @@ JPClass* JPTypeManager::findClassByName(const string& name)
 JPClass* JPTypeManager::findClassForObject(jobject obj)
 {
 	JP_TRACE_IN("JPTypeManager::findClassForObject");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val;
 	val.l = obj;
 	auto *cls = (JPClass*) (frame.CallLongMethodA(m_JavaTypeManager.get(), m_FindClassForObject, &val));
@@ -76,7 +74,7 @@ JPClass* JPTypeManager::findClassForObject(jobject obj)
 void JPTypeManager::populateMethod(void* method, jobject obj)
 {
 	JP_TRACE_IN("JPTypeManager::populateMethod");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val[2];
 	val[0].j = (jlong) method;
 	val[1].l = obj;
@@ -88,7 +86,7 @@ void JPTypeManager::populateMethod(void* method, jobject obj)
 void JPTypeManager::populateMembers(JPClass* cls)
 {
 	JP_TRACE_IN("JPTypeManager::populateMembers");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val[1];
 	val[0].l = (jobject) cls->getJavaClass();
 	frame.CallVoidMethodA(m_JavaTypeManager.get(), m_PopulateMembers, val);
@@ -98,7 +96,7 @@ void JPTypeManager::populateMembers(JPClass* cls)
 int JPTypeManager::interfaceParameterCount(JPClass *cls)
 {
 	JP_TRACE_IN("JPTypeManager::interfaceParameterCount");
-	JPJavaFrame frame = JPJavaFrame::outer(m_Context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val[1];
 	val[0].l = (jobject) cls->getJavaClass();
 	return frame.CallIntMethodA(m_JavaTypeManager.get(), m_InterfaceParameterCount, val);

--- a/native/common/jp_voidtype.cpp
+++ b/native/common/jp_voidtype.cpp
@@ -24,6 +24,11 @@ JPVoidType::JPVoidType()
 JPVoidType::~JPVoidType()
 = default;
 
+JPClass* JPVoidType::getBoxedClass(JPJavaFrame& frame) const
+{
+	return frame.getContext()->_java_lang_Void;
+}
+
 JPPyObject JPVoidType::invokeStatic(JPJavaFrame& frame, jclass claz, jmethodID mth, jvalue* val)
 {
 	{
@@ -47,7 +52,7 @@ JPPyObject JPVoidType::invoke(JPJavaFrame& frame, jobject obj, jclass clazz, jme
 
 // GCOVR_EXCL_START
 
-JPValue JPVoidType::getValueFromObject(const JPValue& obj)
+JPValue JPVoidType::getValueFromObject(JPJavaFrame& frame, const JPValue& obj)
 {
 	// This is needed if we call a caller sensitive method
 	// and we get a return which is expected to be a void object

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -53,8 +53,7 @@ static void PyJPBuffer_releaseBuffer(PyJPBuffer *self, Py_buffer *view)
 int PyJPBuffer_getBuffer(PyJPBuffer *self, Py_buffer *view, int flags)
 {
 	JP_PY_TRY("PyJPBufferPrimitive_getBuffer");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (self->m_Buffer == nullptr)
 		JP_RAISE(PyExc_ValueError, "Null buffer"); // GCOVR_EXCL_LINE
 	try

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -242,7 +242,6 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 static PyObject *PyJPChar_str(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_str");
-	//PyJPModule_getContext(); // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (javaSlot == nullptr)
 	{  // GCOVR_EXCL_START
@@ -259,7 +258,6 @@ static PyObject *PyJPChar_str(PyJPChar *self)
 static PyObject *PyJPChar_repr(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_repr");
-	////PyJPModule_getContext(); // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (javaSlot == nullptr)
 	{  // GCOVR_EXCL_START
@@ -276,7 +274,6 @@ static PyObject *PyJPChar_repr(PyJPChar *self)
 static PyObject *PyJPChar_index(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_index");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -287,7 +284,6 @@ static PyObject *PyJPChar_index(PyJPChar *self)
 static PyObject *PyJPChar_float(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_float");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -298,7 +294,6 @@ static PyObject *PyJPChar_float(PyJPChar *self)
 static PyObject *PyJPChar_abs(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_nop");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -312,7 +307,6 @@ static PyObject *PyJPChar_abs(PyJPChar *self)
 static Py_ssize_t PyJPChar_len(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_nop");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return -1;
@@ -357,7 +351,6 @@ static PyObject *apply(PyObject *first, PyObject *second, PyObject* (*func)(PyOb
 static  PyObject *PyJPChar_and(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_and");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_And);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -365,7 +358,6 @@ static  PyObject *PyJPChar_and(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_or(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_or");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Or);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -373,7 +365,6 @@ static  PyObject *PyJPChar_or(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_xor(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_xor");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Xor);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -381,7 +372,6 @@ static  PyObject *PyJPChar_xor(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_add(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_add");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *slot0 = PyJPValue_getJavaSlot(first);
 	JPValue *slot1 = PyJPValue_getJavaSlot(second);
 	if (slot1 != nullptr && slot0 != nullptr)
@@ -424,7 +414,6 @@ static  PyObject *PyJPChar_add(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_subtract(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_subtract");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Subtract);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -432,7 +421,6 @@ static  PyObject *PyJPChar_subtract(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_mult(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_mult");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Multiply);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -440,7 +428,6 @@ static  PyObject *PyJPChar_mult(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_rshift(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_rshift");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Rshift);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -448,7 +435,6 @@ static  PyObject *PyJPChar_rshift(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_lshift(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_lshift");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Lshift);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -456,7 +442,6 @@ static  PyObject *PyJPChar_lshift(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_floordiv(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_floordiv");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_FloorDivide);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -464,7 +449,6 @@ static  PyObject *PyJPChar_floordiv(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_divmod(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_divmod");
-	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Divmod);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -472,7 +456,6 @@ static  PyObject *PyJPChar_divmod(PyObject *first, PyObject *second)
 static PyObject *PyJPChar_neg(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_neg");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -485,7 +468,6 @@ static PyObject *PyJPChar_neg(PyJPChar *self)
 static PyObject *PyJPChar_pos(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_pos");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -498,7 +480,6 @@ static PyObject *PyJPChar_pos(PyJPChar *self)
 static PyObject *PyJPChar_inv(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPObject_neg");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -511,7 +492,6 @@ static PyObject *PyJPChar_inv(PyJPChar *self)
 static PyObject *PyJPJChar_compare(PyObject *self, PyObject *other, int op)
 {
 	JP_PY_TRY("PyJPJChar_compare");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot1 = PyJPValue_getJavaSlot(other);
 	JPValue *javaSlot0 = PyJPValue_getJavaSlot(self);
 	if (isNull(javaSlot0))
@@ -576,7 +556,6 @@ static PyObject *PyJPJChar_compare(PyObject *self, PyObject *other, int op)
 static Py_hash_t PyJPChar_hash(PyObject *self)
 {
 	JP_PY_TRY("PyJPObject_hash");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot(self);
 	if (isNull(javaSlot))
 		return Py_TYPE(Py_None)->tp_hash(Py_None);
@@ -587,7 +566,6 @@ static Py_hash_t PyJPChar_hash(PyObject *self)
 static int PyJPChar_bool(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPObject_bool");
-	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (isNull(javaSlot))
 		return 0;
@@ -597,12 +575,10 @@ static int PyJPChar_bool(PyJPChar *self)
 
 
 static PyMethodDef charMethods[] = {
-	//	{"thing", (PyCFunction) PyJPMethod_matchReport, METH_VARARGS, ""},
 	{nullptr},
 };
 
 struct PyGetSetDef charGetSet[] = {
-	//	{"thing", (getter) PyJPMethod_getSelf, NULL, NULL, NULL},
 	{nullptr},
 };
 

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -157,6 +157,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
  */
 Py_UCS2 fromJPValue(const JPValue & value)
 {
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass* cls = value.getClass();
 	if (cls->isPrimitive())
 		return (Py_UCS2) (value.getValue().c);
@@ -164,7 +165,7 @@ Py_UCS2 fromJPValue(const JPValue & value)
 	if (value.getValue().l == nullptr)
 		return (Py_UCS2) - 1;
 	else
-		return (Py_UCS2) (pcls->getValueFromObject(value).getValue().c);
+		return (Py_UCS2) (pcls->getValueFromObject(frame, value).getValue().c);
 }
 
 /** Get the value of the char.  Does not touch Java.
@@ -196,10 +197,7 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 		return nullptr;
 	}  // GCOVR_EXCL_STOP
 
-	JPContext *context = PyJPModule_getContext();
-
 	// Create an instance (this may fail)
-	JPJavaFrame frame = JPJavaFrame::outer(context);
 	if (PyTuple_Size(pyargs) != 1)
 	{
 		PyErr_SetString(PyExc_TypeError, "Java chars require one argument");
@@ -209,6 +207,8 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 	JPValue jv;
 	PyObject *in = PyTuple_GetItem(pyargs, 0);
 	Py_UCS4 cv = ord(in);
+
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (cv != (Py_UCS4) - 1)
 	{
 		JPPyObject v = JPPyObject::call(PyLong_FromLong(cv));
@@ -242,7 +242,7 @@ static PyObject * PyJPChar_new(PyTypeObject *type, PyObject *pyargs, PyObject * 
 static PyObject *PyJPChar_str(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_str");
-	PyJPModule_getContext(); // Check that JVM is running
+	//PyJPModule_getContext(); // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (javaSlot == nullptr)
 	{  // GCOVR_EXCL_START
@@ -259,7 +259,7 @@ static PyObject *PyJPChar_str(PyJPChar *self)
 static PyObject *PyJPChar_repr(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_repr");
-	PyJPModule_getContext(); // Check that JVM is running
+	////PyJPModule_getContext(); // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (javaSlot == nullptr)
 	{  // GCOVR_EXCL_START
@@ -276,7 +276,7 @@ static PyObject *PyJPChar_repr(PyJPChar *self)
 static PyObject *PyJPChar_index(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_index");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -287,7 +287,7 @@ static PyObject *PyJPChar_index(PyJPChar *self)
 static PyObject *PyJPChar_float(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_float");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -298,7 +298,7 @@ static PyObject *PyJPChar_float(PyJPChar *self)
 static PyObject *PyJPChar_abs(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_nop");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -312,7 +312,7 @@ static PyObject *PyJPChar_abs(PyJPChar *self)
 static Py_ssize_t PyJPChar_len(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_nop");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return -1;
@@ -357,7 +357,7 @@ static PyObject *apply(PyObject *first, PyObject *second, PyObject* (*func)(PyOb
 static  PyObject *PyJPChar_and(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_and");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_And);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -365,7 +365,7 @@ static  PyObject *PyJPChar_and(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_or(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_or");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Or);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -373,7 +373,7 @@ static  PyObject *PyJPChar_or(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_xor(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_xor");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Xor);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -381,7 +381,7 @@ static  PyObject *PyJPChar_xor(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_add(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_add");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *slot0 = PyJPValue_getJavaSlot(first);
 	JPValue *slot1 = PyJPValue_getJavaSlot(second);
 	if (slot1 != nullptr && slot0 != nullptr)
@@ -424,7 +424,7 @@ static  PyObject *PyJPChar_add(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_subtract(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_subtract");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Subtract);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -432,7 +432,7 @@ static  PyObject *PyJPChar_subtract(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_mult(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_mult");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Multiply);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -440,7 +440,7 @@ static  PyObject *PyJPChar_mult(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_rshift(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_rshift");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Rshift);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -448,7 +448,7 @@ static  PyObject *PyJPChar_rshift(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_lshift(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_lshift");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Lshift);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -456,7 +456,7 @@ static  PyObject *PyJPChar_lshift(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_floordiv(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_floordiv");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_FloorDivide);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -464,7 +464,7 @@ static  PyObject *PyJPChar_floordiv(PyObject *first, PyObject *second)
 static  PyObject *PyJPChar_divmod(PyObject *first, PyObject *second)
 {
 	JP_PY_TRY("PyJPChar_divmod");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	return apply(first, second, PyNumber_Divmod);
 	JP_PY_CATCH(nullptr);  // GCOVR_EXCL_LINE
 }
@@ -472,7 +472,7 @@ static  PyObject *PyJPChar_divmod(PyObject *first, PyObject *second)
 static PyObject *PyJPChar_neg(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_neg");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -485,7 +485,7 @@ static PyObject *PyJPChar_neg(PyJPChar *self)
 static PyObject *PyJPChar_pos(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPChar_pos");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -498,7 +498,7 @@ static PyObject *PyJPChar_pos(PyJPChar *self)
 static PyObject *PyJPChar_inv(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPObject_neg");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (assertNotNull(javaSlot))
 		return nullptr;
@@ -511,7 +511,7 @@ static PyObject *PyJPChar_inv(PyJPChar *self)
 static PyObject *PyJPJChar_compare(PyObject *self, PyObject *other, int op)
 {
 	JP_PY_TRY("PyJPJChar_compare");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot1 = PyJPValue_getJavaSlot(other);
 	JPValue *javaSlot0 = PyJPValue_getJavaSlot(self);
 	if (isNull(javaSlot0))
@@ -576,7 +576,7 @@ static PyObject *PyJPJChar_compare(PyObject *self, PyObject *other, int op)
 static Py_hash_t PyJPChar_hash(PyObject *self)
 {
 	JP_PY_TRY("PyJPObject_hash");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot(self);
 	if (isNull(javaSlot))
 		return Py_TYPE(Py_None)->tp_hash(Py_None);
@@ -587,7 +587,7 @@ static Py_hash_t PyJPChar_hash(PyObject *self)
 static int PyJPChar_bool(PyJPChar *self)
 {
 	JP_PY_TRY("PyJPObject_bool");
-	PyJPModule_getContext();  // Check that JVM is running
+	//PyJPModule_getContext();  // Check that JVM is running
 	JPValue *javaSlot = PyJPValue_getJavaSlot((PyObject*) self);
 	if (isNull(javaSlot))
 		return 0;

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -523,8 +523,7 @@ PyObject* PyJPClass_subclasscheck(PyTypeObject *type, PyTypeObject *test)
 	}
 	// GCOVR_EXCL_STOP
 
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	// Check for class inheritance first
 	JPClass *testClass = PyJPClass_getJPClass((PyObject*) test);
@@ -565,8 +564,7 @@ PyObject* PyJPClass_subclasscheck(PyTypeObject *type, PyTypeObject *test)
 static PyObject *PyJPClass_class(PyObject *self, PyObject *closure)
 {
 	JP_PY_TRY("PyJPClass_class");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue* javaSlot = PyJPValue_getJavaSlot(self);
 	if (javaSlot == nullptr)
 	{
@@ -580,8 +578,8 @@ static PyObject *PyJPClass_class(PyObject *self, PyObject *closure)
 static int PyJPClass_setClass(PyObject *self, PyObject *type, PyObject *closure)
 {
 	JP_PY_TRY("PyJPClass_setClass", self);
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
+	JPContext *context = frame.getContext();
 	JPValue* javaSlot = PyJPValue_getJavaSlot(type);
 	if (javaSlot == nullptr || javaSlot->getClass() != context->_java_lang_Class)
 	{
@@ -661,15 +659,13 @@ PyObject* PyJPClass_instancecheck(PyTypeObject *self, PyObject *test)
 	// JInterface is a meta
 	if ((PyObject*) self == _JInterface)
 	{
-		JPContext *context = PyJPModule_getContext();
-		JPJavaFrame frame = JPJavaFrame::outer(context);
+		JPJavaFrame frame = JPJavaFrame::outer();
 		JPClass *testClass = PyJPClass_getJPClass((PyObject*) test);
 		return PyBool_FromLong(testClass != nullptr && testClass->isInterface());
 	}
 	if ((PyObject*) self == _JException)
 	{
-		JPContext *context = PyJPModule_getContext();
-		JPJavaFrame frame = JPJavaFrame::outer(context);
+		JPJavaFrame frame = JPJavaFrame::outer();
 		JPClass *testClass = PyJPClass_getJPClass((PyObject*) test);
 		if (testClass)
 			return PyBool_FromLong(testClass->isThrowable());
@@ -680,8 +676,7 @@ PyObject* PyJPClass_instancecheck(PyTypeObject *self, PyObject *test)
 static PyObject *PyJPClass_canCast(PyJPClass *self, PyObject *other)
 {
 	JP_PY_TRY("PyJPClass_canCast");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	JPClass *cls = self->m_Class;
 
@@ -698,8 +693,7 @@ static PyObject *PyJPClass_canCast(PyJPClass *self, PyObject *other)
 static PyObject *PyJPClass_canConvertToJava(PyJPClass *self, PyObject *other)
 {
 	JP_PY_TRY("PyJPClass_canConvertToJava");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	JPClass *cls = self->m_Class;
 
@@ -742,8 +736,8 @@ static bool PySlice_CheckFull(PyObject *item)
 static PyObject *PyJPClass_array(PyJPClass *self, PyObject *item)
 {
 	JP_PY_TRY("PyJPClass_array");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
+	JPContext *context = frame.getContext();
 
 	if (self->m_Class == NULL)
 	{
@@ -837,8 +831,7 @@ static PyObject *PyJPClass_array(PyJPClass *self, PyObject *item)
 static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 {
 	JP_PY_TRY("PyJPClass_cast");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass *type = self->m_Class;
 	JPValue *val = PyJPValue_getJavaSlot(other);
 
@@ -893,7 +886,7 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 		auto *array = (PyJPArray*) other;
 		if (array->m_Array->isSlice())
 		{
-			JPJavaFrame frame = JPJavaFrame::outer(context);
+			JPJavaFrame frame = JPJavaFrame::outer();
 			jvalue v;
 			v.l = array->m_Array->clone(frame, other);
 			return type->convertToPythonObject(frame, v, true).keep();
@@ -917,8 +910,7 @@ static PyObject *PyJPClass_castEq(PyJPClass *self, PyObject *other)
 static PyObject *PyJPClass_convertToJava(PyJPClass *self, PyObject *other)
 {
 	JP_PY_TRY("PyJPClass_convertToJava");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	JPClass *cls = self->m_Class;
 
@@ -950,8 +942,7 @@ static PyObject *PyJPClass_repr(PyJPClass *self)
 static PyObject *PyJPClass_getDoc(PyJPClass *self, void *ctxt)
 {
 	JP_PY_TRY("PyJPMethod_getDoc");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (self->m_Doc)
 	{
 		Py_INCREF(self->m_Doc);
@@ -1065,9 +1056,9 @@ JPClass* PyJPClass_getJPClass(PyObject* obj)
 		if (javaSlot == nullptr)
 			return nullptr;
 		JPClass *cls = javaSlot->getClass();
-		if (cls != cls->getContext()->_java_lang_Class)
+		JPJavaFrame frame = JPJavaFrame::outer();
+		if (cls != frame.getContext()->_java_lang_Class)
 			return nullptr;
-		JPJavaFrame frame = JPJavaFrame::outer(cls->getContext());
 		return frame.findClass((jclass) javaSlot->getJavaObject());
 	} catch (...) // GCOVR_EXCL_LINE
 	{
@@ -1083,7 +1074,7 @@ JPPyObject PyJPClass_getBases(JPJavaFrame &frame, JPClass* cls)
 
 	// Decide the base for this object
 	JPPyObject baseType;
-	JPContext *context = PyJPModule_getContext();
+	JPContext *context = frame.getContext();
 	JPClass *super = cls->getSuperClass();
 	if (dynamic_cast<JPBoxedType*> (cls) == cls)
 	{

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -886,7 +886,6 @@ static PyObject *PyJPClass_cast(PyJPClass *self, PyObject *other)
 		auto *array = (PyJPArray*) other;
 		if (array->m_Array->isSlice())
 		{
-			JPJavaFrame frame = JPJavaFrame::outer();
 			jvalue v;
 			v.l = array->m_Array->clone(frame, other);
 			return type->convertToPythonObject(frame, v, true).keep();

--- a/native/python/pyjp_field.cpp
+++ b/native/python/pyjp_field.cpp
@@ -37,8 +37,7 @@ static void PyJPField_dealloc(PyJPField *self)
 static PyObject *PyJPField_get(PyJPField *self, PyObject *obj, PyObject *type)
 {
 	JP_PY_TRY("PyJPField_get");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	// Clear any pending interrupts if we are on the main thread.
 	if (hasInterrupt())
 		frame.clearInterrupt(false);
@@ -57,8 +56,7 @@ static PyObject *PyJPField_get(PyJPField *self, PyObject *obj, PyObject *type)
 static int PyJPField_set(PyJPField *self, PyObject *obj, PyObject *pyvalue)
 {
 	JP_PY_TRY("PyJPField_set");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (self->m_Field->isFinal())
 	{
 		PyErr_SetString(PyExc_AttributeError, "Field is final");
@@ -88,8 +86,7 @@ static int PyJPField_set(PyJPField *self, PyObject *obj, PyObject *pyvalue)
 static PyObject *PyJPField_repr(PyJPField *self)
 {
 	JP_PY_TRY("PyJPField_repr");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	return PyUnicode_FromFormat("<java field '%s' of '%s'>",
 			self->m_Field->getName().c_str(),
 			self->m_Field->getClass()->getCanonicalName().c_str()

--- a/native/python/pyjp_method.cpp
+++ b/native/python/pyjp_method.cpp
@@ -90,8 +90,7 @@ static PyObject *PyJPMethod_get(PyJPMethod *self, PyObject *obj, PyObject *type)
 static PyObject *PyJPMethod_call(PyJPMethod *self, PyObject *args, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPMethod_call");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JP_TRACE(self->m_Method->getName());
 	// Clear any pending interrupts if we are on the main thread
 	if (hasInterrupt())
@@ -113,8 +112,7 @@ static PyObject *PyJPMethod_call(PyJPMethod *self, PyObject *args, PyObject *kwa
 static PyObject *PyJPMethod_matches(PyJPMethod *self, PyObject *args, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPMethod_matches");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JP_TRACE(self->m_Method->getName());
 	if (self->m_Instance == nullptr)
 	{
@@ -131,8 +129,7 @@ static PyObject *PyJPMethod_matches(PyJPMethod *self, PyObject *args, PyObject *
 static PyObject *PyJPMethod_str(PyJPMethod *self)
 {
 	JP_PY_TRY("PyJPMethod_str");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	return PyUnicode_FromFormat("%s.%s",
 			self->m_Method->getClass()->getCanonicalName().c_str(),
 			self->m_Method->getName().c_str());
@@ -188,7 +185,7 @@ static PyObject *PyJPMethod_getDoc(PyJPMethod *self, void *ctxt)
 {
 	JP_PY_TRY("PyJPMethod_getDoc");
 	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (self->m_Doc)
 	{
 		Py_INCREF(self->m_Doc);
@@ -239,7 +236,7 @@ PyObject *PyJPMethod_getAnnotations(PyJPMethod *self, void *ctxt)
 {
 	JP_PY_TRY("PyJPMethod_getAnnotations");
 	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (self->m_Annotations)
 	{
 		Py_INCREF(self->m_Annotations);

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -387,8 +387,7 @@ static void releaseView(void* view)
 static PyObject* PyJPModule_convertToDirectByteBuffer(PyObject* self, PyObject* src)
 {
 	JP_PY_TRY("PyJPModule_convertToDirectByteBuffer");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	if (PyObject_CheckBuffer(src))
 	{
@@ -419,8 +418,7 @@ static PyObject* PyJPModule_enableStacktraces(PyObject* self, PyObject* src)
 PyObject *PyJPModule_newArrayType(PyObject *module, PyObject *args)
 {
 	JP_PY_TRY("PyJPModule_newArrayType");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	PyObject *type, *dims;
 	if (!PyArg_ParseTuple(args, "OO", &type, &dims))
@@ -446,8 +444,8 @@ PyObject *PyJPModule_newArrayType(PyObject *module, PyObject *args)
 PyObject *PyJPModule_getClass(PyObject* module, PyObject *obj)
 {
 	JP_PY_TRY("PyJPModule_getClass");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
+	JPContext *context = frame.getContext();
 
 	JPClass* cls;
 	if (JPPyString::check(obj))
@@ -485,8 +483,7 @@ PyObject *PyJPModule_hasClass(PyObject* module, PyObject *obj)
 	JP_PY_TRY("PyJPModule_hasClass");
 	if (!JPContext_global->isRunning())
 		Py_RETURN_FALSE; // GCOVR_EXCL_LINE
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	JPClass* cls;
 	if (JPPyString::check(obj))
@@ -598,8 +595,7 @@ static PyObject* PyJPModule_isPackage(PyObject *module, PyObject *pkg)
 		PyErr_Format(PyExc_TypeError, "isPackage required unicode");
 		return nullptr;
 	}
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	return PyBool_FromLong(frame.isPackage(JPPyString::asStringUTF8(pkg)));
 	JP_PY_CATCH(nullptr); // GCOVR_EXCL_LINE
 }
@@ -823,7 +819,7 @@ void PyJPModule_rethrow(const JPStackInfo& info)
 static PyObject *PyJPModule_convertBuffer(JPPyBuffer& buffer, PyObject *dtype)
 {
 	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	Py_buffer& view = buffer.getView();
 
 	// Okay two possibilities here.  We have a valid dtype specified,

--- a/native/python/pyjp_monitor.cpp
+++ b/native/python/pyjp_monitor.cpp
@@ -34,7 +34,7 @@ static int PyJPMonitor_init(PyJPMonitor *self, PyObject *args)
 	JP_PY_TRY("PyJPMonitor_init");
 	self->m_Monitor = nullptr;
 	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 
 	PyObject* value;
 
@@ -66,7 +66,7 @@ static int PyJPMonitor_init(PyJPMonitor *self, PyObject *args)
 		return -1;
 	}
 
-	self->m_Monitor = new JPMonitor(context, v1->getValue().l);
+	self->m_Monitor = new JPMonitor(v1->getValue().l);
 	return 0;
 	JP_PY_CATCH(-1);
 }
@@ -89,8 +89,7 @@ static PyObject *PyJPMonitor_str(PyJPMonitor *self)
 static PyObject *PyJPMonitor_enter(PyJPMonitor *self, PyObject *args)
 {
 	JP_PY_TRY("PyJPMonitor_enter");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	self->m_Monitor->enter();
 	Py_RETURN_NONE;
 	JP_PY_CATCH(nullptr);
@@ -99,8 +98,7 @@ static PyObject *PyJPMonitor_enter(PyJPMonitor *self, PyObject *args)
 static PyObject *PyJPMonitor_exit(PyJPMonitor *self, PyObject *args)
 {
 	JP_PY_TRY("PyJPMonitor_exit");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	self->m_Monitor->exit();
 	Py_RETURN_NONE;
 	JP_PY_CATCH(nullptr);

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -35,12 +35,11 @@ extern "C"
 static PyObject *PyJPNumber_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPNumber_new", type);
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
 	auto *cls = (JPClass*) PyJPClass_getJPClass((PyObject*) type);
 	if (cls == nullptr)
 		JP_RAISE(PyExc_TypeError, "Class type incorrect");
 
+	JPJavaFrame frame = JPJavaFrame::outer();
 	jvalue val;
 	// One argument tries Java conversion first
 	if (PyTuple_Size(args) == 1)
@@ -85,8 +84,7 @@ static PyObject *PyJPNumber_new(PyTypeObject *type, PyObject *args, PyObject *kw
 static PyObject *PyJPNumberLong_int(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberLong_int");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (!isNull(self))
 		return PyLong_Type.tp_as_number->nb_int(self);
 	PyErr_SetString(PyExc_TypeError, "cast of null pointer would return non-int");
@@ -96,8 +94,7 @@ static PyObject *PyJPNumberLong_int(PyObject *self)
 static PyObject *PyJPNumberLong_float(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberLong_float");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (!isNull(self))
 		return PyLong_Type.tp_as_number->nb_float(self);
 	PyErr_SetString(PyExc_TypeError, "cast of null pointer would return non-float");
@@ -107,8 +104,7 @@ static PyObject *PyJPNumberLong_float(PyObject *self)
 static PyObject *PyJPNumberFloat_int(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberFloat_int");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (!isNull(self))
 		return PyFloat_Type.tp_as_number->nb_int(self);
 	PyErr_SetString(PyExc_TypeError, "cast of null pointer would return non-int");
@@ -118,8 +114,7 @@ static PyObject *PyJPNumberFloat_int(PyObject *self)
 static PyObject *PyJPNumberFloat_float(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberFloat_float");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (!isNull(self))
 		return PyFloat_Type.tp_as_number->nb_float(self);
 	PyErr_SetString(PyExc_TypeError, "cast of null pointer would return non-float");
@@ -129,8 +124,7 @@ static PyObject *PyJPNumberFloat_float(PyObject *self)
 static PyObject *PyJPNumberLong_str(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberLong_str");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (isNull(self))
 		return Py_TYPE(Py_None)->tp_str(Py_None);
 	return PyLong_Type.tp_str(self);
@@ -140,8 +134,7 @@ static PyObject *PyJPNumberLong_str(PyObject *self)
 static PyObject *PyJPNumberFloat_str(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberFloat_str");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (isNull(self))
 		return Py_TYPE(Py_None)->tp_str(Py_None);
 	return PyFloat_Type.tp_str(self);
@@ -151,8 +144,7 @@ static PyObject *PyJPNumberFloat_str(PyObject *self)
 static PyObject *PyJPNumberLong_repr(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberLong_repr");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (isNull(self))
 		return Py_TYPE(Py_None)->tp_str(Py_None);
 	return PyLong_Type.tp_repr(self);
@@ -162,8 +154,7 @@ static PyObject *PyJPNumberLong_repr(PyObject *self)
 static PyObject *PyJPNumberFloat_repr(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberFloat_repr");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (isNull(self))
 		return Py_TYPE(Py_None)->tp_str(Py_None);
 	return PyFloat_Type.tp_repr(self);
@@ -177,8 +168,7 @@ static const char* op_names[] = {
 static PyObject *PyJPNumberLong_compare(PyObject *self, PyObject *other, int op)
 {
 	JP_PY_TRY("PyJPNumberLong_compare");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (isNull(self))
 	{
 		if (op == Py_EQ)
@@ -201,8 +191,7 @@ static PyObject *PyJPNumberLong_compare(PyObject *self, PyObject *other, int op)
 static PyObject *PyJPNumberFloat_compare(PyObject *self, PyObject *other, int op)
 {
 	JP_PY_TRY("PyJPNumberFloat_compare");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	if (isNull(self))
 	{
 		if (op == Py_EQ)
@@ -225,8 +214,7 @@ static PyObject *PyJPNumberFloat_compare(PyObject *self, PyObject *other, int op
 static Py_hash_t PyJPNumberLong_hash(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberLong_hash");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *javaSlot = PyJPValue_getJavaSlot(self);
 	if (javaSlot == nullptr)
 		return Py_TYPE(Py_None)->tp_hash(Py_None);
@@ -243,8 +231,7 @@ static Py_hash_t PyJPNumberLong_hash(PyObject *self)
 static Py_hash_t PyJPNumberFloat_hash(PyObject *self)
 {
 	JP_PY_TRY("PyJPNumberFloat_hash");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *javaSlot = PyJPValue_getJavaSlot(self);
 	if (javaSlot == nullptr)
 		return Py_TYPE(Py_None)->tp_hash(Py_None);
@@ -261,8 +248,6 @@ static Py_hash_t PyJPNumberFloat_hash(PyObject *self)
 static PyObject *PyJPBoolean_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPBoolean_new", type);
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
 	JPPyObject self;
 	if (PyTuple_Size(args) != 1)
 	{
@@ -278,6 +263,7 @@ static PyObject *PyJPBoolean_new(PyTypeObject *type, PyObject *args, PyObject *k
 		PyErr_SetString(PyExc_TypeError, "Class type incorrect");
 		return nullptr;
 	}
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPMatch match(&frame, self.get());
 	cls->findJavaConversion(match);
 	jvalue val = match.convert();
@@ -406,7 +392,7 @@ void PyJPNumber_initType(PyObject* module)
 
 JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPValue& value)
 {
-	JPContext *context = frame.getContext();
+	JPContext *context = PyJPModule_getContext();
 	// Bools are not numbers in Java
 	if (value.getClass() == context->_java_lang_Boolean)
 	{

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -33,8 +33,7 @@ static PyObject *PyJPObject_new(PyTypeObject *type, PyObject *pyargs, PyObject *
 	}
 
 	// Create an instance (this may fail)
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPPyObjectVector args(pyargs);
 	JPValue jv = cls->newInstance(frame, args);
 
@@ -67,8 +66,7 @@ static PyObject *PyJPObject_compare(PyObject *self, PyObject *other, int op)
 		return out;
 	}
 
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *javaSlot0 = PyJPValue_getJavaSlot(self);
 	JPValue *javaSlot1 = PyJPValue_getJavaSlot(other);
 
@@ -110,8 +108,7 @@ static PyObject *PyJPObject_compare(PyObject *self, PyObject *other, int op)
 static PyObject *PyJPComparable_compare(PyObject *self, PyObject *other, int op)
 {
 	JP_PY_TRY("PyJPComparable_compare");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *javaSlot0 = PyJPValue_getJavaSlot(self);
 	JPValue *javaSlot1 = PyJPValue_getJavaSlot(other);
 
@@ -202,8 +199,7 @@ static PyObject *PyJPComparable_compare(PyObject *self, PyObject *other, int op)
 static Py_hash_t PyJPObject_hash(PyObject *obj)
 {
 	JP_PY_TRY("PyJPObject_hash");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *javaSlot = PyJPValue_getJavaSlot(obj);
 	if (javaSlot == nullptr)
 		return Py_TYPE(Py_None)->tp_hash(Py_None);
@@ -267,13 +263,12 @@ static PyObject *PyJPException_new(PyTypeObject *type, PyObject *pyargs, PyObjec
 	}  // GCOVR_EXCL_STOP
 
 	// Special constructor path for Exceptions
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPPyObjectVector args(pyargs);
 	if (args.size() == 2 && args[0] == _JObjectKey)
 		return ((PyTypeObject*) PyExc_BaseException)->tp_new(type, args[1], kwargs);
 
 	// Create an instance (this may fail)
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
 	JPValue jv = cls->newInstance(frame, args);
 
 	// Exception must be constructed with the BaseException_new
@@ -301,8 +296,7 @@ static int PyJPException_init(PyObject *self, PyObject *pyargs, PyObject *kwargs
 static PyObject* PyJPException_expandStacktrace(PyObject* self)
 {
 	JP_PY_TRY("PyJPModule_expandStackTrace");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *val = PyJPValue_getJavaSlot(self);
 
 	// These two are loop invariants and must match each time
@@ -396,7 +390,7 @@ void PyJPObject_initType(PyObject* module)
 void PyJPException_normalize(JPJavaFrame frame, JPPyObject exc, jthrowable th, jthrowable enclosing)
 {
 	JP_TRACE_IN("PyJPException_normalize");
-	JPContext *context = frame.getContext();
+	JPContext *context = PyJPModule_getContext();
 	while (th != nullptr)
 	{
 		// Attach the frame to first

--- a/native/python/pyjp_proxy.cpp
+++ b/native/python/pyjp_proxy.cpp
@@ -28,8 +28,6 @@ extern "C"
 static PyObject *PyJPProxy_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPProxy_new");
-	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
 	auto *self = (PyJPProxy*) type->tp_alloc(type, 0);
 	JP_PY_CHECK();
 
@@ -48,6 +46,7 @@ static PyObject *PyJPProxy_new(PyTypeObject *type, PyObject *args, PyObject *kwa
 		return nullptr;
 	}
 
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClassList interfaces;
 	JPPySequence intf = JPPySequence::use(pyintf);
 	jlong len = intf.size();
@@ -66,9 +65,9 @@ static PyObject *PyJPProxy_new(PyTypeObject *type, PyObject *args, PyObject *kwa
 	}
 
 	if (dispatch == Py_None)
-		self->m_Proxy = new JPProxyDirect(context, self, interfaces);
+		self->m_Proxy = new JPProxyDirect(self, interfaces);
 	else
-		self->m_Proxy = new JPProxyIndirect(context, self, interfaces);
+		self->m_Proxy = new JPProxyIndirect(self, interfaces);
 	self->m_Target = instance;
 	self->m_Dispatch = dispatch;
 	self->m_Convert = (convert != 0);
@@ -108,7 +107,7 @@ void PyJPProxy_dealloc(PyJPProxy* self)
 
 static PyObject *PyJPProxy_class(PyJPProxy *self, void *context)
 {
-	JPJavaFrame frame = JPJavaFrame::outer(self->m_Proxy->getContext());
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass* cls = self->m_Proxy->getInterfaces()[0];
 	return PyJPClass_create(frame, cls).keep();
 }

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -163,10 +163,14 @@ void PyJPValue_finalize(void* obj)
 	JPValue* value = PyJPValue_getJavaSlot((PyObject*) obj);
 	if (value == nullptr)
 		return;
+
+	// We can skip if the JVM is stopped.  No need for an exception here.
 	JPContext *context = JPContext_global;
 	if (context == nullptr || !context->isRunning())
 		return;
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+
+	// JVM is running so set up the frame.
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPClass* cls = value->getClass();
 	// This one can't check for initialized because we may need to delete a stale
 	// resource after shutdown.
@@ -185,7 +189,7 @@ PyObject* PyJPValue_str(PyObject* self)
 {
 	JP_PY_TRY("PyJPValue_str", self);
 	JPContext *context = PyJPModule_getContext();
-	JPJavaFrame frame = JPJavaFrame::outer(context);
+	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue* value = PyJPValue_getJavaSlot(self);
 	if (value == nullptr)
 	{


### PR DESCRIPTION
This PR is built on the Proxy upgrade PR.   It is to be reviewed after the Proxy is incorporated.

This PR corrects the issues with JPContext.  

JPContext was added in order to potentially support reloading the JVM.  Unfortunately, Java 1.4 removed the hooks necessary for that task but left the API.   Thus while we could support it if there was a conforming JVM, no such beast exists.   This left our code with lots of unnecessary handling what essentially was a singleton.  Because it appeared in many forms in the code often with different rules this disguised global structure is based often unnecessarily and is checked randomly for consistency.

This PR converts usage to two forms.   

- Those in which there is JavaFrame already open and we can just access the context in through JPJavaFrame::getContext().
- Those in which the Python code can execute without the JVM running or where we need to condition on the current state of teh JVM in which JPContext_global is best.

Unfortunately, there was a very large amount of clean up required, so this is a large PR.

This also resynced many of the long ago auto generated files which have been hand edited and thus drifted apart.  While they are still too different to be autogenerated, they are now closer than before.