### PR TITLE
Add jdk.zipfs module dependency for jlink/jdeps support

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -19,6 +19,8 @@ Latest Changes:
 
   - Fixed JArray constructor ignoring slice bounds when creating from sliced array. #845
 
+  - Added jdk.zipfs module dependency to module-info for proper jlink/jdeps detection. #908
+
 
 - **1.7.1 - 2026-05-06**
 

--- a/native/jpype_module/src/main/java/module-info.java
+++ b/native/jpype_module/src/main/java/module-info.java
@@ -19,7 +19,8 @@ module jpype {
   requires java.xml;
   requires java.sql;
   requires java.management;
-  
+  requires jdk.zipfs;  // Issue #908: Required for JAR filesystem access via FileSystemProvider
+
   exports org.jpype;
   exports org.jpype.html;
   exports org.jpype.javadoc;


### PR DESCRIPTION
Fixes issue #908 where jdeps could not detect the jdk.zipfs dependency because it was loaded via reflection through FileSystemProvider.

JPypePackageManager uses FileSystemProvider.installedProviders() to access JAR filesystems, which loads jdk.zipfs via ServiceLoader. Since this is done reflectively, jdeps cannot detect it from bytecode analysis alone.

Adding 'requires jdk.zipfs;' to module-info.java makes the dependency explicit, allowing jlink to properly include it when building custom JRE distributions.

Fixes: #908 