### PR TITLE
[jp_context] added additional code path to treat condition of Java8

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -120,7 +120,7 @@ jobs:
         imageName: "ubuntu-latest"
         jdk.version: '8'
         python.version: '3.12'
-        pytest.selector: "test_raise_for_java8"
+        pytest_selector: "test_raise_for_java8"
   pool:
     vmImage: $(imageName)
   steps:

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -108,12 +108,12 @@ jobs:
       mac_py39_jdk11:
         imageName: "macos-13"
         python.version: '3.9'
-        jpypetest.fast: 'true'
+        extra_args: '--fast'
         jdk.version: '11'
       mac_py312_jdk17:
         imageName: "macos-13"
         python.version: '3.12'
-        jpypetest.fast: 'true'
+        extra_args: '--fast'
         jdk.version: '17'
       # special
       java8_deprecation:
@@ -121,7 +121,7 @@ jobs:
         jdk.version: '11'
         java_runtime: '8'
         python.version: '3.12'
-        pytest_args: "-k test_raise_for_java8"
+        extra_args: "-k test_raise_for_java8"
   pool:
     vmImage: $(imageName)
   steps:

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -118,7 +118,8 @@ jobs:
       # special
       java8_deprecation:
         imageName: "ubuntu-latest"
-        jdk.version: '8'
+        jdk.version: '9'
+        java_runtime: '8'
         python.version: '3.12'
         pytest_selector: "test_raise_for_java8"
   pool:

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -119,6 +119,7 @@ jobs:
       java8_deprecation:
         imageName: "ubuntu-latest"
         jdk.version: '8'
+        python.version: '3.12'
         pytest.selector: "test_raise_for_java8"
   pool:
     vmImage: $(imageName)

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -104,7 +104,7 @@ jobs:
         imageName: "windows-2022"
         python.version: '3.12'
         jdk.version: '21'
-      # OSX, we only test an old Python version with JDK8 and recent Py with recent JDK.
+      # OSX, we only test an old and new Python/Java version combination for the sake of CI runtime.
       mac_py39_jdk11:
         imageName: "macos-13"
         python.version: '3.9'
@@ -137,3 +137,21 @@ jobs:
   steps:
   - template: scripts/deps.yml
   - template: scripts/debug.yml
+
+- job: Java8Depreaction
+  strategy:
+    matrix:
+      linux_py38_jdk11:
+        imageName: "ubuntu-latest"
+        jdk.version: "8"
+        python.version: '3.9'
+      windows_py39_jdk11:
+        imageName: "windows-2022"
+        python.version: '3.9'
+        jdk.version: '8'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - template: scripts/deps.yml
+  - script: |
+      python -m pytest -v --junit-xml=build/test/test8.xml test/jpypetest -k test_raise_for_java8

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -118,10 +118,10 @@ jobs:
       # special
       java8_deprecation:
         imageName: "ubuntu-latest"
-        jdk.version: '9'
+        jdk.version: '11'
         java_runtime: '8'
         python.version: '3.12'
-        pytest_selector: "test_raise_for_java8"
+        pytest_args: "-k test_raise_for_java8"
   pool:
     vmImage: $(imageName)
   steps:

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -115,7 +115,11 @@ jobs:
         python.version: '3.12'
         jpypetest.fast: 'true'
         jdk.version: '17'
-
+      # special
+      java8_deprecation:
+        imageName: "ubuntu-latest"
+        jdk.version: '8'
+        pytest.selector: "test_raise_for_java8"
   pool:
     vmImage: $(imageName)
   steps:
@@ -137,21 +141,3 @@ jobs:
   steps:
   - template: scripts/deps.yml
   - template: scripts/debug.yml
-
-- job: Java8Depreaction
-  strategy:
-    matrix:
-      linux_py38_jdk11:
-        imageName: "ubuntu-latest"
-        jdk.version: "8"
-        python.version: '3.9'
-      windows_py39_jdk11:
-        imageName: "windows-2022"
-        python.version: '3.9'
-        jdk.version: '8'
-  pool:
-    vmImage: $(imageName)
-  steps:
-  - template: scripts/deps.yml
-  - script: |
-      python -m pytest -v --junit-xml=build/test/test8.xml test/jpypetest -k test_raise_for_java8

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -108,12 +108,12 @@ jobs:
       mac_py39_jdk11:
         imageName: "macos-13"
         python.version: '3.9'
-        extra_args: '--fast'
+        pytest_suppl_args: '--fast'
         jdk.version: '11'
       mac_py312_jdk17:
         imageName: "macos-13"
         python.version: '3.12'
-        extra_args: '--fast'
+        pytest_suppl_args: '--fast'
         jdk.version: '17'
       # special
       java8_deprecation:
@@ -121,7 +121,7 @@ jobs:
         jdk.version: '11'
         java_runtime: '8'
         python.version: '3.12'
-        extra_args: "-k test_raise_for_java8"
+        pytest_suppl_args: "-k test_raise_for_java8"
   pool:
     vmImage: $(imageName)
   steps:

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -127,6 +127,8 @@ jobs:
 
   - template: scripts/deps.yml
   - template: scripts/test.yml
+    parameters:
+      - pytest.selector
 
 - job: Debug
   condition: eq(1,0)

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -124,11 +124,8 @@ jobs:
   pool:
     vmImage: $(imageName)
   steps:
