### PR TITLE
update license fields in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 description = "A Python to Java bridge"
 readme = "README.rst"
 requires-python = ">=3.8"
-license = {text = "License :: OSI Approved :: Apache Software License"}
+license = {text = "Apache-2.0"}
 classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.8',
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
     'Topic :: Software Development',
     'Topic :: Scientific/Engineering',
+    'License :: OSI Approved :: Apache Software License',
 ]
 dependencies = [
     'packaging',


### PR DESCRIPTION
License in the pyproject.toml need to be SPDX (https://spdx.org/licenses/) for the license field
The other one is for the classifiers.

At this moment the license of Jpype1 is shown as "License :: OSI Approved :: Apache Software License" but should be " 	Apache-2.0" 
https://pypi.org/project/jpype1/

