### PR TITLE
[ci/codeql] ignore test (py) and fix cpp scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,9 @@ jobs:
         if: ${{ matrix.language == 'python' }}
 
       - name: Build cpp
-        run: pip install . --verbose --no-build-isolation
+        run: |
+          pip install scikit-build-core
+          pip install . --verbose --no-build-isolation
         if: ${{ matrix.language == 'cpp' }}
 
       - name: Build java


### PR DESCRIPTION
#1322 introduced a breakage within the cpp scanning. The build isolation of pip hinders the codeql tracer