-
   - template: scripts/deps.yml
   - template: scripts/test.yml
-    parameters:
-      - pytest.selector
 
 - job: Debug
   condition: eq(1,0)

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -2,10 +2,11 @@
 parameters:
   - name: pytest_args
     type: string
-    default: ''
+    default: "" # empty string literal in windoze is the devil
   - name: java_runtime
     type: string
-    default: $(jdk.version)
+    # to be expanded later in the template compilation via the runtime variable.
+    default: "$(jdk.version)"
 
 steps:
 
@@ -41,12 +42,12 @@ steps:
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni '${{ parameters.pytest_args }}'
-  displayName: 'Test JDK $(java_runtime) and Python $(python.version)'
+  displayName: 'Test Java ${{ parameters.java_runtime }} and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast '${{ parameters.pytest_args }}'
-  displayName: 'Test JDK $(java_runtime) and Python $(python.version) (fast)'
+  displayName: 'Test Java ${{ parameters.java_runtime }} and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -27,13 +27,12 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pip install -U pytest
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '$(pytest.selector)'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '$(pytest.selector)'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -5,7 +5,7 @@ parameters:
     default: ''
   - name: java_runtime
     type: string
-    default: ${{ jdk.version }}
+    default: $(jdk.version)
 
 steps:
 
@@ -37,16 +37,16 @@ steps:
 # different runtime jdk?
 - template: jdk.yml
   parameters:
-    version: ${{ parameters.java_runtime }}
+    version: $(java_runtime)
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni '${{ parameters.pytest_args }}'
-  displayName: 'Test JDK ${{ parameters.java_runtime }} and Python $(python.version)'
+  displayName: 'Test JDK $(java_runtime) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast '${{ parameters.pytest_args }}'
-  displayName: 'Test JDK ${{ parameters.java_runtime }} and Python $(python.version) (fast)'
+  displayName: 'Test JDK $(java_runtime) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -42,10 +42,9 @@ steps:
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni \
-      ${{ eq(variables['jpypetest.fast'], 'true') ? "--fast" : "" }} \ 
+      ${{ if eq(variables['jpypetest.fast'], 'true') }}--fast${{ else }}${{ end }} \ 
       ${{ parameters.pytest_args }}
   displayName: 'Test Java ${{ parameters.java_runtime }} and Python $(python.version)'
-  condition:
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -3,6 +3,9 @@ parameters:
   - name: pytest_selector
     type: string
     default: ''
+  - name: java_runtime
+    type: string
+    default: '11'
 
 steps:
 
@@ -34,7 +37,7 @@ steps:
 # different runtime jdk?
 - template: jdk.yml
   parameters:
-    version: $(java_runtime)
+    version: $(parameters.java_runtime)
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ parameters.pytest_selector }}'

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -21,37 +21,27 @@ steps:
 - template: sdist.yml
 
 - script: |
-    python -m pip install -e .
+    python -m pip install -v -e .
   displayName: 'Build/install module'
 
 - script: |
+    # todo: numpy prior execution to build specific paths?
     pip install numpy jedi typing_extensions
     python -c "import jpype"
   displayName: 'Check module'
 
+# install testing dependencies
 - script: |
     pip install setuptools
     python setup.py test_java
     pip install -r test-requirements.txt
   displayName: 'Install test'
 
-- pwsh: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $env:EXTRA_ARGS
-  displayName: "Test JDK $(jdk.version) and Python $(python.version)"
-  condition: eq( variables['Agent.OS'], 'Windows_NT' )
-  env:
-    EXTRA_ARGS: ${{ parameters.pytest_suppl_args }}
-
-- bash: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $EXTRA_ARGS
-  displayName: "Test JDK $(jdk.version) and Python $(python.version)"
-  condition: or(eq( variables['Agent.OS'], 'Linux'), eq( variables['Agent.OS'], 'Darwin'))
-  env:
-    EXTRA_ARGS: ${{ parameters.pytest_suppl_args }}
-
+# execute pytest
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni ${{ parameters.pytest_suppl_args }}
-  displayName: "jooo"
+  displayName: "Test JDK $(jdk.version) and Python $(python.version)"
+
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |
     pip install .

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,6 +1,6 @@
 # This task tests individual platforms and versions
 parameters:
-  - name: pytest.selector
+  - name: pytest_selector
     type: string
     default: ''
 
@@ -32,12 +32,12 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ pytest.selector }}'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ pytest_selector }}'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ pytest.selector }}'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ pytest_selector }}'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -2,11 +2,15 @@
 parameters:
   - name: pytest_args
     type: string
-    default: "" # empty string literal in windoze is the devil
+    default: "" # empty string literal in windoze is the devil, so we wrap around that with additional (empty) variables
   - name: java_runtime
     type: string
     # to be expanded later in the template compilation via the runtime variable.
     default: "$(jdk.version)"
