### PR TITLE
Fix overloaded methods from multiple interfaces not being detected (#…

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -19,6 +19,8 @@ Latest Changes:
 
   - Fixed JArray constructor ignoring slice bounds when creating from sliced array. #845
 
+  - Fixed overloaded methods from multiple interfaces not being detected. #844
+
 
 - **1.7.1 - 2026-05-06**
 

--- a/native/jpype_module/src/main/java/org/jpype/manager/TypeManager.java
+++ b/native/jpype_module/src/main/java/org/jpype/manager/TypeManager.java
@@ -672,8 +672,9 @@ public class TypeManager
     LinkedList<Method> declaredMethods = filterOverridden(cls, cls.getDeclaredMethods());
 
     // We only need one dispatch per name
+    // Use all methods (including inherited) not just declared methods (issue #844)
     TreeSet<String> resolve = new TreeSet<>();
-    for (Method method : declaredMethods)
+    for (Method method : methods)
     {
       resolve.add(method.getName());
     }

--- a/test/harness/jpype/overloads/InterfaceOverload.java
+++ b/test/harness/jpype/overloads/InterfaceOverload.java
@@ -1,0 +1,41 @@
+package jpype.overloads;
+
+/**
+ * Test case for issue #844: Overloaded methods across ancestor types
+ * are sometimes not detected.
+ */
+public class InterfaceOverload {
+
+	public interface DoStuffNoArgs {
+		default void doStuff() {
+		}
+	}
+
+	public interface DoStuffWithArgs {
+		default void doStuff(String arg) {
+		}
+	}
+
+	/**
+	 * Class implementing both interfaces - should have both doStuff overloads available
+	 */
+	public static class BothOverloads implements DoStuffWithArgs, DoStuffNoArgs {
+	}
+
+	/**
+	 * Helper to track which overload was called
+	 */
+	public static class CallTracker implements DoStuffWithArgs, DoStuffNoArgs {
+		public String lastCall = null;
+
+		@Override
+		public void doStuff() {
+			lastCall = "noargs";
+		}
+
+		@Override
+		public void doStuff(String arg) {
+			lastCall = "string:" + arg;
+		}
+	}
+}

--- a/test/jpypetest/test_overloads.py
+++ b/test/jpypetest/test_overloads.py
@@ -330,3 +330,19 @@ class OverloadTestCase(common.JPypeTestCase):
         self.assertEqual(obj.testMember(jpype.JBoolean(True), Derived), 3)
         self.assertEqual(obj.testMember(jpype.JObject(True, Boolean), Derived), 4)
         self.assertEqual(obj.testMember(jpype.JObject(True, Object), Derived), 4)
+    def testInterfaceOverload(self):
+        """Test issue #844: Overloaded methods across ancestor interfaces"""
+        InterfaceOverload = JClass("jpype.overloads.InterfaceOverload")
+
+        # Test that both overloads exist
+        obj = InterfaceOverload.BothOverloads()
+        obj.doStuff()  # Should not raise TypeError
+        obj.doStuff("test")  # Should not raise TypeError
+
+        # Test that correct overload is called
+        tracker = InterfaceOverload.CallTracker()
+        tracker.doStuff()
+        self.assertEqual(tracker.lastCall, "noargs")
+
+        tracker.doStuff("hello")
+        self.assertEqual(tracker.lastCall, "string:hello")


### PR DESCRIPTION
When a class implements multiple interfaces with default methods having the same name but different signatures, JPype was only exposing methods from one interface.

Root cause: TypeManager.createMethodDispatches() built the method dispatcher table using only getDeclaredMethods(), which returns methods declared directly in the class, not inherited from interfaces. For classes that don't override interface methods, this resulted in empty dispatcher tables.

Solution: Use getMethods() results to build the dispatcher table, which includes all public methods including those inherited from interfaces.

Changes:
- TypeManager.java: Changed line 676 to iterate over 'methods' instead of 'declaredMethods' when building the resolve set
- Added InterfaceOverload.java test fixture with multiple interface scenarios
- Added testInterfaceOverload() to test_overloads.py
- Updated CHANGELOG.rst

All existing tests pass. MCVE from https://github.com/ctrueden/jpype-mcve now works correctly.

Fixes #1430
Fixes #844 