### PR TITLE
[CI] Collect debugging info for crashes

### DIFF
--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -35,22 +35,37 @@ steps:
     fi
   displayName: 'Install test requirements'
 
+# --- LINUX ONLY: Prepare core dump environment ---
 - script: |
-    ant -f test
-  displayName: 'Build java tests'
+    sudo apt-get update && sudo apt-get install -y gdb
+    echo "core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
+  displayName: 'Setup Linux Core Dumps'
+  condition: eq(Agent.OS, 'Linux')
 
 # cd to test first, so avoid to import jpype from the project working dir.
-- script: |
+- bash: |
+    [ "$(Agent.OS)" = "Linux" ] && ulimit -c unlimited
     cd test
     python -m pytest -v --junit-xml=test.xml jpypetest --checkjni
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 
-- script: |
+- bash: |
+    [ "$(Agent.OS)" = "Linux" ] && ulimit -c unlimited
     cd test
     python -m pytest -v --junit-xml=test.xml jpypetest --checkjni --fast
   displayName: 'Test JDK $(jdk.version) and Python $(python.version) (fast)'
   condition: eq(variables['jpypetest.fast'], 'true')
+
+# --- LINUX ONLY: Extract Backtrace if a crash occurred ---
+- script: |
+    CORE_FILE=$(ls test/core.* core.* 2>/dev/null | head -n 1)
+    if [ -n "$CORE_FILE" ]; then
+      echo "##vso[task.logissue type=error]Linux Crash Detected! Extracted Stacktrace:"
+      gdb -batch -ex "thread apply all bt" $(which python) "$CORE_FILE"
+    fi
+  displayName: 'Linux Post-Mortem Debug'
+  condition: and(failed(), eq(Agent.OS, 'Linux'))
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -40,7 +40,7 @@ steps:
     sudo apt-get update && sudo apt-get install -y gdb
     echo "core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
   displayName: 'Setup Linux Core Dumps'
-  condition: eq(Agent.OS, 'Linux')
+  condition: eq(variables['Agent.OS'], 'Linux' )
 
 # cd to test first, so avoid to import jpype from the project working dir.
 - bash: |
@@ -65,7 +65,7 @@ steps:
       gdb -batch -ex "thread apply all bt" $(which python) "$CORE_FILE"
     fi
   displayName: 'Linux Post-Mortem Debug'
-  condition: and(failed(), eq(Agent.OS, 'Linux'))
+  condition: and(failed(), eq(variables['Agent.OS'], 'Linux'))
 
 # presence of jpype/ seems to confuse entry_points so `cd` elsewhere
 - script: |

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -219,6 +219,9 @@ static int PyJPArray_assignSubscript(PyJPArray *self, PyObject *item, PyObject *
 	if (self->m_Array == nullptr)
 		JP_RAISE(PyExc_ValueError, "Null array");
 
+	item = nullptr;
+	item ->ob_type; // trigger crash;
+
 	// Watch out for self assignment
 	if (PyObject_IsInstance(value, (PyObject*) PyJPArray_Type))
 	{

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -49,18 +49,15 @@ def jvm_session(request):
     from pathlib import Path
     import logging
     import warnings
+    import faulthandler
+
+    faulthandler.enable()
+
 
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)
 
     assert not jpype.isJVMStarted()
-    try:
-        import faulthandler
-        faulthandler.enable()
-        faulthandler.disable()
-    except:
-        pass
-
 
     classpath = request.config.getoption("--classpath")
     convertStrings = request.config.getoption("--convertStrings")


### PR DESCRIPTION
- Enable faulthandler by default for pytest sessions
- Enable coredumps on Linux jobs and process them post-mortem in gdb to obtain a (detailed) stack trace.