+
+variables:
+  ARG_FAST:    ${{ if eq(variables['jpypetest.fast'], 'true') }} --fast
+  PYTEST_ARGS:  ${{ if not eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}
 
 steps:
 
@@ -35,16 +39,9 @@ steps:
     pip install -r test-requirements.txt
   displayName: 'Install test'
 
-# different runtime jdk?
-- template: jdk.yml
-  parameters:
-    version: ${{ parameters.java_runtime }}
-
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni \
-      ${{ if eq(variables['jpypetest.fast'], 'true') }}--fast${{ else }}${{ end }} \ 
-      ${{ parameters.pytest_args }}
-  displayName: 'Test Java ${{ parameters.java_runtime }} and Python $(python.version)'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(ARG_FAST) $(PYTEST_ARGS)
+  displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,6 +1,6 @@
 # This task tests individual platforms and versions
 parameters:
-  - name: extra_args
+  - name: pytest_suppl_args
     type: string
     default: ""
   - name: java_runtime
@@ -39,7 +39,7 @@ steps:
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(EXTRA_ARGS)
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   env:
-    EXTRA_ARGS: ${{ parameters.extraArgs }}
+    EXTRA_ARGS: ${{ parameters.pytest_suppl_args }}
     # make the flags available as env vars if you prefer script-based assembly
     #ARG_FAST: ${{ if eq(jpypetest.fast, true) }} --fast
    # ARG_PYTEST: ${{ if !eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -32,12 +32,12 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ pytest_selector }}'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ parameters.pytest_selector }}'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ pytest_selector }}'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ parameters.pytest_selector }}'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -8,10 +8,6 @@ parameters:
     # to be expanded later in the template compilation via the runtime variable.
     default: "$(jdk.version)"
 
-variables:
-  ARG_FAST:    ${{ if eq(variables['jpypetest.fast'], 'true') }} --fast
-  PYTEST_ARGS:  ${{ if not eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}
-
 steps:
 
 - template: python.yml
@@ -40,9 +36,12 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(ARG_FAST) $(PYTEST_ARGS)
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(ARG_FAST) $(ARG_PYTEST)
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
-
+  env:
+    # make the flags available as env vars if you prefer script-based assembly
+    ARG_FAST: ${{ if eq(jpypetest.fast, true) }} --fast
+    ARG_PYTEST: ${{ if not eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |
     pip install .

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,6 +1,8 @@
 # This task tests individual platforms and versions
 parameters:
-  - pytest.selector
+  - name: pytest.selector
+    type: string
+    default: ''
 
 steps:
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -40,17 +40,17 @@ steps:
   displayName: "Test JDK $(jdk.version) and Python $(python.version)"
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
   env:
-    EXTRA_ARGS: ${{ parameters.extraArgs }}
+    EXTRA_ARGS: ${{ parameters.pytest_suppl_args }}
 
 - bash: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $EXTRA_ARGS
   displayName: "Test JDK $(jdk.version) and Python $(python.version)"
   condition: or(eq( variables['Agent.OS'], 'Linux'), eq( variables['Agent.OS'], 'Darwin'))
   env:
-    EXTRA_ARGS: ${{ parameters.extraArgs }}
+    EXTRA_ARGS: ${{ parameters.pytest_suppl_args }}
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni ${{ parameters.extraArgs }}
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni ${{ parameters.pytest_suppl_args }}
   displayName: "jooo"
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,8 +1,8 @@
 # This task tests individual platforms and versions
 parameters:
-  - name: pytest_args
+  - name: extra_args
     type: string
-    default: "" # empty string literal in windoze is the devil, so we wrap around that with additional (empty) variables
+    default: ""
   - name: java_runtime
     type: string
     # to be expanded later in the template compilation via the runtime variable.
@@ -36,12 +36,13 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(ARG_FAST) $(ARG_PYTEST)
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(EXTRA_ARGS)
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   env:
+    EXTRA_ARGS: ${{ parameters.extraArgs }}
     # make the flags available as env vars if you prefer script-based assembly
-    ARG_FAST: ${{ if eq(jpypetest.fast, true) }} --fast
-    ARG_PYTEST: ${{ if not eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}
+    #ARG_FAST: ${{ if eq(jpypetest.fast, true) }} --fast
+   # ARG_PYTEST: ${{ if !eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |
     pip install .

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -37,7 +37,7 @@ steps:
 # different runtime jdk?
 - template: jdk.yml
   parameters:
-    version: $(parameters.java_runtime)
+    version: ${{ parameters.java_runtime }}
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ parameters.pytest_selector }}'

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,4 +1,7 @@
 # This task tests individual platforms and versions
+parameters:
+  - pytest.selector
+
 steps:
 
 - template: python.yml
@@ -27,12 +30,12 @@ steps:
   displayName: 'Install test'
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '$(pytest.selector)'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ pytest.selector }}'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '$(pytest.selector)'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ pytest.selector }}'
   displayName: 'Test JDK $(jdk.version) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -31,14 +31,19 @@ steps:
     pip install -r test-requirements.txt
   displayName: 'Install test'
 
+# different runtime jdk?
+- template: jdk.yml
+  parameters:
+    version: $(java_runtime)
+
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ parameters.pytest_selector }}'
-  displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
+  displayName: 'Test JDK $(JAVA_HOME) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ parameters.pytest_selector }}'
-  displayName: 'Test JDK $(jdk.version) and Python $(python.version) (fast)'
+  displayName: 'Test JDK $(JAVA_HOME) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,11 +1,11 @@
 # This task tests individual platforms and versions
 parameters:
-  - name: pytest_selector
+  - name: pytest_args
     type: string
     default: ''
   - name: java_runtime
     type: string
-    default: '11'
+    default: ${{ jdk.version }}
 
 steps:
 
