### PR TITLE
[ci/release] fix variable decl

### DIFF
--- a/.azure/release.yml
+++ b/.azure/release.yml
@@ -24,10 +24,11 @@ pr:
     - .azure/release.yml
 
 variables:
-  package_name: jpype1
-  run_goal: 1  # Set to 1 to enable, 0 to disable, 2 on for special targets
-  # currently contains a public_repo scoped Github token to avoid rate limiting (old) Python interpreter downloads.
-  group: Secrets
+  - name: package_name
+    value: jpype1
+  - name: run_goal
+    value: 1  # Set to 1 to enable, 0 to disable, 2 on for special targets
+  - group: Secrets # currently contains a public_repo scoped Github token to avoid rate limiting (old) Python interpreter downloads.
 
 stages:
 - stage: Initial


### PR DESCRIPTION
Now arbitrary Python versions can be downloaded.

run of release pipeline looks good:
https://dev.azure.com/jpype-project/jpype/_build/results?buildId=1786&view=logs&j=b8057df5-3baa-5fec-ba79-03609ea2d5d9