### PR TITLE
[CI] Correctly pass the token into the templates

### DIFF
--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -70,8 +70,6 @@ jobs:
   dependsOn: Deps
   variables: # default values for all following matrix elements
     imageName: "ubuntu-latest"
-  env:
-    GH_TOKEN_SECRET: $(githubToken) # Map gh token here, so the whole job can use it.
   strategy:
     matrix:
       # Linux
@@ -141,7 +139,7 @@ jobs:
   - template: scripts/deps.yml
   - template: scripts/test.yml
     parameters:
-      githubToken: $(GH_TOKEN_SECRET) # Pass the ALREADY RESOLVED environment variable value
+      githubToken: $(githubToken)
 
 - job: Debug
   condition: eq(1,0)

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -70,7 +70,6 @@ jobs:
   dependsOn: Deps
   variables: # default values for all following matrix elements
     imageName: "ubuntu-latest"
-    githubToken: $(githubToken)
   strategy:
     matrix:
       # Linux
@@ -139,6 +138,8 @@ jobs:
   - template: scripts/pip-caching.yml
   - template: scripts/deps.yml
   - template: scripts/test.yml
+    parameters:
+      githubToken: $(githubToken)
 
 - job: Debug
   condition: eq(1,0)

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -52,13 +52,13 @@ jobs:
   steps:
   - template: scripts/documentation.yml
 
-#- job: Coverage
-#  pool:
-#    vmImage: "ubuntu-latest"
-#  dependsOn: Deps
-#  steps:
-#  - template: scripts/deps.yml
-#  - template: scripts/coverage.yml
+- job: Coverage
+  pool:
+    vmImage: "ubuntu-latest"
+  dependsOn: Deps
+  steps:
+  - template: scripts/deps.yml
+  - template: scripts/coverage.yml
 
 - job: Tracing
   pool:
@@ -73,63 +73,55 @@ jobs:
   strategy:
     matrix:
       # Linux
-# fixme: once the token issue is resolved, re-activate.
       linux_py38_jdk11:
         python.version: '3.8'
         jdk.version: '11'
-#      linux_py39_jdk11:
-#        imageName: "ubuntu-latest"
-#        python.version: '3.9'
-#        jdk.version: '11'
-#      linux_py310_jdk17:
-#        imageName: "ubuntu-latest"
-#        python.version: '3.10'
-#        jdk.version: '17'
-#      linux_py311_jdk17:
-#        imageName: "ubuntu-latest"
-#        python.version: '3.11'
-#        jdk.version: '17'
-#      linux_py312_jdk17:
-#        imageName: "ubuntu-latest"
-#        python.version: '3.12'
-#        jdk.version: '17'
-#      linux_py312_jdk17_no_numpy:
-#        imageName: "ubuntu-latest"
-#        python.version: '3.12'
-#        jdk.version: '17'
-#        skip_numpy: 'true'
-#      linux_py313_jdk17:
-#        imageName: "ubuntu-latest"
-#        python.version: "3.13"
-#        jdk.version: '17'
-#      linux_py314_jdk11:
-#        imageName: "ubuntu-latest"
-#        python.version: "3.14"
-#        jdk.version: '11'
-#      # Windows
-#      windows_py310_jdk11:
-#        imageName: "windows-2022"
-#        python.version: '3.10'
-#        jdk.version: '11'
-#      windows_py311_jdk17:
-#        imageName: "windows-2022"
-#        python.version: '3.11'
-#        jdk.version: '17'
-#      windows_py312_jdk21:
-#        imageName: "windows-2022"
-#        python.version: '3.12'
-#        jdk.version: '21'
-#      # OSX, we only test an old Python version with JDK8 and recent Py with recent JDK.
-#      mac_py310_jdk11:
-#        imageName: "macos-14"
-#        python.version: '3.10'
-#        jpypetest.fast: 'true'
-#        jdk.version: '11'
-#      mac_py312_jdk17:
-#        imageName: "macos-latest"
-#        python.version: '3.12'
-#        jpypetest.fast: 'true'
-#        jdk.version: '17'
+      linux_py39_jdk11:
+        python.version: '3.9'
+        jdk.version: '11'
+      linux_py310_jdk17:
+        python.version: '3.10'
+        jdk.version: '17'
+      linux_py311_jdk17:
+        python.version: '3.11'
+        jdk.version: '17'
+      linux_py312_jdk17:
+        python.version: '3.12'
+        jdk.version: '17'
+      linux_py312_jdk17_no_numpy:
+        python.version: '3.12'
+        jdk.version: '17'
+        skip_numpy: 'true'
+      linux_py313_jdk17:
+        python.version: "3.13"
+        jdk.version: '17'
+      linux_py314_jdk11:
+        python.version: "3.14"
+        jdk.version: '11'
+      # Windows
+      windows_py310_jdk11:
+        imageName: "windows-2022"
+        python.version: '3.10'
+        jdk.version: '11'
+      windows_py311_jdk17:
+        imageName: "windows-2022"
+        python.version: '3.11'
+        jdk.version: '17'
+      windows_py312_jdk21:
+        imageName: "windows-2022"
+        python.version: '3.12'
+        jdk.version: '21'
+      # OSX, we only test an old Python version with JDK8 and recent Py with recent JDK.
+      mac_py310_jdk11:
+        imageName: "macos-14"
+        python.version: '3.10'
+        jpypetest.fast: 'true'
+        jdk.version: '11'
+      mac_py312_jdk17:
+        imageName: "macos-latest"
+        python.version: '3.12'
+        jpypetest.fast: 'true'
+        jdk.version: '17'
 
   pool:
     vmImage: $(imageName)

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -40,21 +40,6 @@ variables:
 #  value: 'true'
 
 jobs:
-# fixme: in order to work with old (EOL) Python version (3.8, 3.9), we require this to work.
-# Has been reported to Azure DevOps forum, since it is the documented pattern and used to work for the last JP release 1.7.1
-#- job: TestGHToken
-#  steps:
-#    - bash: |
-#        env | sort
-#        echo "Token length: ${#GH_TOKEN}"
-#        echo "Starts with: ${GH_TOKEN:0:4}"
-#      env:
-#        GH_TOKEN: $(githubToken)
-#      displayName: Debug token at job level
-#    - template: scripts/test.yml
-#  pool:
-#    vmImage: 'ubuntu-latest'
-
 - job: Deps
   pool:
     vmImage: "ubuntu-latest"
@@ -83,67 +68,69 @@ jobs:
 
 - job: Test
   dependsOn: Deps
+  variables: # default values for all following matrix elements
+    imageName: "ubuntu-latest"
+    githubToken: $(githubToken)
   strategy:
     matrix:
       # Linux
 # fixme: once the token issue is resolved, re-activate.
-#      linux_py38_jdk11:
-#        imageName: "ubuntu-latest"
-#        python.version: '3.8'
-#        jdk.version: '11'
+      linux_py38_jdk11:
+        python.version: '3.8'
+        jdk.version: '11'
 #      linux_py39_jdk11:
 #        imageName: "ubuntu-latest"
 #        python.version: '3.9'
 #        jdk.version: '11'
-      linux_py310_jdk17:
-        imageName: "ubuntu-latest"
-        python.version: '3.10'
-        jdk.version: '17'
-      linux_py311_jdk17:
-        imageName: "ubuntu-latest"
-        python.version: '3.11'
-        jdk.version: '17'
-      linux_py312_jdk17:
-        imageName: "ubuntu-latest"
-        python.version: '3.12'
-        jdk.version: '17'
-      linux_py312_jdk17_no_numpy:
-        imageName: "ubuntu-latest"
-        python.version: '3.12'
-        jdk.version: '17'
-        skip_numpy: 'true'
-      linux_py313_jdk17:
-        imageName: "ubuntu-latest"
-        python.version: "3.13"
-        jdk.version: '17'
-      linux_py314_jdk11:
-        imageName: "ubuntu-latest"
-        python.version: "3.14"
-        jdk.version: '11'
-      # Windows
-      windows_py310_jdk11:
-        imageName: "windows-2022"
-        python.version: '3.10'
-        jdk.version: '11'
-      windows_py311_jdk17:
-        imageName: "windows-2022"
-        python.version: '3.11'
-        jdk.version: '17'
-      windows_py312_jdk21:
-        imageName: "windows-2022"
-        python.version: '3.12'
-        jdk.version: '21'
-      # OSX, we only test an old Python version with JDK8 and recent Py with recent JDK.
-      mac_py310_jdk11:
-        imageName: "macos-14"
-        python.version: '3.10'
-        jpypetest.fast: 'true'
-        jdk.version: '11'
-      mac_py312_jdk17:
-        imageName: "macos-latest"
-        python.version: '3.12'
-        jpypetest.fast: 'true'
-        jdk.version: '17'
+#      linux_py310_jdk17:
+#        imageName: "ubuntu-latest"
+#        python.version: '3.10'
+#        jdk.version: '17'
+#      linux_py311_jdk17:
+#        imageName: "ubuntu-latest"
+#        python.version: '3.11'
+#        jdk.version: '17'
+#      linux_py312_jdk17:
+#        imageName: "ubuntu-latest"
+#        python.version: '3.12'
+#        jdk.version: '17'
+#      linux_py312_jdk17_no_numpy:
+#        imageName: "ubuntu-latest"
+#        python.version: '3.12'
+#        jdk.version: '17'
+#        skip_numpy: 'true'
+#      linux_py313_jdk17:
+#        imageName: "ubuntu-latest"
+#        python.version: "3.13"
+#        jdk.version: '17'
+#      linux_py314_jdk11:
+#        imageName: "ubuntu-latest"
+#        python.version: "3.14"
+#        jdk.version: '11'
+#      # Windows
+#      windows_py310_jdk11:
+#        imageName: "windows-2022"
+#        python.version: '3.10'
+#        jdk.version: '11'
+#      windows_py311_jdk17:
+#        imageName: "windows-2022"
+#        python.version: '3.11'
+#        jdk.version: '17'
+#      windows_py312_jdk21:
+#        imageName: "windows-2022"
+#        python.version: '3.12'
+#        jdk.version: '21'
+#      # OSX, we only test an old Python version with JDK8 and recent Py with recent JDK.
+#      mac_py310_jdk11:
+#        imageName: "macos-14"
+#        python.version: '3.10'
+#        jpypetest.fast: 'true'
+#        jdk.version: '11'
+#      mac_py312_jdk17:
+#        imageName: "macos-latest"
+#        python.version: '3.12'
+#        jpypetest.fast: 'true'
+#        jdk.version: '17'
 
   pool:
     vmImage: $(imageName)

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -52,13 +52,13 @@ jobs:
   steps:
   - template: scripts/documentation.yml
 