@@ -40,13 +40,13 @@ steps:
     version: ${{ parameters.java_runtime }}
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni -k '${{ parameters.pytest_selector }}'
-  displayName: 'Test JDK $(JAVA_HOME) and Python $(python.version)'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni '${{ parameters.pytest_args }}'
+  displayName: 'Test JDK ${{ parameters.java_runtime }} and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast -k '${{ parameters.pytest_selector }}'
-  displayName: 'Test JDK $(JAVA_HOME) and Python $(python.version) (fast)'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast '${{ parameters.pytest_args }}'
+  displayName: 'Test JDK ${{ parameters.java_runtime }} and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -41,14 +41,11 @@ steps:
     version: ${{ parameters.java_runtime }}
 
 - script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni '${{ parameters.pytest_args }}'
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni \
+      ${{ eq(variables['jpypetest.fast'], 'true') ? "--fast" : "" }} \ 
+      ${{ parameters.pytest_args }}
   displayName: 'Test Java ${{ parameters.java_runtime }} and Python $(python.version)'
-  condition: eq(variables['jpypetest.fast'], 'false')
-
-- script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni --fast '${{ parameters.pytest_args }}'
-  displayName: 'Test Java ${{ parameters.java_runtime }} and Python $(python.version) (fast)'
-  condition: eq(variables['jpypetest.fast'], 'true')
+  condition:
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -38,7 +38,7 @@ steps:
 # different runtime jdk?
 - template: jdk.yml
   parameters:
-    version: $(java_runtime)
+    version: ${{ parameters.java_runtime }}
 
 - script: |
     python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni '${{ parameters.pytest_args }}'

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -35,14 +35,23 @@ steps:
     pip install -r test-requirements.txt
   displayName: 'Install test'
 
-- script: |
-    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $(EXTRA_ARGS)
-  displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
+- pwsh: |
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $env:EXTRA_ARGS
+  displayName: "Test JDK $(jdk.version) and Python $(python.version)"
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
   env:
-    EXTRA_ARGS: ${{ parameters.pytest_suppl_args }}
-    # make the flags available as env vars if you prefer script-based assembly
-    #ARG_FAST: ${{ if eq(jpypetest.fast, true) }} --fast
-   # ARG_PYTEST: ${{ if !eq(parameters.pytest_args, '') }} ${{ parameters.pytest_args }}
+    EXTRA_ARGS: ${{ parameters.extraArgs }}
+
+- bash: |
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni $EXTRA_ARGS
+  displayName: "Test JDK $(jdk.version) and Python $(python.version)"
+  condition: or(eq( variables['Agent.OS'], 'Linux'), eq( variables['Agent.OS'], 'Darwin'))
+  env:
+    EXTRA_ARGS: ${{ parameters.extraArgs }}
+
+- script: |
+    python -m pytest -v --junit-xml=build/test/test.xml test/jpypetest --checkjni ${{ parameters.extraArgs }}
+  displayName: "jooo"
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |
     pip install .

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -264,6 +264,7 @@ public:
 
 	// This will gather C++ resources to clean up after shutdown.
 	std::list<JPResource*> m_Resources;
+	static PyObject* getJVMVersion(const char*);
 } ;
 
 extern "C" JPContext* JPContext_global;

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -264,7 +264,8 @@ public:
 
 	// This will gather C++ resources to clean up after shutdown.
 	std::list<JPResource*> m_Resources;
