### PR TITLE
Add arm64 Windows to _jvmfinder.

### DIFF
--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -317,6 +317,7 @@ def _checkJVMArch(jvmPath, maxsize=sys.maxsize):
     IMAGE_FILE_MACHINE_I386 = 332
     IMAGE_FILE_MACHINE_IA64 = 512
     IMAGE_FILE_MACHINE_AMD64 = 34404
+    IMAGE_FILE_MACHINE_ARM64 = 43620
 
     is64 = maxsize > 2**32
     with open(jvmPath, "rb") as f:
@@ -334,7 +335,7 @@ def _checkJVMArch(jvmPath, maxsize=sys.maxsize):
         if is64:
             raise JVMNotSupportedException(
                 "JVM mismatch, python is 64 bit and JVM is 32 bit.")
-    elif machine == IMAGE_FILE_MACHINE_IA64 or machine == IMAGE_FILE_MACHINE_AMD64:
+    elif machine == IMAGE_FILE_MACHINE_IA64 or machine == IMAGE_FILE_MACHINE_AMD64 or machine == IMAGE_FILE_MACHINE_ARM64:
         if not is64:
             raise JVMNotSupportedException(
                 "JVM mismatch, python is 32 bit and JVM is 64 bit.")

--- a/test/jpypetest/test_jvmfinder.py
+++ b/test/jpypetest/test_jvmfinder.py
@@ -19,12 +19,14 @@
 # from unittest import mock
 import os
 import pathlib
+import struct
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
-from jpype._jvmfinder import (LinuxJVMFinder, JVMNotSupportedException, DarwinJVMFinder,
-                              WindowsJVMFinder)
+from jpype._jvmfinder import (_checkJVMArch, LinuxJVMFinder, JVMNotSupportedException,
+                              DarwinJVMFinder, WindowsJVMFinder)
 
 
 class JVMFinderTest(unittest.TestCase):
@@ -78,6 +80,26 @@ class JVMFinderTest(unittest.TestCase):
             finder = LinuxJVMFinder()
             with self.assertRaises(JVMNotSupportedException):
                 finder.find_libjvm('arbitrary java home')
+
+    def test_check_jvm_arch_on_arm64(self):
+        PE_HEADER_POINTER_OFFSET = 0x3C
+        PE_HEADER_OFFSET = 0x80
+        PE_SIGNATURE_SIZE = 4
+        IMAGE_FILE_MACHINE_ARM64 = 43620
+        PYTHON_64_BIT_MAXSIZE = 2**63
+
+        with tempfile.NamedTemporaryFile(delete=False) as test_file:
+            test_file.write(b"MZ")
+            test_file.seek(PE_HEADER_POINTER_OFFSET)
+            test_file.write(struct.pack("<L", PE_HEADER_OFFSET))
+            test_file.seek(PE_HEADER_OFFSET + PE_SIGNATURE_SIZE)
+            test_file.write(struct.pack("<H", IMAGE_FILE_MACHINE_ARM64))
+            path = test_file.name
+
+        try:
+            _checkJVMArch(path, maxsize=PYTHON_64_BIT_MAXSIZE)
+        finally:
+            os.remove(path)
 
     @mock.patch('os.walk')
     @mock.patch('os.path.exists')


### PR DESCRIPTION
On an arm64 Windows laptop, I'm able to build a native wheel for jpype without any code changes. However, the built wheel can only start the JVM if explicitly passed the arm64 `jvm.dll` path. This change solves that, so that the JVM can start on an arm64 Windows machine without the DLL path being passed explicitly. I've also added a unit test that confirms that `_checkJVMArch()` passes in the case of 0xAA64 (43620).

This change would hopefully enable native support for the arm64 Windows ecosystem for jpype, and CI/CD should be manageable with minimal overhead via the GitHub-hosted `windows-11-arm` [runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).