### PR TITLE
Fix numpy null

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -80,6 +80,11 @@ jobs:
         imageName: "ubuntu-latest"
         python.version: '3.12'
         jdk.version: '17'
+      linux_py312_jdk17_no_numpy:
+        imageName: "ubuntu-latest"
+        python.version: '3.12'
+        jdk.version: '17'
+        skip_numpy: 'true'
       linux_py313_jdk17:
         imageName: "ubuntu-latest"
         python.version: "3.13"

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -38,6 +38,7 @@ steps:
       pip install -r test-requirements.txt
     fi
   displayName: 'Install test requirements'
+  script: bash
 
 - script: |
     ant -f test

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -29,7 +29,7 @@ steps:
 #    python -c "import jpype"
 #  displayName: 'Build/install/check module (editable)'
 
-- script: |
+- bash: |
     # Create a temporary requirements file without numpy if skip_numpy is true
     if [ "$(skip_numpy)" == "true" ]; then
       grep -v "numpy" test-requirements.txt > test-requirements-no-numpy.txt
@@ -38,7 +38,6 @@ steps:
       pip install -r test-requirements.txt
     fi
   displayName: 'Install test requirements'
-  script: bash
 
 - script: |
     ant -f test

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -30,7 +30,13 @@ steps:
 #  displayName: 'Build/install/check module (editable)'
 
 - script: |
-    pip install -r test-requirements.txt
+    # Create a temporary requirements file without numpy if skip_numpy is true
+    if [ "$(skip_numpy)" == "true" ]; then
+      grep -v "numpy" test-requirements.txt > test-requirements-no-numpy.txt
+      pip install -r test-requirements-no-numpy.txt
+    else
+      pip install -r test-requirements.txt
+    fi
   displayName: 'Install test requirements'
 
 - script: |

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -53,7 +53,7 @@ public:
     {
         PyObject* obj = match.object;
 
-        if (PyBool_Check(obj) || PyJP_IsInstanceSingle(obj, __numpy_bool_type))
+        if (PyBool_Check(obj) || PyJP_IsInstanceSingle(obj, (PyTypeObject*)_numpy_bool_type))
         {
             match.conversion = this;
             return match.type = JPMatch::_exact;

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -53,7 +53,7 @@ public:
     {
         PyObject* obj = match.object;
 
-        if (PyBool_Check(obj) || PyObject_IsInstance(obj, (PyObject*)_NPBool_Type))
+        if (PyBool_Check(obj) || PyJP_IsInstanceSingle(obj, __numpy_bool_type))
         {
             match.conversion = this;
             return match.type = JPMatch::_exact;

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -775,13 +775,13 @@ public:
 
 		// Hot path dispatch using the numpy tree
 		PyTypeObject* nptype = PyJP_GetNumPyBaseType(type);
-		if (nptype != null)
+		if (nptype != nullptr)
 		{
-			if (nptype == _numpy_int32_type)
+			if (nptype == (PyTypeObject*) _numpy_int32_type)
 				match.closure = JPContext_global->_java_lang_Integer;
-			else if (nptype == _numpy_int16_type)
+			else if (nptype == (PyTypeObject*) _numpy_int16_type)
 				match.closure = JPContext_global->_java_lang_Short;
-			else if (nptype == _numpy_int8_type)
+			else if (nptype == (PyTypeObject*) _numpy_int8_type)
 				match.closure = JPContext_global->_java_lang_Byte;
 		}
 

--- a/native/common/jp_classhints.cpp
+++ b/native/common/jp_classhints.cpp
@@ -771,18 +771,20 @@ public:
 	jvalue convert(JPMatch &match) override
 	{
 		PyTypeObject* type = Py_TYPE(match.object);
-		const char *name = type->tp_name;
 		match.closure = JPContext_global->_java_lang_Long;
-		if (strncmp(name, "numpy", 5) == 0)
+
+		// Hot path dispatch using the numpy tree
+		PyTypeObject* nptype = PyJP_GetNumPyBaseType(type);
+		if (nptype != null)
 		{
-			// We only handle specific sized types, all others go to long.
-			if (strcmp(&name[5], ".int8") == 0)
-				match.closure = JPContext_global->_java_lang_Byte;
-			else if (strcmp(&name[5], ".int16") == 0)
-				match.closure = JPContext_global->_java_lang_Short;
-			else if (strcmp(&name[5], ".int32") == 0)
+			if (nptype == _numpy_int32_type)
 				match.closure = JPContext_global->_java_lang_Integer;
+			else if (nptype == _numpy_int16_type)
+				match.closure = JPContext_global->_java_lang_Short;
+			else if (nptype == _numpy_int8_type)
+				match.closure = JPContext_global->_java_lang_Byte;
 		}
+
 		return JPConversionBox::convert(match);
 	}
 } _boxLongConversion;

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -157,6 +157,7 @@ extern PyObject *_JVMNotRunning;
 extern PyObject *PyJPClassMagic;
 // for caching type checks with Numpy bool after np version 2.1
 extern PyObject* _num_bool_type;
+extern PyObject* _numpy_int8_type;
 extern PyObject* _numpy_int16_type;
 extern PyObject* _numpy_int32_type;
 extern PyObject* _numpy_bool_type;
@@ -185,7 +186,7 @@ PyObject  *PyJPModule_getClass(PyObject* module, PyObject *obj);
 PyObject  *PyJPValue_getattro(PyObject *obj, PyObject *name);
 int        PyJPValue_setattro(PyObject *self, PyObject *name, PyObject *value);
 PyObject  *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p);
-PyTypeObject* PyJP_GetNumPyBaseType(PyObject* obj);
+PyTypeObject* PyJP_GetNumPyBaseType(PyTypeObject* obj);
 
 #ifdef __cplusplus
 }

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -156,7 +156,10 @@ extern PyObject *_JObjectKey;
 extern PyObject *_JVMNotRunning;
 extern PyObject *PyJPClassMagic;
 // for caching type checks with Numpy bool after np version 2.1
-extern PyTypeObject *_NPBool_Type;
+extern PyObject* _num_bool_type;
+extern PyObject* _numpy_int16_type;
+extern PyObject* _numpy_int32_type;
+extern PyObject* _numpy_bool_type;
 
 extern JPContext* JPContext_global;
 
@@ -182,6 +185,7 @@ PyObject  *PyJPModule_getClass(PyObject* module, PyObject *obj);
 PyObject  *PyJPValue_getattro(PyObject *obj, PyObject *name);
 int        PyJPValue_setattro(PyObject *self, PyObject *name, PyObject *value);
 PyObject  *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p);