-- job: Coverage
-  pool:
-    vmImage: "ubuntu-latest"
-  dependsOn: Deps
-  steps:
-  - template: scripts/deps.yml
-  - template: scripts/coverage.yml
+#- job: Coverage
+#  pool:
+#    vmImage: "ubuntu-latest"
+#  dependsOn: Deps
+#  steps:
+#  - template: scripts/deps.yml
+#  - template: scripts/coverage.yml
 
 - job: Tracing
   pool:

--- a/.azure/build.yml
+++ b/.azure/build.yml
@@ -70,6 +70,8 @@ jobs:
   dependsOn: Deps
   variables: # default values for all following matrix elements
     imageName: "ubuntu-latest"
+  env:
+    GH_TOKEN_SECRET: $(githubToken) # Map gh token here, so the whole job can use it.
   strategy:
     matrix:
       # Linux
@@ -139,7 +141,7 @@ jobs:
   - template: scripts/deps.yml
   - template: scripts/test.yml
     parameters:
-      githubToken: $(githubToken)
+      githubToken: $(GH_TOKEN_SECRET) # Pass the ALREADY RESOLVED environment variable value
 
 - job: Debug
   condition: eq(1,0)

--- a/.azure/release.yml
+++ b/.azure/release.yml
@@ -194,6 +194,7 @@ stages:
       parameters:
         version: '$(python.version)'
         architecture: '$(python.architecture)'
+        githubToken: '$(githubToken)'
     - template: scripts/jdk.yml
       parameters:
         version: '11'
@@ -228,6 +229,7 @@ stages:
       parameters:
         version: '$(python.version)'
         architecture: '$(python.architecture)'
+        githubToken: '$(githubToken)'
     - template: scripts/jdk.yml
       parameters:
         version: '11'

--- a/.azure/scripts/python.yml
+++ b/.azure/scripts/python.yml
@@ -18,6 +18,9 @@ steps:
       disableDownloadFromRegistry: false # boolean. Disable downloading releases from the GitHub registry. Default: false.
       allowUnstable: true # boolean. Optional. Use when disableDownloadFromRegistry = false. Allow downloading unstable releases. Default: false.
       githubToken: ${{ parameters.githubToken }} # Token allowing API access to Github (for not hitting a rate limit while downloading).
+    env:
+      # Explicitly map it to an ENV variable for the task process
+      GITHUB_TOKEN: ${{ parameters.githubToken }}
   - bash: |
       echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi

--- a/.azure/scripts/python.yml
+++ b/.azure/scripts/python.yml
@@ -17,7 +17,7 @@ steps:
       versionSpec: ${{ parameters.version }}
       disableDownloadFromRegistry: false # boolean. Disable downloading releases from the GitHub registry. Default: false.
       allowUnstable: true # boolean. Optional. Use when disableDownloadFromRegistry = false. Allow downloading unstable releases. Default: false.
-      githubToken: ${{ githubToken }} # Token allowing API access to Github (for not hitting a rate limit while downloading).
+      githubToken: ${{ parameters.githubToken }} # Token allowing API access to Github (for not hitting a rate limit while downloading).
   - bash: |
       echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi

--- a/.azure/scripts/python.yml
+++ b/.azure/scripts/python.yml
@@ -7,21 +7,17 @@ parameters:
   type: string
   default: 'x64'
 
