### PR TITLE
fix pyproject.toml pytest addopts type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pytest]
-addopts = "--verbose"
+addopts = ["--verbose"]
 testpaths = ["test", "jpype/_pyinstaller"]
 
 


### PR DESCRIPTION
Very recent Pytest update requests that "addopts" option in pyproject.toml is a list, not a plain string