+PyTypeObject* PyJP_GetNumPyBaseType(PyObject* obj);
 
 #ifdef __cplusplus
 }

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -22,31 +22,6 @@
 #include <Windows.h>
 #endif
 
-namespace {
-int init_numpy_bool_type()
-{
-	JP_TRACE("init_numpy_bool_type()");
-	PyObject *numpy = PyImport_ImportModule("numpy");
-	if (numpy == nullptr) {
-		// we do not want a Python error to be propagated.
-		PyErr_Clear(); // GCOVR_EXCL_LINE
-		return -1; // GCOVR_EXCL_LINE
-	}
-
-	PyObject *t = PyObject_GetAttrString(numpy, "bool_");
-	Py_DECREF(numpy);
-	if (t == nullptr) {
-		JP_TRACE("bool_ attr not found"); // GCOVR_EXCL_LINE
-		return -1; // GCOVR_EXCL_LINE
-	}
-
-	/* store as PyTypeObject* for fast checks */
-	_NPBool_Type = (PyTypeObject *)t;
-	return 0;
-}
-
-}
-
 void PyJPModule_installGC(PyObject* module);
 
 bool _jp_cpp_exceptions = false;
@@ -98,7 +73,6 @@ PyObject* _JMethodAnnotations = nullptr;
 PyObject* _JMethodCode = nullptr;
 PyObject* _JObjectKey = nullptr;
 PyObject* _JVMNotRunning = nullptr;
-PyTypeObject* _NPBool_Type = nullptr;
 
 void PyJPModule_loadResources(PyObject* module)
 {
@@ -244,6 +218,32 @@ int PyJP_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj)
 		return 0;
 	return PyTuple_GetItem(mro1, n1 - n2) == (PyObject*) type;
 }
