### PR TITLE
[JPConversionAsBoolean] fixed numpy 2.3 breaking change of np.bool_  not being a Python bool anymore.

### DIFF
--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -49,15 +49,20 @@ class JPConversionAsBoolean : public JPConversion
 {
 public:
 
-	JPMatch::Type matches(JPClass *cls, JPMatch &match) override
-	{
-		if (!PyBool_Check(match.object))
-			return match.type = JPMatch::_none;
-		match.conversion = this;
-		return match.type = JPMatch::_exact;
-	}
+    JPMatch::Type matches(JPClass *cls, JPMatch &match) override
+    {
+        PyObject* obj = match.object;
 
-	void getInfo(JPClass * cls, JPConversionInfo &info) override
+        if (PyBool_Check(obj) || PyObject_IsInstance(obj, (PyObject*)_NPBool_Type))
+        {
+            match.conversion = this;
+            return match.type = JPMatch::_exact;
+        }
+
+        return match.type = JPMatch::_none;
+    }
+
+    void getInfo(JPClass * cls, JPConversionInfo &info) override
 	{
 		PyList_Append(info.exact, (PyObject*) & PyBool_Type);
 	}

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -514,7 +514,7 @@ public:
 		for (jlong i = 0; i < length && match.type > JPMatch::_none; i++)
 		{
 			// This is a special case.  Sequences produce new references
-			// so we must hold the reference in a container while the
+			// so we must hold the reference in a container while
 			// the match is caching it.
 			JPPyObject item = seq[i];
 			JPMatch imatch(match.frame, item.get());

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -154,7 +154,9 @@ extern PyObject *_JMethodAnnotations;
 extern PyObject *_JMethodCode;
 extern PyObject *_JObjectKey;
 extern PyObject *_JVMNotRunning;
-extern PyObject* PyJPClassMagic;
+extern PyObject *PyJPClassMagic;
+// for caching type checks with Numpy bool after np version 2.1
+extern PyTypeObject *_NPBool_Type;
 
 extern JPContext* JPContext_global;
 

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -24,6 +24,29 @@
 #include <Windows.h>
 #endif
 
+namespace {
+int init_numpy_bool_type()
+{
+	JP_TRACE("init_numpy_bool_type()");
+	PyObject *numpy = PyImport_ImportModule("numpy");
+	if (numpy == nullptr) {
+		return -1;
+	}
+
+	PyObject *t = PyObject_GetAttrString(numpy, "bool_");
+	Py_DECREF(numpy);
+	if (t == nullptr) {
+		JP_TRACE("bool_ attr not found");
+		return -1;
+	}
+
+	/* store as PyTypeObject* for fast checks */
+	_NPBool_Type = (PyTypeObject *)t;
+	return 0;
+}
+
+}
+
 void PyJPModule_installGC(PyObject* module);
 
 bool _jp_cpp_exceptions = false;
@@ -76,6 +99,7 @@ PyObject* _JMethodAnnotations = nullptr;
 PyObject* _JMethodCode = nullptr;
 PyObject* _JObjectKey = nullptr;
 PyObject* _JVMNotRunning = nullptr;
+PyTypeObject* _NPBool_Type = nullptr;
 
 void PyJPModule_loadResources(PyObject* module)
 {
@@ -791,6 +815,8 @@ PyMODINIT_FUNC PyInit__jpype()
 	PyJPChar_initType(module);
 
 	_PyJPModule_trace = true;
+
+	init_numpy_bool_type();
 
 	return module;
 	JP_PY_CATCH(nullptr); // GCOVR_EXCL_LINE

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -634,3 +634,10 @@ class ArrayTestCase(common.JPypeTestCase):
         a = jpype.JInt[5]
         with self.assertRaises(TypeError):
             b = a * 3
+
+    @common.requireNumpy
+    def testNumpyBool2dArray(self):
+        """Regression test for numpy 2.3"""
+        np_array = np.array([[True, False], [False, True]])
+        bool_2d = JArray(JBoolean, dims=2)(np_array)
+        np.testing.assert_array_equal(np_array, bool_2d)


### PR DESCRIPTION
Historically, NumPy had its own boolean scalar type, numpy.bool_, which is a subclass of numpy.generic but not of Python’s built-in bool. For a long time it was also an instance of PyBool_Type — so PyBool_Check(obj) returned true for both True/False and for numpy.bool_ scalars.

Fixes https://github.com/jpype-project/jpype/issues/1307