### PR TITLE
removed readthedocs_ext from requirements

### DIFF
--- a/.azure/doc-requirements.txt
+++ b/.azure/doc-requirements.txt
@@ -2,6 +2,5 @@ Pygments
 docutils
 commonmark
 recommonmark
-sphinx
+sphinx>=9
 sphinx-rtd-theme
-readthedocs-sphinx-ext

--- a/.azure/scripts/documentation.yml
+++ b/.azure/scripts/documentation.yml
@@ -2,7 +2,7 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.10'
+    versionSpec: '3.11'
 
 - script: |
     pip install  --exists-action=w --no-cache-dir -r test-requirements.txt -r .azure/doc-requirements.txt

--- a/.azure/scripts/documentation.yml
+++ b/.azure/scripts/documentation.yml
@@ -2,7 +2,7 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.9'
+    versionSpec: '3.10'
 
 - script: |
     pip install  --exists-action=w --no-cache-dir -r test-requirements.txt -r .azure/doc-requirements.txt

--- a/.azure/scripts/documentation.yml
+++ b/.azure/scripts/documentation.yml
@@ -9,7 +9,7 @@ steps:
   displayName: 'Install requirements'
 
 - script: |
-    python -m sphinx -T -b readthedocs -d _build/doctrees-readthedocs -D language=en -W doc build/html
+    python -m sphinx -T -b html -d _build/doctrees-readthedocs -D language=en -W doc build/html
   displayName: 'Check documentation'
 
 - task: CopyFiles@2

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,8 @@ sys.path.insert(0, os.path.abspath('.'))
 extensions = ['sphinx.ext.napoleon',
         'sphinx.ext.autodoc',
        'sphinx.ext.autosectionlabel',
-       'readthedocs_ext.readthedocs', ]
+]
+
 autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
 [project.optional-dependencies]
 
 docs = [
-    'readthedocs-sphinx-ext',
     'sphinx',
     'sphinx-rtd-theme',
 ]


### PR DESCRIPTION
The Sphinx extension "readthedocs_ext" is kind of deprecated (archived repo) and not compatible with the latest release of Sphinx.
Therefor we remove it from our doc building process.

Fixes #1339 