+
+PyTypeObject* PyJP_GetNumPyBaseType(PyObject* obj)
+{
+	PyTypeObject* type = Py_TYPE(obj);
+	PyObject* mro = type->tp_mro;
+	if (mro == nullptr || _numpy_generic_type == nullptr) return nullptr;
+
+	Py_ssize_t n = PyTuple_GET_SIZE(mro);
+
+	// 1. Check the Gate using cached generic position
+	// If n < 2, it's a raw object/type.
+	// If the item at (n - _numpy_genericpos) isn't generic, it's not NumPy.
+	if (n < _numpy_genericpos || 
+			PyTuple_GET_ITEM(mro, n - _numpy_genericpos) != _numpy_generic_type)
+		return nullptr;
+
+	// 2. Resolve the concrete base (e.g., int32) using cached type position
+	// If the user subclassed it, n will be > _numpy_typepos.
+	// The base type is always at index (n - _numpy_typepos).
+	if (n >= _numpy_typepos && _numpy_typepos > 0)
+		return (PyTypeObject*) PyTuple_GET_ITEM(mro, n - _numpy_typepos);
+    
+	// 3. Fallback for types with shallower MROs (like bool_ or generic itself)
+	return type;
+}
+
 
 int PyJP_IsInstanceSingle(PyObject* obj, PyTypeObject* type)
 {
@@ -631,6 +631,56 @@ static PyObject* PyJPModule_isPackage(PyObject *module, PyObject *pkg)
 	JP_PY_CATCH(nullptr); // GCOVR_EXCL_LINE
 }
 
+int _numpy_typepos = 0;
+int _numpy_genericpos = 0;
+PyObject* _numpy_generic_type = nullptr;
+PyObject* _numpy_bool_type = nullptr;
+PyObject* _numpy_int8_type  = nullptr;
+PyObject* _numpy_int16_type = nullptr;
+PyObject* _numpy_int32_type = nullptr;
+
+static int  PyJPModule_InitNumpy()
+{
+    JP_TRACE("JPClassHints::initNumPy()");
+
+    // Default to standard Python bool in case NumPy isn't there
+    _numpy_bool_type = &PyBool_Type;
+
+    // Import NumPy only once
+    PyObject *numpy = PyImport_ImportModule("numpy");
+    if (numpy == nullptr) {
+        // Clear the error so JPype can continue without NumPy support
+        PyErr_Clear();
+        return;
+    }
+
+    auto get_type = [&](const char* name) -> PyObject* {
+        PyObject* attr = PyObject_GetAttrString(numpy, name);
+        if (attr == nullptr) {
+            PyErr_Clear();
+            JP_TRACE("NumPy attribute not found:", name);
+        }
+        return attr;
+    };
+
+    _numpy_generic_type = get_type("generic");
+
+    // 1. Existing boolean initialization
+    _numpy_bool_type = get_type("bool_");
+
+    // 2. Your new j2ni/transfer type pointers
+    _numpy_int8_type  = get_type("int8");
+    _numpy_int16_type = get_type("int16");
+    _numpy_int32_type = get_type("int32");
+
+	// Cache for speed
+	_numpy_typepos = PyTuple_GET_SIZE(((PyTypeObject*)_numpy_int32_type)->tp_mro)
+	_numpy_genericpos = PyTuple_GET_SIZE(((PyTypeObject*)_numpy_generic_type)->tp_mro)
+
+    // Finished with the module handle
+    Py_DECREF(numpy);
+
+}
 
 #if 1
 // GCOVR_EXCL_START
@@ -815,7 +865,7 @@ PyMODINIT_FUNC PyInit__jpype()
 
 	_PyJPModule_trace = true;
 
-	init_numpy_bool_type();
+	PyJPModule_InitNumpy();
 
 	return module;
 	JP_PY_CATCH(nullptr); // GCOVR_EXCL_LINE

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -25,6 +25,14 @@
 void PyJPModule_installGC(PyObject* module);
 
 bool _jp_cpp_exceptions = false;
+static int _numpy_typepos = 0;
+static int _numpy_genericpos = 0;
+PyObject* _numpy_generic_type = nullptr;
+PyObject* _numpy_bool_type = nullptr;
+PyObject* _numpy_int8_type  = nullptr;
+PyObject* _numpy_int16_type = nullptr;
+PyObject* _numpy_int32_type = nullptr;
+
 
 extern void PyJPArray_initType(PyObject* module);
 extern void PyJPBuffer_initType(PyObject* module);
@@ -219,9 +227,8 @@ int PyJP_IsSubClassSingle(PyTypeObject* type, PyTypeObject* obj)
 	return PyTuple_GetItem(mro1, n1 - n2) == (PyObject*) type;
 }
 
