### PR TITLE
update pyproject.toml to follow new license format so builds are supported after Feb. 18th

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "A Python to Java bridge"
 readme = "README.rst"
 requires-python = ">=3.8"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 classifiers = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.8',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Software Development',
-    'Topic :: Scientific/Engineering',
-    'License :: OSI Approved :: Apache Software License',
+    'Topic :: Scientific/Engineering'
 ]
 dependencies = [
     'packaging',


### PR DESCRIPTION
```
#16 10.05       [stderr]
#16 10.05       /root/.cache/uv/builds-v0/.tmpGUmIWv/lib/python3.14/site-packages/setuptools/config/_apply_pyprojecttoml.py:82:
#16 10.05       SetuptoolsDeprecationWarning: `project.license` as a TOML table is
#16 10.05       deprecated
#16 10.05       !!
#16 10.05 
#16 10.05       
#16 10.05       ********************************************************************************
#16 10.05               Please use a simple string containing a SPDX expression for
#16 10.05       `project.license`. You can also use `project.license-files`. (Both
#16 10.05       options available on setuptools>=77.0.0).
#16 10.05 
#16 10.05               By 2026-Feb-18, you need to update your project and remove
#16 10.05       deprecated calls
#16 10.05               or your builds will no longer be supported.
#16 10.05 
#16 10.05               See
#16 10.05       https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
#16 10.05       for details.
#16 10.05       
#16 10.05       ********************************************************************************
```

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license