-steps:
-  - bash: |
-      echo "Token length: ${#GH_TOKEN}"
-      echo "Starts with: ${GH_TOKEN:0:4}"
-    env:
-      GH_TOKEN: $(githubToken)
-    displayName: Debug githubToken
+- name: githubToken
+  type: string
 
+steps:
   - task: UsePythonVersion@0
     inputs:
       architecture: ${{ parameters.architecture }}
       versionSpec: ${{ parameters.version }}
       disableDownloadFromRegistry: false # boolean. Disable downloading releases from the GitHub registry. Default: false.
       allowUnstable: true # boolean. Optional. Use when disableDownloadFromRegistry = false. Allow downloading unstable releases. Default: false.
-      githubToken: $(githubToken) # global (secret) variable to allow API access to Github (for not hitting a rate limit while downloading).
+      githubToken: ${{ githubToken }} # Token allowing API access to Github (for not hitting a rate limit while downloading).
   - bash: |
       echo AGENT_JOBSTATUS = $AGENT_JOBSTATUS
       if [[ "$AGENT_JOBSTATUS" == "SucceededWithIssues" ]]; then exit 1; fi

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -1,9 +1,12 @@
 # This task tests individual platforms and versions
 
 parameters:
- - name: PIP_CACHE_DIR
-   type: string
-   default: $(PIP_CACHE_DIR)
+- name: PIP_CACHE_DIR
+  type: string
+  default: $(PIP_CACHE_DIR)
+
+- name: githubToken
+  type: string
 
 steps:
 

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -13,6 +13,7 @@ steps:
 - template: python.yml
   parameters:
     version: '$(python.version)'
+    githubToken: '$(githubToken)'
 
 - template: jdk.yml
   parameters:

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -13,7 +13,7 @@ steps:
 - template: python.yml
   parameters:
     version: '$(python.version)'
-    githubToken: '$(githubToken)'
+    githubToken: '$(parameters.githubToken)'
 
 - template: jdk.yml
   parameters:

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -13,7 +13,7 @@ steps:
 - template: python.yml
   parameters:
     version: '$(python.version)'
-    githubToken: '$(parameters.githubToken)'
+    githubToken: '${{ parameters.githubToken }}'
 
 - template: jdk.yml
   parameters:

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -13,7 +13,7 @@ steps:
 - template: python.yml
   parameters:
     version: '$(python.version)'
-    githubToken: '${{ parameters.githubToken }}'
+    githubToken: ${{ parameters.githubToken }}
 
 - template: jdk.yml
   parameters:

--- a/jpype/_jinit.py
+++ b/jpype/_jinit.py
@@ -15,13 +15,13 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
-from typing import Callable
+from typing import Callable, List
 
 import _jpype
 
 __all__ = ['onJVMStart']
 
-JInitializers: list[Callable] = []
+JInitializers: List[Callable] = []
 
 
 def onJVMStart(func):

--- a/jpype/dbapi2.py
+++ b/jpype/dbapi2.py
@@ -45,8 +45,8 @@ class JDBCTypeProtocol(typing.Protocol):
 
 _SQLException = None
 _SQLTimeoutException = None
-_registry: dict[str, JDBCTypeProtocol] = {}
-_types: list[JDBCTypeProtocol] = []
+_registry: typing.Dict[str, JDBCTypeProtocol] = {}
+_types: typing.List[JDBCTypeProtocol] = []
 
 
 def _nop(x):
@@ -246,11 +246,11 @@ _default_map = {ARRAY: OBJECT, OBJECT: OBJECT, NULL: OBJECT,
                 LONGNVARCHAR: STRING, DOUBLE: DOUBLE, OTHER: OBJECT
                 }
 
-_default_setters: dict[typing.Any, typing.Union[JDBCType, _JDBCTypePrimitive]] = {}
+_default_setters: typing.Dict[typing.Any, typing.Union[JDBCType, _JDBCTypePrimitive]] = {}
 
-_default_converters = {}  # type: ignore[var-annotated]
+_default_converters : typing.Dict[typing.Any, typing.Callable] = {}
 
-_default_adapters = {}  # type: ignore[var-annotated]
+_default_adapters : typing.Dict[typing.Any, typing.Any] = {}
 
 
 # Setters take (connection, meta, col, type) -> JDBCTYPE


### PR DESCRIPTION
Finally got the token to work. It involved changing a setting deeply hidden in Azure DevOps (Triggers menu of the build pipeline), namely passing on secret variables to builds of forks. Since the token is scoped and has no permissions at all, this is (currently) a safe procedure. We should not add important secrets in CI as they can be stolen by just opening up a PR.

Also fixed the type annotations to work with Python 3.8