-PyTypeObject* PyJP_GetNumPyBaseType(PyObject* obj)
+PyTypeObject* PyJP_GetNumPyBaseType(PyTypeObject* type)
 {
-	PyTypeObject* type = Py_TYPE(obj);
 	PyObject* mro = type->tp_mro;
 	if (mro == nullptr || _numpy_generic_type == nullptr) return nullptr;
 
@@ -631,56 +638,32 @@ static PyObject* PyJPModule_isPackage(PyObject *module, PyObject *pkg)
 	JP_PY_CATCH(nullptr); // GCOVR_EXCL_LINE
 }
 
-int _numpy_typepos = 0;
-int _numpy_genericpos = 0;
-PyObject* _numpy_generic_type = nullptr;
-PyObject* _numpy_bool_type = nullptr;
-PyObject* _numpy_int8_type  = nullptr;
-PyObject* _numpy_int16_type = nullptr;
-PyObject* _numpy_int32_type = nullptr;
-
-static int  PyJPModule_InitNumpy()
+static void PyJPModule_InitNumpy()
 {
-    JP_TRACE("JPClassHints::initNumPy()");
-
-    // Default to standard Python bool in case NumPy isn't there
-    _numpy_bool_type = &PyBool_Type;
-
-    // Import NumPy only once
     PyObject *numpy = PyImport_ImportModule("numpy");
-    if (numpy == nullptr) {
-        // Clear the error so JPype can continue without NumPy support
+    if (numpy == nullptr) 
+    {
         PyErr_Clear();
         return;
     }
 
-    auto get_type = [&](const char* name) -> PyObject* {
-        PyObject* attr = PyObject_GetAttrString(numpy, name);
-        if (attr == nullptr) {
-            PyErr_Clear();
-            JP_TRACE("NumPy attribute not found:", name);
-        }
-        return attr;
-    };
+    // Do it one by one. If one fails, you can actually handle it.
+    _numpy_generic_type = PyObject_GetAttrString(numpy, "generic");
+    _numpy_bool_type    = PyObject_GetAttrString(numpy, "bool_");
+    _numpy_int8_type   = PyObject_GetAttrString(numpy, "int8");
+    _numpy_int16_type   = PyObject_GetAttrString(numpy, "int16");
+    _numpy_int32_type   = PyObject_GetAttrString(numpy, "int32");
 
-    _numpy_generic_type = get_type("generic");
+    // Check for nulls BEFORE you try to access internals
+    if (_numpy_int32_type && _numpy_generic_type)
+    {
+        _numpy_typepos = PyTuple_GET_SIZE(((PyTypeObject*)_numpy_int32_type)->tp_mro);
+        _numpy_genericpos = PyTuple_GET_SIZE(((PyTypeObject*)_numpy_generic_type)->tp_mro);
+    }
 
-    // 1. Existing boolean initialization
-    _numpy_bool_type = get_type("bool_");
-
-    // 2. Your new j2ni/transfer type pointers
-    _numpy_int8_type  = get_type("int8");
-    _numpy_int16_type = get_type("int16");
-    _numpy_int32_type = get_type("int32");
-
-	// Cache for speed
-	_numpy_typepos = PyTuple_GET_SIZE(((PyTypeObject*)_numpy_int32_type)->tp_mro)
-	_numpy_genericpos = PyTuple_GET_SIZE(((PyTypeObject*)_numpy_generic_type)->tp_mro)
-
-    // Finished with the module handle
     Py_DECREF(numpy);
-
 }
+
 
 #if 1
 // GCOVR_EXCL_START


### PR DESCRIPTION
The numpy bool fix #1320 introduced a regression where systems without NumPy would SIGSEGV. This occurred because PyObject_IsInstance was called with a nullptr for the type, as the CPython API lacks internal null guards.

Key Changes:

- Safety & Speed: Replaced the PyObject_IsInstance calls in native/common/jp_booleantype.cpp with our internal PyJP_IsInstanceSingle. This provides a fast-path check and inherent safety against nullptr handles.   It also ensures that if for some reason someone inherited from numpy.bool it would still work.

- Refined Logic: Updated the conversion script portion to respect derived types. Replaced janky strcmp logic with proper type-hierarchy awareness.  This also allows for derived types to work successfully.  This fixes the rare case that numpy is renamed.

- CI Reinforcement: Added a linux_py312_jdk17_no_numpy job to the Azure Pipeline matrix. This ensures that JPype’s "vanilla" Python support remains stable and is never again regressed by optional dependencies.

Fixes #1358