### PR TITLE
#1413: Handle "+" character in file paths

### DIFF
--- a/native/jpype_module/src/main/java/org/jpype/pkg/JPypePackageManager.java
+++ b/native/jpype_module/src/main/java/org/jpype/pkg/JPypePackageManager.java
@@ -469,9 +469,12 @@ public class JPypePackageManager
       // Java 8 bug https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8131067
       // Zip file system provider returns doubly % encoded URIs. We resolve this
       // by re-encoding the URI after decoding it.
+      //
+      // Replace "+" with its URL-encoded representation to avoid conversion to
+      // a space and ensure correct round-trip encoding.
       uri = new URI(
               uri.getScheme(),
-              URLDecoder.decode(uri.getSchemeSpecificPart(), StandardCharsets.UTF_8),
+              URLDecoder.decode(uri.getSchemeSpecificPart().replace("+", "%2b"), StandardCharsets.UTF_8),
               uri.getFragment()
       );
 


### PR DESCRIPTION
`URLDecoder.decode` applies the `application/x-www-form-urlencoded` MIME format, which includes converting "+" characters to space characters. If a path contains "+" characters, upon re-encoding, they will be converted to `%20` instead of `%2b`, yielding a different file path than we started with.

We handle this by converting "+" to "%2b" before decoding to ensure that it is preserved across the round trip.

Resolves: https://github.com/jpype-project/jpype/issues/1413