-	static PyObject* getJVMVersion(const char*);
+    // TODO: this is actually not dependent on jpcontext at all and should go somewhere else
+	static PyObject* getJVMVersion(PyObject* self, PyObject* args);
 } ;
 
 extern "C" JPContext* JPContext_global;

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -236,9 +236,7 @@ PyObject* JPContext::getJVMVersion(PyObject* self, PyObject* args) {
         JP_TRACE("Load entry points");
         JPPlatformAdapter *platform = JPPlatformAdapter::getAdapter();
         // Load symbols from the shared library
-        printf("prior load lib\n");
         platform->loadLibrary(jvm_path);
-        printf("after load lib\n");
         CreateJVM_Method = (jint(JNICALL *)(JavaVM **, void **, void *) )platform->getSymbol("JNI_CreateJavaVM");
     } catch (JPypeException& ex)
     {
@@ -274,29 +272,19 @@ PyObject* JPContext::getJVMVersion(PyObject* self, PyObject* args) {
             env->NewStringUTF("java.version")
     );
 
-    const char* chars = env->GetStringUTFChars(versionStr, nullptr);
-
     if (versionStr == nullptr) {
-        std::cerr << "CallStaticObjectMethod returned null" << std::endl;
+		JP_TRACE("CallStaticObjectMethod returned null");
     } else {
         const char* versionCStr = env->GetStringUTFChars(versionStr, nullptr);
         if (versionCStr) {
-            std::cout << "Java version: " << versionCStr << std::endl;
             // convert c string to pyobject string
             PyObject *py = PyUnicode_FromStringAndSize(versionCStr, strlen(versionCStr));
             env->ReleaseStringUTFChars(versionStr, versionCStr);
             return py;
         } else {
-            throw std::runtime_error("Failed to get UTF chars from jstring");
-            std::cerr << "Failed to get UTF chars from jstring" << std::endl;
+			JP_TRACE("Failed to get UTF chars from jstring");
         }
     }
-    //JP_TRACE("cstr version: %s\n", version);
-
-    // convert c string to pyobject string
-    //PyObject *py = PyUnicode_FromStringAndSize(version, strlen(version));
-    // free resources.
-	//env->ReleaseStringUTFChars(versionStr, version);
 	jvm->DestroyJavaVM();
 
 	return nullptr;

--- a/native/common/jp_platform.cpp
+++ b/native/common/jp_platform.cpp
@@ -132,6 +132,7 @@ public:
 		{
 			JP_TRACE("null library");
 			JP_TRACE("errno", errno);
+			JP_TRACE("strerror", strerror(errno));
 			if (errno == ENOEXEC)
 			{
 				JP_TRACE("dignostics", dlerror());

--- a/native/common/jp_platform.cpp
+++ b/native/common/jp_platform.cpp
@@ -107,7 +107,7 @@ public:
 #endif // HPUX
 #include <errno.h>
 
-// The code in this modules is mostly excluded from coverage as it is only
+// The code in this module is mostly excluded from coverage as it is only
 // possible to execute during a fatal error.
 
 class LinuxPlatformAdapter : public JPPlatformAdapter

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -702,8 +702,8 @@ static PyObject *PyJPModule_bootstrap(PyObject *module)
 #endif
 
 static PyMethodDef moduleMethods[] = {
-        // obtain jvm version (must be called in separate process!)
-		{"_get_jvm_version", (PyCFunction) JPContext::getJVMVersion, METH_VARARGS, ""},
+    // obtain jvm version from a new JVM instance. (must be called in separate process or things will horribly go wrong!)
+	{"_get_jvm_version", (PyCFunction) JPContext::getJVMVersion, METH_VARARGS, ""},
 	// Startup and initialization
 	{"isStarted", (PyCFunction) PyJPModule_isStarted, METH_NOARGS, ""},
 #ifdef ANDROID

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -702,6 +702,8 @@ static PyObject *PyJPModule_bootstrap(PyObject *module)
 #endif
 
 static PyMethodDef moduleMethods[] = {
+        // obtain jvm version (must be called in separate process!)
+		{"_get_jvm_version", (PyCFunction) JPContext::getJVMVersion, METH_VARARGS, ""},
 	// Startup and initialization
 	{"isStarted", (PyCFunction) PyJPModule_isStarted, METH_NOARGS, ""},
 #ifdef ANDROID

--- a/setupext/build_ext.py
+++ b/setupext/build_ext.py
@@ -306,6 +306,12 @@ class BuildExtCommand(build_ext):
             "Jar cache is missing, using --enable-build-jar to recreate it.")
 
         target_version = "11"
+        # todo: target and source version are used synonymously. consider -release x
+        """
+        warning: [options] location of system modules is not set in conjunction with -source 11
+          not setting the location of system modules may lead to class files that cannot run on JDK 11
+          --release 11 is recommended instead of -source 11 -target 11 because it sets the location of system modules automatically
+        """
         # build the jar
         try:
             dirname = os.path.dirname(self.get_ext_fullpath("JAVA"))

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -15,8 +15,6 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
-from functools import lru_cache
-
 import pytest
 import _jpype
 import jpype
@@ -152,43 +150,3 @@ class JPypeTestCase(unittest.TestCase):
 
     def useEqualityFunc(self, func):
         return UseFunc(self, func, 'assertEqual')
-
-
-@lru_cache(1)
-def java_version() -> dict:
-
-    def get_jvm_version(java_bin="java"):
-        import subprocess
-        import re
-
-        try:
-            # java -version prints to stderr for most vendors
-            result = subprocess.run(
-                [java_bin, "-version"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                check=True
-            )
-            output = result.stderr.decode() + "\n" + result.stdout.decode()
-
-            # Look for first quoted string like "25.0.1" or "11.0.20"
-            m = re.search(r'"([\d._]+)"', output)
-            if m:
-                version_str = m.group(1)
-                # Normalize underscores to dots
-                version_str = version_str.replace("_", ".")
-                # Split into components if needed
-                parts = version_str.split(".")
-                major = int(parts[0])
-                minor = int(parts[1]) if len(parts) > 1 else 0
-                patch = int(parts[2]) if len(parts) > 2 else 0
-                return {"full": version_str, "major": major, "minor": minor, "patch": patch}
-            else:
-                raise ValueError("Cannot parse java -version output")
-
-        except FileNotFoundError:
-            raise RuntimeError(f"Java binary not found: {java_bin}")
-        except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"java -version failed: {e}")
-
-    return get_jvm_version()

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -155,38 +155,40 @@ class JPypeTestCase(unittest.TestCase):
 
 
 @lru_cache(1)
-def java_version():
-    import subprocess
-import re
+def java_version() -> dict:
 
-def get_jvm_version(java_bin="java"):
-    import subprocess
-    try:
-        # java -version prints to stderr for most vendors
-        result = subprocess.run(
-            [java_bin, "-version"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=True
-        )
-        output = result.stderr.decode() + "\n" + result.stdout.decode()
+    def get_jvm_version(java_bin="java"):
+        import subprocess
+        import re
 
-        # Look for first quoted string like "25.0.1" or "11.0.20"
-        m = re.search(r'"([\d._]+)"', output)
-        if m:
-            version_str = m.group(1)
-            # Normalize underscores to dots
-            version_str = version_str.replace("_", ".")
-            # Split into components if needed
-            parts = version_str.split(".")
-            major = int(parts[0])
-            minor = int(parts[1]) if len(parts) > 1 else 0
-            patch = int(parts[2]) if len(parts) > 2 else 0
-            return {"full": version_str, "major": major, "minor": minor, "patch": patch}
-        else:
-            raise ValueError("Cannot parse java -version output")
+        try:
+            # java -version prints to stderr for most vendors
+            result = subprocess.run(
+                [java_bin, "-version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True
+            )
+            output = result.stderr.decode() + "\n" + result.stdout.decode()
 
-    except FileNotFoundError:
-        raise RuntimeError(f"Java binary not found: {java_bin}")
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"java -version failed: {e}")
+            # Look for first quoted string like "25.0.1" or "11.0.20"
+            m = re.search(r'"([\d._]+)"', output)
+            if m:
+                version_str = m.group(1)
+                # Normalize underscores to dots
+                version_str = version_str.replace("_", ".")
+                # Split into components if needed
+                parts = version_str.split(".")
+                major = int(parts[0])
+                minor = int(parts[1]) if len(parts) > 1 else 0
+                patch = int(parts[2]) if len(parts) > 2 else 0
+                return {"full": version_str, "major": major, "minor": minor, "patch": patch}
+            else:
+                raise ValueError("Cannot parse java -version output")
+
+        except FileNotFoundError:
+            raise RuntimeError(f"Java binary not found: {java_bin}")
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"java -version failed: {e}")
+
+    return get_jvm_version()

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -158,9 +158,10 @@ class JPypeTestCase(unittest.TestCase):
 def java_version():
     import subprocess
     import sys
-    java_version = str(subprocess.check_output([sys.executable, "-c",
-                          "import jpype; jpype.startJVM(); "
-                          "print(jpype.java.lang.System.getProperty('java.version'))"]),
-                       encoding='ascii')
+    # java_version = str(subprocess.check_output([sys.executable, "-c",
+    #                       "import jpype; jpype.startJVM(); "
+    #                       "print(jpype.java.lang.System.getProperty('java.version'))"]),
+    #                    encoding='ascii')
+    java_version = str(subprocess.check_output(["java", "-version"]))
     # todo: make this robust for version "numbers" containing strings (e.g.) 22.1-internal
     return tuple(map(int, java_version.split(".")))

--- a/test/jpypetest/common.py
+++ b/test/jpypetest/common.py
@@ -157,11 +157,36 @@ class JPypeTestCase(unittest.TestCase):
 @lru_cache(1)
 def java_version():
     import subprocess
-    import sys
-    # java_version = str(subprocess.check_output([sys.executable, "-c",
-    #                       "import jpype; jpype.startJVM(); "
-    #                       "print(jpype.java.lang.System.getProperty('java.version'))"]),
-    #                    encoding='ascii')
-    java_version = str(subprocess.check_output(["java", "-version"]))
-    # todo: make this robust for version "numbers" containing strings (e.g.) 22.1-internal
-    return tuple(map(int, java_version.split(".")))
+import re
+
+def get_jvm_version(java_bin="java"):
+    import subprocess
+    try:
+        # java -version prints to stderr for most vendors
+        result = subprocess.run(
+            [java_bin, "-version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True
+        )
+        output = result.stderr.decode() + "\n" + result.stdout.decode()
+
+        # Look for first quoted string like "25.0.1" or "11.0.20"
+        m = re.search(r'"([\d._]+)"', output)
+        if m:
+            version_str = m.group(1)
+            # Normalize underscores to dots
+            version_str = version_str.replace("_", ".")
+            # Split into components if needed
+            parts = version_str.split(".")
+            major = int(parts[0])
+            minor = int(parts[1]) if len(parts) > 1 else 0
+            patch = int(parts[2]) if len(parts) > 2 else 0
+            return {"full": version_str, "major": major, "minor": minor, "patch": patch}
+        else:
+            raise ValueError("Cannot parse java -version output")
+
+    except FileNotFoundError:
+        raise RuntimeError(f"Java binary not found: {java_bin}")
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"java -version failed: {e}")

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -15,10 +15,12 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
+import os
 
 import pytest
 
 import common
+import jpype
 
 
 def pytest_addoption(parser):
@@ -45,3 +47,51 @@ def common_opts(request):
     request.cls._convertStrings = request.config.getoption("--convertStrings")
     request.cls._jacoco = request.config.getoption("--jacoco")
     request.cls._checkjni = request.config.getoption("--checkjni")
+
+def _run_cmd(queue, jvm_path):
+    import _jpype, pathlib
+    print("pid:", os.getpid())
+    version = _jpype._get_jvm_version(jvm_path)
+    queue.put(version)
+
+@pytest.fixture(scope="session", autouse=True)
+def java_version():
+    print("pid:", os.getpid())
+    print("hi from java version")
+    def _java_version() -> dict:
+        import jpype
+        jvm_path = jpype.getDefaultJVMPath()
+
+
+        import multiprocessing as mp
+        ctx = mp.get_context("spawn")
+        queue = ctx.Queue()
+        p = ctx.Process(target=_run_cmd, args=(queue, jvm_path))
+        p.start()
+        print("join version proc")
+        p.join(timeout=1)
+        print("joinED version proc")
+        version = queue.get()
+        print(version)
+
+        def parse_output(output):
+            import re
+
+            # Look for first quoted string like "25.0.1" or "11.0.20"
+            m = re.search(r'"([\d._]+)"', output)
+            if m:
+                version_str = m.group(1)
+                # Normalize underscores to dots
+                version_str = version_str.replace("_", ".")
+                # Split into components if needed
+                parts = version_str.split(".")
+                major = int(parts[0])
+                minor = int(parts[1]) if len(parts) > 1 else 0
+                patch = int(parts[2]) if len(parts) > 2 else 0
+                return {"full": version_str, "major": major, "minor": minor, "patch": patch}
+            else:
+                raise ValueError("Cannot parse java -version output")
+
+        return parse_output(version)
+
+    return _java_version()

--- a/test/jpypetest/test_sql_h2.py
+++ b/test/jpypetest/test_sql_h2.py
@@ -21,13 +21,10 @@ except ImportError:
 
 db_name = "jdbc:h2:mem:testdb"
 
-def setUpModule(module):
-    from common import java_version
-    version = java_version()
-    if version["major"] == 1 and version["minor"] == 8:
+@pytest.fixture(scope="module", autouse=True)
+def check_jvm_version(java_version):
+    if java_version["major"] == 1 and java_version["minor"] == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
-
-
 
 class ConnectTestCase(common.JPypeTestCase):
     def setUp(self):

--- a/test/jpypetest/test_sql_h2.py
+++ b/test/jpypetest/test_sql_h2.py
@@ -24,7 +24,7 @@ db_name = "jdbc:h2:mem:testdb"
 def setUpModule(module):
     from common import java_version
     version = java_version()
-    if version[0] == 1 and version[1] == 8:
+    if version["major"] == 1 and version["minor"] == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 

--- a/test/jpypetest/test_sql_h2.py
+++ b/test/jpypetest/test_sql_h2.py
@@ -23,7 +23,7 @@ db_name = "jdbc:h2:mem:testdb"
 
 @pytest.fixture(scope="module", autouse=True)
 def check_jvm_version(java_version):
-    if java_version["major"] == 1 and java_version["minor"] == 8:
+    if java_version.major == 1 and java_version.minor == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 class ConnectTestCase(common.JPypeTestCase):

--- a/test/jpypetest/test_sql_hsqldb.py
+++ b/test/jpypetest/test_sql_hsqldb.py
@@ -28,7 +28,7 @@ def setUpModule(module):
     from common import java_version
     import pytest
     version = java_version()
-    if version[0] == 1 and version[1] == 8:
+    if version["major"] == 1 and version["minor"] == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 

--- a/test/jpypetest/test_sql_hsqldb.py
+++ b/test/jpypetest/test_sql_hsqldb.py
@@ -28,7 +28,7 @@ db_name = "jdbc:hsqldb:mem:myDb"
 
 @pytest.fixture(scope="module", autouse=True)
 def check_jvm_version(java_version):
-    if java_version["major"] == 1 and java_version["minor"] == 8:
+    if java_version.major == 1 and java_version.minor == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 @common.unittest.skipUnless(zlib, "requires zlib")

--- a/test/jpypetest/test_sql_hsqldb.py
+++ b/test/jpypetest/test_sql_hsqldb.py
@@ -1,6 +1,8 @@
 # This file is Public Domain and may be used without restrictions,
 # because noone should have to waste their lives typing this again.
 import _jpype
+import pytest
+
 import jpype
 from jpype.types import *
 from jpype import java
@@ -24,21 +26,14 @@ db_name = "jdbc:hsqldb:mem:myDb"
 #first = "jdbc:derby:memory:myDb;create=True"
 
 
-def setUpModule(module):
-    from common import java_version
-    import pytest
-    version = java_version()
-    if version["major"] == 1 and version["minor"] == 8:
+@pytest.fixture(scope="module", autouse=True)
+def check_jvm_version(java_version):
+    if java_version["major"] == 1 and java_version["minor"] == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
-
 @common.unittest.skipUnless(zlib, "requires zlib")
+@pytest.mark.skipif(common.fast, reason="skip sql tests due to fast setting.")
 class ConnectTestCase(common.JPypeTestCase):
-    def setUp(self):
-        common.JPypeTestCase.setUp(self)
-        if common.fast:
-            raise common.unittest.SkipTest("fast")
-
     def testConnect(self):
         cx = dbapi2.connect(db_name)
         self.assertIsInstance(cx, dbapi2.Connection)

--- a/test/jpypetest/test_sql_sqlite.py
+++ b/test/jpypetest/test_sql_sqlite.py
@@ -23,7 +23,7 @@ db_name = "jdbc:sqlite::memory:"
 def setUpModule(module):
     from common import java_version
     version = java_version()
-    if version[0] == 1 and version[1] == 8:
+    if version["major"] == 1 and version["minor"] == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 

--- a/test/jpypetest/test_sql_sqlite.py
+++ b/test/jpypetest/test_sql_sqlite.py
@@ -22,7 +22,7 @@ db_name = "jdbc:sqlite::memory:"
 
 @pytest.fixture(scope="module", autouse=True)
 def check_jvm_version(java_version):
-    if java_version["major"] == 1 and java_version["minor"] == 8:
+    if java_version.major == 1 and java_version.minor == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 

--- a/test/jpypetest/test_sql_sqlite.py
+++ b/test/jpypetest/test_sql_sqlite.py
@@ -20,18 +20,14 @@ except ImportError:
 
 db_name = "jdbc:sqlite::memory:"
 
-def setUpModule(module):
-    from common import java_version
-    version = java_version()
-    if version["major"] == 1 and version["minor"] == 8:
+@pytest.fixture(scope="module", autouse=True)
+def check_jvm_version(java_version):
+    if java_version["major"] == 1 and java_version["minor"] == 8:
         pytest.skip("jdk8 unsupported", allow_module_level=True)
 
 
+@pytest.mark.skipif(common.fast, reason="skip sql tests due to fast setting.")
 class ConnectTestCase(common.JPypeTestCase):
-    def setUp(self):
-        common.JPypeTestCase.setUp(self)
-        if common.fast:
-            raise common.unittest.SkipTest("fast")
 
     def testConnect(self):
         cx = dbapi2.connect(db_name)

--- a/test/jpypetest/test_startup.py
+++ b/test/jpypetest/test_startup.py
@@ -226,9 +226,8 @@ class StartJVMCase(unittest.TestCase):
         except ZoneRulesException:
             self.fail("JpypeZoneRulesProvider not loaded")
 
-    #@unittest.skipUnless(common.java_version()["major"] < 9, "run only for Java8")
     def test_raise_for_java8(self, java_version):
-        if java_version["major"] < 9:
+        if java_version.major < 9:
             self.skipTest("run only for Java8")
         with self.assertRaises(RuntimeError, msg=".*requires at least Java9 to run.*"):
             jpype.startJVM()

--- a/test/jpypetest/test_startup.py
+++ b/test/jpypetest/test_startup.py
@@ -226,7 +226,7 @@ class StartJVMCase(unittest.TestCase):
         except ZoneRulesException:
             self.fail("JpypeZoneRulesProvider not loaded")
 
-    @unittest.skipUnless(common.java_version() < (9,), "run only for Java8")
+    @unittest.skipUnless(common.java_version()["major"] < 9, "run only for Java8")
     def test_raise_for_java8(self):
         with self.assertRaises(RuntimeError, msg=".*requires at least Java9 to run.*"):
             jpype.startJVM()

--- a/test/jpypetest/test_startup.py
+++ b/test/jpypetest/test_startup.py
@@ -15,7 +15,6 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
-import pytest
 from packaging.version import Version
 
 import jpype

--- a/test/jpypetest/test_startup.py
+++ b/test/jpypetest/test_startup.py
@@ -226,7 +226,9 @@ class StartJVMCase(unittest.TestCase):
         except ZoneRulesException:
             self.fail("JpypeZoneRulesProvider not loaded")
 
-    @unittest.skipUnless(common.java_version()["major"] < 9, "run only for Java8")
-    def test_raise_for_java8(self):
+    #@unittest.skipUnless(common.java_version()["major"] < 9, "run only for Java8")
+    def test_raise_for_java8(self, java_version):
+        if java_version["major"] < 9:
+            self.skipTest("run only for Java8")
         with self.assertRaises(RuntimeError, msg=".*requires at least Java9 to run.*"):
             jpype.startJVM()

--- a/test/jpypetest/test_startup.py
+++ b/test/jpypetest/test_startup.py
@@ -15,6 +15,9 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
+import pytest
+from packaging.version import Version
+
 import jpype
 import subrun
 import os
@@ -226,8 +229,11 @@ class StartJVMCase(unittest.TestCase):
         except ZoneRulesException:
             self.fail("JpypeZoneRulesProvider not loaded")
 
-    def test_raise_for_java8(self, java_version):
-        if java_version.major < 9:
+    def test_raise_for_java8(self):
+        # we cannot use our pytest java_version fixture here, because the run is not performed in pytest in the subrun.
+        import _jpype
+        jvm_version = _jpype._get_jvm_version(jpype.getDefaultJVMPath())
+        if Version(jvm_version).major < 9:
             self.skipTest("run only for Java8")
         with self.assertRaises(RuntimeError, msg=".*requires at least Java9 to run.*"):
             jpype.startJVM()

--- a/test/jpypetest/test_startup.py
+++ b/test/jpypetest/test_startup.py
@@ -225,3 +225,8 @@ class StartJVMCase(unittest.TestCase):
             ZoneId.of("JpypeTest/Timezone")
         except ZoneRulesException:
             self.fail("JpypeZoneRulesProvider not loaded")
+
+    @unittest.skipUnless(common.java_version() < (9,), "run only for Java8")
+    def test_raise_for_java8(self):
+        with self.assertRaises(RuntimeError, msg=".*requires at least Java9 to run.*"):
+            jpype.startJVM()


### PR DESCRIPTION
We require now JNI_VERSION 9 := Java 9 to enforce the usage of at least Java9. If we fail to create the JVM with this requirement, we provide a user understandable error message.

I've tested it locally building Jpype with Java25 and then run it with Java8 to trigger the error message.
Also added a test case for it. This required to change the ci pipeline at little bit. We are now able to pass additional arguments to pytest via new parameter.

I've also added a simple function to obtain the JVM version for a given JVM library path. However due to restrictions of JNI, we need to ensure this method is only called from a distinct process, e.g. starting multiple JVM instances is not allowed.

