### PR TITLE
Fixes #1290

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -12,6 +12,8 @@ Latest Changes:
 
   - Fixed conversion of float16 for subnormal numbers.
 
+  - Fixed segmentation fault on null String.
+
   - Fixed bugs with java.util.List concat and repeat methods.
 
   - Enhancement to JProxy to handle wrapping an existing Python object with a Java

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -1094,6 +1094,8 @@ public:
 string JPJavaFrame::toString(jobject o)
 {
 	auto str = (jstring) CallObjectMethodA(o, getContext()->m_Object_ToStringID, nullptr);
+	if (str == nullptr)
+		return "null";
 	return toStringUTF8(str);
 }
 

--- a/test/harness/jpype/str/Bad.java
+++ b/test/harness/jpype/str/Bad.java
@@ -1,0 +1,24 @@
+/* ****************************************************************************
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  See NOTICE file for details.
+**************************************************************************** */
+package jpype.str;
+
+public class Bad
+{
+  public String toString()
+  {
+     return null;
+  }
+}

--- a/test/jpypetest/test_jstring.py
+++ b/test/jpypetest/test_jstring.py
@@ -181,3 +181,7 @@ class JStringTestCase(common.JPypeTestCase):
         self.assertEqual(s[:5], s2[:5])
         self.assertEqual(s[3:], s2[3:])
         self.assertEqual(s[::-1], s2[::-1])
+
+    def testBad(self):
+        bad = jpype.JClass("jpype.str.Bad")()
+        self.assertEqual(str(bad), "null")


### PR DESCRIPTION
Converts null point into "null" on conversion to string.   Not sure how proper that would be though it is relatively consistent with Java.

```public class T
{
 public static void main(String[] str)
 {
   String a = null;
   System.out.println("test "+ a + " there");   // Prints "test null there"
 }
}
```

I aim to include this in the 1.6 release.
