### PR TITLE
Revised memory model for JPype

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -7,6 +7,15 @@ Latest Changes:
 
 - **1.7.2.dev0**
 
+  - Fixed heap corruption when boxing large `JLong`/`JInt`/`JShort`/`JByte`/`JBoolean`
+    values on Python 3.8-3.11, caused by a fixed-offset allocator layout
+    assumption colliding with CPython's own implicit `__dict__` slot for
+    variable-length int subclasses.
+
+  - Fixed a GC refcount-accounting bug in the internal Java-class metaclass
+    where `tp_traverse`/`tp_clear` did not chain to `type`'s own
+    implementation.
+
   - Fixed memory leak with int and float conversions. #1379
 
   - Fixed instablity in threading for method dispatch. #1366

--- a/native/common/jp_class.cpp
+++ b/native/common/jp_class.cpp
@@ -376,9 +376,36 @@ JPPyObject JPClass::convertToPythonObject(JPJavaFrame& frame, jvalue value, bool
 	} else
 	{
 		PyTypeObject *type = ((PyTypeObject*) wrapper.get());
-		// Simple objects don't have a new or init function
-		PyObject *obj2 = type->tp_alloc(type, 0);
+		// Simple objects don't have a new or init function.  If this type is
+		// abstract (kept layout-trivial so it can be mixed into any foreign
+		// family -- see PyJPClass_FromSpecWithBases), redirect the actual
+		// allocation to its hidden concrete companion, exactly as
+		// PyJPObject_new does for the ordinary constructor path.
+		PyTypeObject *allocType = type;
+		if (PyJPClass_getOffset(type) == -1)
+		{
+			allocType = PyJPClass_getConcrete(type);
+			if (allocType == nullptr)
+			{
+				PyErr_SetString(PyExc_TypeError, "Concrete implementation missing for abstract type");
+				JP_RAISE_PYTHON();
+			}
+		}
+		PyObject *obj2 = allocType->tp_alloc(allocType, 0);
 		JP_PY_CHECK();
+
+		if (allocType != type)
+		{
+			// Polymorph back to the canonical/abstract type, so
+			// type(instance) stays consistent with cls->getHost() and any
+			// other identity-sensitive code -- mirrors PyJPObject_new's own
+			// polymorph-back (see pyjp_object.cpp) and the legacy
+			// PyJPValue_alloc's Py_SET_TYPE trick.
+			Py_INCREF(type);
+			Py_SET_TYPE(obj2, type);
+			Py_DECREF(allocType);
+		}
+
 		obj = JPPyObject::claim(obj2);
 	}
 

--- a/native/common/jp_primitivetype.cpp
+++ b/native/common/jp_primitivetype.cpp
@@ -14,6 +14,7 @@
    See NOTICE file for details.
  *****************************************************************************/
 #include "jpype.h"
+#include "pyjp.h"
 
 JPPrimitiveType::JPPrimitiveType(const string& name)
 : JPClass(name, 0x411)
@@ -30,43 +31,20 @@ bool JPPrimitiveType::isPrimitive() const
 
 extern "C" Py_ssize_t PyJPValue_getJavaSlotOffset(PyObject* self);
 
-// equivalent of long_subtype_new as it isn't exposed
-
 PyObject *JPPrimitiveType::convertLong(PyTypeObject* wrapper, PyLongObject* tmp)
 {
 	if (wrapper == nullptr)
 		JP_RAISE(PyExc_SystemError, "bad wrapper");
 
-#if PY_VERSION_HEX<0x030c0000
-	// Determine number of digits to copy
-	Py_ssize_t n = Py_SIZE(tmp);
-	if (n < 0)
-		n = -n;
-
-	auto *newobj = (PyLongObject *) wrapper->tp_alloc(wrapper, n);
-	if (newobj == nullptr)
-		return nullptr;
-
-	// Size is in units of digits
-	((PyVarObject*) newobj)->ob_size = Py_SIZE(tmp);
-	for (Py_ssize_t i = 0; i < n; i++)
-	{
-		newobj->ob_digit[i] = tmp->ob_digit[i];
-	}
-
-#else
-	// 3.12 completely does away with ob_size field and repurposes it
-	
-	// Determine the number of digits to copy
-	int n = (tmp->long_value.lv_tag >> 3);
-
-	PyLongObject *newobj = (PyLongObject *) wrapper->tp_alloc(wrapper, n);
-	if (newobj == NULL)
-		return NULL;
-
-	newobj->long_value.lv_tag = tmp->long_value.lv_tag;
-	memcpy(&newobj->long_value.ob_digit, &tmp->long_value.ob_digit, n*sizeof(digit));
-#endif
-	return (PyObject*) newobj;
+	// Must go through PyJPNumber_longFromLongLong (fixed reserved digit
+	// budget), not a hand-rolled long_subtype_new-equivalent sized to tmp's
+	// actual digit count: wrapper (e.g. jpype.JInt, a subclass of
+	// _jpype._JNumberLong) has its Java-value slot at a fixed offset past a
+	// fixed-size digit budget, computed independently of any particular
+	// value. PyLong_AsLongLong can't fail/overflow here -- tmp always
+	// represents a genuine Java primitive (byte/short/int/long), which
+	// always fits within 64 bits.
+	long long value = PyLong_AsLongLong((PyObject*) tmp);
+	return PyJPNumber_longFromLongLong(wrapper, value);
 }
 

--- a/native/python/include/pyjp.h
+++ b/native/python/include/pyjp.h
@@ -95,6 +95,10 @@ struct PyJPArray
 	PyObject_HEAD
 	JPArray *m_Array;
 	JPArrayView *m_View;
+	// Fixed-offset Java-value slot (see PyJPClass_FromSpecWithBases in
+	// pyjp.h/pyjp_class.cpp) -- Array is always single-inheritance below
+	// Object, so it can go straight to concrete like Exception.
+	JPValue extra;
 } ;
 
 struct PyJPClassHints
@@ -155,6 +159,7 @@ extern PyObject *_JMethodCode;
 extern PyObject *_JObjectKey;
 extern PyObject *_JVMNotRunning;
 extern PyObject *PyJPClassMagic;
+extern PyObject *PyJPClassMagicConcrete;
 // for caching type checks with Numpy bool after np version 2.1
 extern PyObject* _num_bool_type;
 extern PyObject* _numpy_int8_type;
@@ -166,10 +171,33 @@ extern JPContext* JPContext_global;
 
 // Class wrapper functions
 int        PyJPClass_Check(PyObject* obj);
-PyObject  *PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases);
+// offset: the Java-value slot family for the resulting type. See
+// plan/ObjectModel.md for the full design. Every family now bakes its
+// slot's location into tp_basicsize itself, so callers must always pass
+// one of:
+//   -1  -> abstract: kept layout-trivial (safe to mix with any foreign
+//          family, e.g. boxed Number/Buffer/Array/Char) and immediately
+//          paired with a hidden concrete companion type that carries the
+//          real, fixed offset.
+//   >0  -> concrete: caller supplies the exact fixed byte offset directly
+//          (e.g. Exception, which has a real compile-time C struct), no
+//          companion needed.
+// (0 used to mean "legacy family, resolved at runtime via the thread-local
+// dummy-heap-type allocator" -- that allocator, PyJPValue_alloc, has been
+// removed; passing 0 is now a hard internal error.)
+PyObject  *PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases, Py_ssize_t offset);
+Py_ssize_t PyJPClass_getOffset(PyTypeObject* type);
+PyTypeObject* PyJPClass_getConcrete(PyTypeObject* type);
+// Like PyJPClass_getOffset, but if `type` itself is abstract (-1) and has a
+// concrete companion, resolves through it to the companion's real, positive
+// offset.  Live instances are always polymorphed back to the canonical
+// (possibly abstract) type at construction time (see PyJPObject_new), so
+// this is what PyJPValue_getJavaSlotOffset's fast path needs -- unlike
+// PyJPClass_getOffset itself, which callers deciding *whether* to redirect
+// allocation still need in its raw, unresolved form.
+Py_ssize_t PyJPClass_getResolvedOffset(PyTypeObject* type);
 
 // Class methods to add to the spec tables
-PyObject  *PyJPValue_alloc(PyTypeObject* type, Py_ssize_t nitems );
 void       PyJPValue_free(void* obj);
 void       PyJPValue_finalize(void* obj);
 int        PyJPValue_traverse(PyObject *self, visitproc visit, void *arg);
@@ -187,6 +215,16 @@ PyObject  *PyJPValue_getattro(PyObject *obj, PyObject *name);
 int        PyJPValue_setattro(PyObject *self, PyObject *name, PyObject *value);
 PyObject  *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p);
 PyTypeObject* PyJP_GetNumPyBaseType(PyTypeObject* obj);
+
+// Build a boxed/primitive-wrapper int value directly, allocating the fixed
+// reserved digit budget (see pyjp_number.cpp) rather than CPython's own
+// long_subtype_new (which sizes the allocation to the value's actual digit
+// count -- wrong once the wrapper type's Java-value slot sits at a fixed
+// offset past a fixed-size digit budget). Used by every construction path
+// for Long/Boolean/int-like primitive wrappers, including
+// JPPrimitiveType::convertLong (jp_primitivetype.cpp), which used to hand-roll
+// its own long_subtype_new equivalent.
+PyObject  *PyJPNumber_longFromLongLong(PyTypeObject* type, long long value);
 
 #ifdef __cplusplus
 }

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -13,6 +13,7 @@
 
    See NOTICE file for details.
  *****************************************************************************/
+#include <cstddef>
 #include "jpype.h"
 #include "pyjp.h"
 #include "jp_array.h"
@@ -494,8 +495,13 @@ static PyType_Spec arrayPrimSpec = {
 
 void PyJPArray_initType(PyObject * module)
 {
+	// Array has a real, compile-time-known C layout (struct PyJPArray) and is
+	// always single-inheritance below Object, so it goes straight to
+	// concrete -- same reasoning as Exception, see pyjp_object.cpp.
+	Py_ssize_t offset = offsetof (struct PyJPArray, extra);
+
 	JPPyObject tuple = JPPyTuple_Pack(PyJPObject_Type);
-	PyJPArray_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&arraySpec, tuple.get());
+	PyJPArray_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&arraySpec, tuple.get(), offset);
 	JP_PY_CHECK();
 #if PY_VERSION_HEX < 0x03090000
 	PyJPArray_Type->tp_as_buffer = &arrayBuffer;
@@ -503,9 +509,12 @@ void PyJPArray_initType(PyObject * module)
 	PyModule_AddObject(module, "_JArray", (PyObject*) PyJPArray_Type);
 	JP_PY_CHECK();
 
+	// ArrayPrimitive adds no new fields (arrayPrimSpec.basicsize == 0, so it
+	// inherits PyJPArray's basicsize as-is) -- same slot location, so pass
+	// the identical offset rather than 0 (which would mean legacy).
 	tuple = JPPyTuple_Pack(PyJPArray_Type);
 	PyJPArrayPrimitive_Type = (PyTypeObject*)
-			PyJPClass_FromSpecWithBases(&arrayPrimSpec, tuple.get());
+			PyJPClass_FromSpecWithBases(&arrayPrimSpec, tuple.get(), offset);
 #if PY_VERSION_HEX < 0x03090000
 	PyJPArrayPrimitive_Type->tp_as_buffer = &arrayPrimBuffer;
 #endif

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -13,6 +13,7 @@
 
    See NOTICE file for details.
  *****************************************************************************/
+#include <cstddef>
 #include "jpype.h"
 #include "pyjp.h"
 #include "jp_buffer.h"
@@ -23,10 +24,14 @@ extern "C"
 {
 #endif
 
+// Buffer has a real, compile-time-known C layout and is always
+// single-inheritance below Object, so it goes straight to concrete -- same
+// reasoning as Exception/Array.
 struct PyJPBuffer
 {
 	PyObject_HEAD
 	JPBuffer *m_Buffer;
+	JPValue extra;
 } ;
 
 static void PyJPBuffer_dealloc(PyJPBuffer *self)
@@ -142,8 +147,9 @@ static PyType_Spec bufferSpec = {
 
 void PyJPBuffer_initType(PyObject * module)
 {
+	Py_ssize_t offset = offsetof (struct PyJPBuffer, extra);
 	JPPyObject tuple = JPPyTuple_Pack(PyJPObject_Type);
-	PyJPBuffer_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&bufferSpec, tuple.get());
+	PyJPBuffer_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&bufferSpec, tuple.get(), offset);
 #if PY_VERSION_HEX < 0x03090000
 	PyJPBuffer_Type->tp_as_buffer = &directBuffer;
 #endif

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -13,6 +13,7 @@
 
    See NOTICE file for details.
  *****************************************************************************/
+#include <cstddef>
 #include "jpype.h"
 #include "pyjp.h"
 #include <structmember.h>
@@ -25,10 +26,17 @@ extern "C"
 
 PyTypeObject *PyJPChar_Type = nullptr;
 
+// m_Data is a fixed 4 bytes regardless of the boxed value (enough for one
+// UCS-2 code point + null in any compact-unicode kind), so -- unlike
+// PyLong/PyFloat subclasses in pyjp_number.cpp -- there's no value-dependent
+// sizing hazard here.  Char can go straight to concrete like Exception/Array/
+// Buffer: single inheritance below Object (plus str, which is trivially
+// compatible since Object is kept layout-trivial).
 struct PyJPChar
 {
 	PyCompactUnicodeObject m_Obj;
 	char m_Data[4];
+	JPValue extra;
 } ;
 
 #define _PyUnicode_LENGTH(op) (((PyASCIIObject *)(op))->length)
@@ -80,7 +88,7 @@ static int assertNotNull(JPValue *javaSlot)
 PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 {
 	// Allocate a new string type (derived from UNICODE)
-	PyJPChar  *self = (PyJPChar*) PyJPValue_alloc(type, 0);
+	PyJPChar  *self = (PyJPChar*) type->tp_alloc(type, 0);
 	if (self == nullptr)
 		return nullptr;
 
@@ -631,8 +639,9 @@ static PyType_Spec charSpec = {
 void PyJPChar_initType(PyObject* module)
 {
 	// We will inherit from str and JObject
+	Py_ssize_t offset = offsetof (struct PyJPChar, extra);
 	JPPyObject bases = JPPyTuple_Pack(&PyUnicode_Type, PyJPObject_Type);
-	PyJPChar_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&charSpec, bases.get());
+	PyJPChar_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&charSpec, bases.get(), offset);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JChar", (PyObject*) PyJPChar_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -14,6 +14,7 @@
    See NOTICE file for details.
  *****************************************************************************/
 #include <algorithm>
+#include <cstddef>
 #include <Python.h>
 #include <frameobject.h>
 #include <structmember.h>
@@ -32,9 +33,33 @@ struct PyJPClass
 	PyHeapTypeObject ht_type;
 	JPClass *m_Class;
 	PyObject *m_Doc;
+	// Java-value slot bookkeeping for the fixed-offset object model.  See
+	// the offset parameter documentation in include/pyjp.h for the
+	// 0 / -1 / >0 sentinel meanings.
+	Py_ssize_t offset;
+	// For an abstract (offset == -1) type: the hidden concrete companion
+	// that actually gets instantiated in its place.  For a concrete
+	// companion: the abstract type it stands in for.  Null otherwise.
+	PyTypeObject *other;
+	// Every _JClass instance (i.e. every generated Java class/interface
+	// wrapper type object, such as the type object for java.lang.String)
+	// itself carries a JPValue for the java.lang.Class object it represents.
+	// struct PyJPClass is a single, closed, compile-time-fixed layout --
+	// PyJPClass_Type is never used as a base for any other spec, and every
+	// wrapper is an *instance* of it, not a Python-level subclass with its
+	// own extra slots -- so this can be a plain trailing field, exactly like
+	// Exception/Array/Buffer/Char, with no per-family scan needed.  See the
+	// PyJPClass_Type special case in PyJPClass_getOffset below.
+	JPValue extra;
 } ;
 
 PyObject* PyJPClassMagic = nullptr;
+PyObject* PyJPClassMagicConcrete = nullptr;
+
+static inline size_t PyJPClass_alignUp(size_t value, size_t alignment)
+{
+	return (value + alignment - 1) & ~(alignment - 1);
+}
 
 #ifdef __cplusplus
 extern "C"
@@ -46,21 +71,103 @@ int PyJPClass_Check(PyObject* obj)
 	return PyJP_IsInstanceSingle(obj, PyJPClass_Type);
 }
 
+Py_ssize_t PyJPClass_getOffset(PyTypeObject* type)
+{
+	// Special case: PyJPClass_Type itself.  Its own instances are the
+	// generated Java class/interface wrapper type objects (e.g. the type
+	// object for java.lang.String) -- each one directly *is* a
+	// `struct PyJPClass`, whose `extra` field is a fixed, compile-time-known
+	// offset, not something computed per-family.  This is what lets
+	// PyJPValue_getJavaSlot(obj) work uniformly whether obj is an ordinary
+	// Java object instance (Py_TYPE(obj) is itself a PyJPClass instance,
+	// handled below) or a class/interface wrapper object (Py_TYPE(obj) is
+	// PyJPClass_Type exactly).
+	if (type == (PyTypeObject*) PyJPClass_Type)
+		return offsetof (struct PyJPClass, extra);
+	if (type == nullptr || Py_TYPE(type) != (PyTypeObject*) PyJPClass_Type)
+		return 0;
+	return ((PyJPClass*) type)->offset;
+}
+
+PyTypeObject* PyJPClass_getConcrete(PyTypeObject* type)
+{
+	if (type == nullptr || Py_TYPE(type) != (PyTypeObject*) PyJPClass_Type)
+		return nullptr;
+	return ((PyJPClass*) type)->other;
+}
+
+Py_ssize_t PyJPClass_getResolvedOffset(PyTypeObject* type)
+{
+	Py_ssize_t off = PyJPClass_getOffset(type);
+	if (off == -1)
+	{
+		PyTypeObject *companion = PyJPClass_getConcrete(type);
+		if (companion != nullptr)
+			off = PyJPClass_getOffset(companion);
+	}
+	return off;
+}
+
+/**
+ * Create a hidden, single-purpose concrete companion type for an abstract
+ * (offset == -1) type.  The companion shares the abstract type's tp_name,
+ * is single-inheritance (bases = (abstract_type,)) so it can never conflict
+ * with a foreign layout at creation time, and is not itself subclassable
+ * (Py_TPFLAGS_BASETYPE cleared once it is built -- see the concrete branch
+ * of PyJPClass_init).
+ */
+static int PyJPClass_concrete(PyTypeObject *abstractType)
+{
+	PyObject *bases = PyTuple_Pack(1, (PyObject*) abstractType);
+	if (bases == nullptr)
+		return -1;
+	PyObject *args = Py_BuildValue("sNN", abstractType->tp_name, bases, PyDict_New());
+	if (args == nullptr)
+		return -1;
+	PyObject *self = ((PyTypeObject*) PyJPClass_Type)->tp_call((PyObject*) PyJPClass_Type, args, PyJPClassMagicConcrete);
+	Py_DECREF(args);
+	if (self == nullptr)
+		return -1;
+	// Intentionally not decref'd: this is a permanent, JVM-lifetime
+	// companion kept alive by the reference tp_call returned, referenced
+	// only via ((PyJPClass*)abstractType)->other (see PyJPClass_init).
+	return 0;
+}
+
 static int PyJPClass_traverse(PyJPClass *self, visitproc visit, void *arg)
 {
+	// This type overrides type's tp_traverse, so it must chain to it to
+	// keep visiting tp_dict/tp_bases/tp_mro/etc, or the GC undercounts
+	// outgoing edges from this object while other objects (e.g. the
+	// wrapper_descriptors in tp_dict) still count their incoming edge to
+	// us - causing a gc refcount underflow assertion at shutdown.
+	if (PyType_Type.tp_traverse((PyObject*) self, visit, arg) != 0)
+		return -1; // GCOVR_EXCL_LINE
 	Py_VISIT(self->m_Doc);
+	// self->other is deliberately NOT visited here: it is a permanent,
+	// JVM-lifetime reference to an abstract type's hidden concrete
+	// companion (see PyJPClass_concrete) that is intentionally never
+	// cleared (the companion's own tp_bases points straight back at this
+	// type, so visiting both halves of that pair turns it into a real,
+	// GC-visible 2-node cycle that tp_clear can never actually break --
+	// a traverse/clear contract violation that corrupts cycle-collector
+	// refcount accounting for the whole connected component it touches,
+	// not just this pair). Treat it the same as the C++-side JPClass::
+	// m_Host reference: a permanent edge that is simply invisible to the
+	// cyclic GC, exactly like this design already intends it to behave.
 	return 0;
 }
 
 static int PyJPClass_clear(PyJPClass *self)
 {
+	PyType_Type.tp_clear((PyObject*) self);
 	Py_CLEAR(self->m_Doc);
 	return 0;
 }
 
 PyObject* examine(PyObject *module, PyObject *other);
 
-PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
+PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases, Py_ssize_t offset)
 {
 	JP_PY_TRY("PyJPClass_FromSpecWithBases");
 #if PY_VERSION_HEX>=0x030c0000
@@ -106,7 +213,12 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 	type->tp_itemsize = spec->itemsize;
 	if (spec->itemsize == 0)
 		type->tp_itemsize = type->tp_base->tp_itemsize;
-	type->tp_alloc = PyJPValue_alloc;
+	// Default allocator: inherit from the base, exactly like ordinary
+	// CPython single-inheritance type creation would.  Every built-in
+	// _jpype._J* family now bakes its Java-value slot into tp_basicsize
+	// itself (concrete: a real trailing struct field; abstract: no slot of
+	// its own yet), so no special allocator is needed here any more.
+	type->tp_alloc = type->tp_base->tp_alloc;
 	type->tp_free = PyJPValue_free;
 	type->tp_finalize = (destructor) PyJPValue_finalize;
 	for (PyType_Slot* slot = spec->slots; slot->slot; slot++)
@@ -250,12 +362,32 @@ PyObject* PyJPClass_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
 
 #endif
 
-	// Make sure our memory model is used
-	type->tp_alloc = (allocfunc) PyJPValue_alloc;
+	// Every built-in family now has its Java-value slot's location either
+	// baked into tp_basicsize (concrete) or deliberately absent (abstract,
+	// awaiting a concrete companion) -- so the inherited allocator set
+	// above is always correct and there is no legacy (offset == 0) case
+	// left to force onto the thread-local dummy-heap-type allocator.
+	if (offset == 0)
+	{
+		PyErr_Format(PyExc_TypeError,
+				"internal error: '%s' registered with offset 0 (legacy "
+				"allocator no longer exists)", spec->name);
+		Py_DECREF(type);
+		JP_RAISE_PYTHON();
+	}
 	type->tp_finalize = (destructor) PyJPValue_finalize;
+	((PyJPClass*) type)->offset = offset;
+	((PyJPClass*) type)->other = nullptr;
 
 	PyType_Ready(type);
 	PyDict_SetItemString(type->tp_dict, "__module__", PyUnicode_FromString("_jpype"));
+
+	if (offset == -1 && PyJPClass_concrete(type) == -1)
+	{
+		Py_DECREF(type);
+		return nullptr;
+	}
+
 	return (PyObject*) type;
 	JP_PY_CATCH(nullptr); // GCOVR_EXCL_LINE
 }
@@ -281,7 +413,13 @@ int PyJPClass_init(PyObject *self, PyObject *args, PyObject *kwargs)
 
 	// Verify that we were called internally
 	int magic = 0;
-	if (kwargs == PyJPClassMagic || (kwargs != nullptr && PyDict_GetItemString(kwargs, "internal") != nullptr))
+	bool concreteCall = false;
+	if (kwargs == PyJPClassMagicConcrete)
+	{
+		magic = 1;
+		concreteCall = true;
+		kwargs = nullptr;
+	} else if (kwargs == PyJPClassMagic || (kwargs != nullptr && PyDict_GetItemString(kwargs, "internal") != nullptr))
 	{
 		magic = 1;
 		kwargs = nullptr;
@@ -322,10 +460,67 @@ int PyJPClass_init(PyObject *self, PyObject *args, PyObject *kwargs)
 		}
 	}
 
-	// We must make sure that all classes have our allocator
-	type->tp_alloc = (allocfunc) PyJPValue_alloc;
+	// Resolve this type's Java-value slot family by scanning all bases.
+	// Priority is legacy > concrete > abstract:
+	//  - any legacy base forces the whole type back to the fully-legacy
+	//    path, no matter what else is mixed in.  This is what keeps boxed
+	//    Number types (which implement Comparable/Serializable -- abstract,
+	//    migrated bases) safe: they stay on the untouched legacy allocator
+	//    rather than risk a CPython "instance lay-out conflict" from mixing
+	//    a migrated family's layout with PyLong/PyFloat ancestry.
+	//  - failing that, a concrete base's offset is inherited directly (no
+	//    further work needed -- CPython's own type_new already grew
+	//    tp_basicsize correctly via ordinary single/solid-base inheritance).
+	//  - failing that, if any base is abstract, this type is abstract too
+	//    and needs its own concrete companion before it can be instantiated.
+	bool anyLegacy = false;
+	Py_ssize_t concreteOffset = 0;
+	bool anyAbstract = false;
+	{
+		Py_ssize_t n = PyTuple_Size(bases);
+		for (Py_ssize_t i = 0; i < n; ++i)
+		{
+			PyObject *b = PyTuple_GetItem(bases, i);
+			if (Py_TYPE(b) != (PyTypeObject*) PyJPClass_Type)
+				continue;
+			Py_ssize_t bo = ((PyJPClass*) b)->offset;
+			if (bo == 0)
+				anyLegacy = true;
+			else if (bo > 0)
+			{
+				if (concreteOffset == 0)
+					concreteOffset = bo;
+			} else
+				anyAbstract = true;
+		}
+	}
+
+	// anyLegacy can no longer trip (no family registers offset == 0 any
+	// more -- see PyJPClass_FromSpecWithBases), and the "no Java-value-
+	// bearing base at all" case is unreachable in practice: PyJPClass_
+	// getBases always supplies either an interface/superclass base (which
+	// itself resolves recursively) or, when super == nullptr, the abstract
+	// PyJPObject_Type explicitly -- so every wrapper's bases tuple contains
+	// at least one non-zero-offset PyJPClass_Type instance, bottoming out
+	// at Object. Both are asserted here rather than silently forced onto a
+	// (now-deleted) legacy allocator, so that if this reasoning is ever
+	// wrong for some case we haven't enumerated, it fails loudly instead of
+	// corrupting memory.
+	if (anyLegacy || (!(concreteOffset > 0) && !anyAbstract))
+	{
+		PyErr_Format(PyExc_TypeError,
+				"internal error: '%s' has no Java-value-bearing base "
+				"(legacy allocator no longer exists)",
+				((PyHeapTypeObject*) type)->ht_name ?
+				PyUnicode_AsUTF8(((PyHeapTypeObject*) type)->ht_name) : "?");
+		return -1;
+	}
+	Py_ssize_t resolvedOffset = (concreteOffset > 0) ? concreteOffset : -1;
+
 	type->tp_finalize = (destructor) PyJPValue_finalize;
 	((PyJPClass*) self)->m_Doc = nullptr;
+	((PyJPClass*) self)->offset = resolvedOffset;
+	((PyJPClass*) self)->other = nullptr;
 
 	// Call the type init
 	int rc = PyType_Type.tp_init(self, args, nullptr);
@@ -344,8 +539,10 @@ int PyJPClass_init(PyObject *self, PyObject *args, PyObject *kwargs)
 
 	// This sanity check is trigger if the user attempts to build their own
 	// type wrapper with a __del__ method defined.	It is hard to trigger.
-	if (type->tp_alloc != (allocfunc) PyJPValue_alloc
-			&& type->tp_alloc != PyBaseObject_Type.tp_alloc)
+	// No family forces its own allocator any more (see PyJPClass_init above),
+	// so the only correct value is whatever ordinary CPython inheritance
+	// already gave this type from its base.
+	if (type->tp_alloc != type->tp_base->tp_alloc)
 	{
 		PyErr_SetString(PyExc_TypeError, "alloc conflict");
 		return -1;
@@ -359,6 +556,27 @@ int PyJPClass_init(PyObject *self, PyObject *args, PyObject *kwargs)
 		type->tp_new = PyJPException_Type->tp_new;
 	}
 #endif
+
+	if (concreteCall)
+	{
+		// This call came from PyJPClass_concrete: bases is exactly
+		// (abstractType,).  Bake in the real fixed offset for it now and
+		// pair the two types together; no further Python-level subclassing
+		// of this hidden companion is allowed.
+		PyObject *abstractBase = PyTuple_GetItem(bases, 0);
+		size_t off = PyJPClass_alignUp((size_t) type->tp_basicsize, alignof (JPValue));
+		type->tp_basicsize = (Py_ssize_t) (off + sizeof (JPValue));
+		((PyJPClass*) self)->offset = (Py_ssize_t) off;
+		((PyJPClass*) abstractBase)->other = type;
+		((PyJPClass*) self)->other = (PyTypeObject*) abstractBase;
+		type->tp_flags &= ~Py_TPFLAGS_BASETYPE;
+	} else if (resolvedOffset == -1)
+	{
+		// An ordinary type that resolved to abstract: give it its own
+		// hidden concrete companion so it can actually be instantiated.
+		if (PyJPClass_concrete(type) == -1)
+			return -1;
+	}
 
 	return rc;
 	JP_PY_CATCH(-1);
@@ -1000,7 +1218,10 @@ static PyGetSetDef classGetSets[] = {
 };
 
 static PyType_Slot classSlots[] = {
-	{ Py_tp_alloc, (void*) PyJPValue_alloc},
+	// No Py_tp_alloc override: struct PyJPClass's own JPValue ("extra") is
+	// now a compile-time-fixed trailing field (see PyJPClass_getOffset's
+	// PyJPClass_Type special case), so classSpec.basicsize already accounts
+	// for it and the ordinary inherited (PyType_Type) allocator is correct.
 	{ Py_tp_finalize, (void*) PyJPValue_finalize},
 	{ Py_tp_init, (void*) PyJPClass_init},
 	{ Py_tp_dealloc, (void*) PyJPClass_dealloc},
@@ -1046,7 +1267,19 @@ JPClass* PyJPClass_getJPClass(PyObject* obj)
 		if (obj == nullptr)
 			return nullptr;
 		if (PyJPClass_Check(obj))
-			return ((PyJPClass*) obj)->m_Class;
+		{
+			JPClass *cls = ((PyJPClass*) obj)->m_Class;
+			if (cls != nullptr)
+				return cls;
+			// obj may be the hidden concrete companion of an abstract type
+			// (or vice versa) -- m_Class is only ever set on the canonical
+			// type returned to PyJPClass_hook's caller, so hop through
+			// `other` to find it.  This is what keeps the fast subtype
+			// check and isinstance/issubclass correct regardless of which
+			// paired type a live instance's Py_TYPE happens to be.
+			PyTypeObject *other = ((PyJPClass*) obj)->other;
+			return (other != nullptr) ? ((PyJPClass*) other)->m_Class : nullptr;
+		}
 		JPValue* javaSlot = PyJPValue_getJavaSlot(obj);
 		if (javaSlot == nullptr)
 			return nullptr;

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -831,6 +831,7 @@ PyMODINIT_FUNC PyInit__jpype()
 	PyModule_AddObject(module, "__builtins__", builtins);
 
 	PyJPClassMagic = PyDict_New();
+	PyJPClassMagicConcrete = PyDict_New();
 	// Initialize each of the python extension types
 	PyJPClass_initType(module);
 	PyJPObject_initType(module);

--- a/native/python/pyjp_number.cpp
+++ b/native/python/pyjp_number.cpp
@@ -16,6 +16,116 @@
 #include "jpype.h"
 #include "pyjp.h"
 #include "jp_boxedtype.h"
+#include <cstddef>
+
+static inline size_t PyJPNumber_alignUp(size_t value, size_t alignment)
+{
+	return (value + alignment - 1) & ~(alignment - 1);
+}
+
+// Long/Boolean are variable-length PyLongObject subtypes.  Rather than a
+// compile-time struct (as Exception/Float use), we reserve a FIXED maximum
+// digit budget -- enough for any 64-bit Java boxed value -- so the appended
+// JPValue's offset never depends on which value is being boxed.  See
+// PyJPNumber_longFromLongLong's header comment for why we can't just let CPython's own
+// long_subtype_new (used by default for any int subtype) handle this.
+#if PYLONG_BITS_IN_DIGIT == 30
+#define JLONG_MAX_DIGITS 3 /* 3*30 = 90 >= 64 bits */
+#elif PYLONG_BITS_IN_DIGIT == 15
+#define JLONG_MAX_DIGITS 5 /* 5*15 = 75 >= 64 bits */
+#else
+#error "Unexpected PYLONG_BITS_IN_DIGIT"
+#endif
+
+// Number of extra digit-slots (nitems) that must be passed to tp_alloc for
+// every Long/Boolean instance so the fixed offset computed in
+// PyJPNumber_initType always lands inside the actual allocation, regardless
+// of alignment padding. Computed once at module init (PyJPNumber_initType).
+static Py_ssize_t gLongReserveItems = 0;
+
+// Float has a genuine compile-time-known C layout (like Exception), so it
+// gets a real struct and a direct offsetof-based concrete offset -- no
+// digit-budget reasoning needed since PyFloatObject is always fixed-size.
+struct PyJPFloat
+{
+	PyFloatObject base;
+	JPValue extra;
+};
+
+/*
+ * WHY THESE DON'T CALL INTO PyLong_Type.tp_new/PyFloat_Type.tp_new WITH THE
+ * ACTUAL SUBTYPE
+ *
+ * CPython's own tp_new for int/float SUBTYPES (long_subtype_new/
+ * float_subtype_new, Objects/longobject.c, Objects/floatobject.c) build a
+ * throwaway base-type instance first and then allocate+copy into the real
+ * subtype using however many digits (int) that specific value needs --
+ * NOT our fixed maximum budget. Since our type's slot offset is now a fixed
+ * constant (computed once, independent of the boxed value), any allocation
+ * that doesn't reserve the full fixed budget would place the appended
+ * JPValue past the end of a too-small allocation. So every construction
+ * path for Long/Boolean must go through PyJPNumber_longFromLongLong (which always
+ * allocates gLongReserveItems digit-slots, regardless of the actual value's
+ * magnitude); Float doesn't have this variable-length concern at all, since
+ * PyFloatObject's size never depends on the value it stores.
+ *
+ * Digit layout is duplicated per CPython version boundary (confirmed
+ * against the CPython source tree directly, tags v3.10.0 through v3.14.0 --
+ * see jpype_boxed_long_antipattern_fix memory for the full derivation):
+ *   - <=3.11: struct _longobject { PyObject_VAR_HEAD; digit ob_digit[1]; };
+ *     sign is the sign of ob_size.
+ *   - >=3.12: struct _longobject { PyObject_HEAD; _PyLongValue long_value; }
+ *     where long_value = { uintptr_t lv_tag; digit ob_digit[1]; }. lv_tag's
+ *     low 2 bits are sign (0=positive,1=zero,2=negative), bit 2 is the
+ *     immortal-object flag (0 for our freshly allocated objects), lv_tag>>3
+ *     is the digit count.
+ */
+PyObject* PyJPNumber_longFromLongLong(PyTypeObject* type, long long value)
+{
+	// Magnitude via unsigned negation so INT64_MIN doesn't overflow.
+	unsigned long long mag = (value < 0)
+			? (0ULL - (unsigned long long) value)
+			: (unsigned long long) value;
+
+	digit digits[JLONG_MAX_DIGITS];
+	unsigned long long m = mag;
+	for (int i = 0; i < JLONG_MAX_DIGITS; i++)
+	{
+		digits[i] = (digit) (m & PyLong_MASK);
+		m >>= PyLong_SHIFT;
+	}
+	int ndigits = JLONG_MAX_DIGITS;
+	while (ndigits > 0 && digits[ndigits - 1] == 0)
+		ndigits--;
+
+	// Always allocate the full reserved budget, regardless of how many
+	// digits this particular value actually needs, so the appended slot's
+	// offset never moves.
+	auto* self = (PyLongObject*) type->tp_alloc(type, gLongReserveItems);
+	if (self == nullptr)
+		return nullptr;
+
+#if PY_VERSION_HEX >= 0x030c0000
+	int sign_code = (mag == 0) ? 1 : (value < 0 ? 2 : 0);
+	self->long_value.lv_tag = ((uintptr_t) ndigits << 3) | (uintptr_t) sign_code;
+	for (int i = 0; i < JLONG_MAX_DIGITS; i++)
+		self->long_value.ob_digit[i] = digits[i];
+#else
+	Py_SET_SIZE(self, (value < 0) ? -ndigits : ndigits);
+	for (int i = 0; i < JLONG_MAX_DIGITS; i++)
+		self->ob_digit[i] = digits[i];
+#endif
+	return (PyObject*) self;
+}
+
+static PyObject* newFloatFixed(PyTypeObject* type, double value)
+{
+	auto* self = (PyFloatObject*) type->tp_alloc(type, 0);
+	if (self == nullptr)
+		return nullptr;
+	self->ob_fval = value;
+	return (PyObject*) self;
+}
 
 static bool isNull(PyObject *self)
 {
@@ -248,21 +358,25 @@ static Py_hash_t PyJPNumberFloat_hash(PyObject *self)
 static PyObject *PyJPBoolean_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPBoolean_new", type);
-	JPPyObject self;
 	if (PyTuple_Size(args) != 1)
 	{
 		PyErr_SetString(PyExc_TypeError, "Requires one argument");
 		return nullptr;
 	}
 	int i = PyObject_IsTrue(PyTuple_GetItem(args, 0));
-	JPPyObject args2 = JPPyTuple_Pack(PyLong_FromLong(i));
-	self = JPPyObject::call(PyLong_Type.tp_new(type, args2.get(), kwargs));
 	JPClass *cls = PyJPClass_getJPClass((PyObject*) type);
 	if (cls == nullptr)
 	{
 		PyErr_SetString(PyExc_TypeError, "Class type incorrect");
 		return nullptr;
 	}
+	// Must use our own fixed-budget allocator, not PyLong_Type.tp_new(type,
+	// ...) -- calling it with the actual subtype would dispatch to CPython's
+	// own long_subtype_new, which allocates only as many digits as the
+	// value 0/1 needs, not our fixed reserved budget, corrupting the
+	// appended JPValue slot. See PyJPNumber_longFromLongLong's header comment.
+	JPPyObject self = JPPyObject::call(PyJPNumber_longFromLongLong(type, i));
+	JP_PY_CHECK();
 	JPJavaFrame frame = JPJavaFrame::outer();
 	JPMatch match(&frame, self.get());
 	cls->findJavaConversion(match);
@@ -335,7 +449,7 @@ static PyType_Slot numberFloatSlots[] = {
 PyTypeObject *PyJPNumberFloat_Type = nullptr;
 PyType_Spec numberFloatSpec = {
 	"_jpype._JNumberFloat",
-	0,
+	sizeof (struct PyJPFloat),
 	0,
 	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
 	numberFloatSlots
@@ -370,21 +484,63 @@ PyType_Spec numberBooleanSpec = {
 
 void PyJPNumber_initType(PyObject* module)
 {
+	// Compute the fixed Long/Boolean digit-slot layout once: enough room for
+	// JLONG_MAX_DIGITS digits (the offset), plus however many whole
+	// digit-slots (nitems, gLongReserveItems) are needed for the actual
+	// allocation to always cover offset+sizeof(JPValue), regardless of
+	// alignment padding. See PyJPNumber_longFromLongLong's header comment.
+	//
+	// EXTRA MARGIN, WHY: jpype.JLong/JInt/JShort/JByte/JBoolean (jpype/types.py)
+	// are ordinary Python subclasses of _jpype._JNumberLong/_JBoolean (`class
+	// JLong(_jpype._JNumberLong, internal=True): pass`, no __slots__). Since
+	// _jpype._JNumberLong itself has tp_dictoffset==0, CPython's type_new_
+	// descriptors (Objects/typeobject.c) adds an implicit instance __dict__
+	// to that first subclass -- and because the base has nonzero tp_itemsize
+	// (it's a variable-length int), CPython does NOT grow tp_basicsize by a
+	// dict *pointed to by a fixed offset*; instead it sets
+	// tp_dictoffset = -sizeof(PyObject*) (a NEGATIVE/dynamic offset) so the
+	// dict pointer resolves at runtime to
+	// (this_type's grown tp_basicsize) + Py_SIZE(obj)*itemsize - sizeof(PyObject*)
+	// == PyLong_Type.tp_basicsize + Py_SIZE(obj)*itemsize
+	// i.e. immediately after however many digits THIS PARTICULAR boxed value
+	// actually has (Py_SIZE, 0..JLONG_MAX_DIGITS). We always allocate/reserve
+	// a fixed JLONG_MAX_DIGITS-digit budget regardless of the real value, so
+	// this dynamic dict slot can land anywhere in
+	// [PyLong_Type.tp_basicsize, PyLong_Type.tp_basicsize + JLONG_MAX_DIGITS*itemsize + sizeof(PyObject*))
+	// -- our own appended JPValue must start at or past the far end of that
+	// whole window, not just past the digit budget itself, or assignJavaSlot
+	// silently overwrites live bytes of that dict pointer (a rare, version-
+	// sensitive CPython heap-layout hazard: newer CPython's managed-dict
+	// scheme, Py_TPFLAGS_MANAGED_DICT, avoids this entirely by not touching
+	// tp_basicsize/tp_dictoffset at all -- confirmed no reproduction on
+	// 3.12 -- but pre-3.11-style dict slots hit it whenever a boxed value
+	// needs the full digit budget, e.g. JLong(2**61)).
+	auto base = (size_t) PyLong_Type.tp_basicsize;
+	auto itemsize = (size_t) PyLong_Type.tp_itemsize;
+	size_t rawNeeded = base + (size_t) JLONG_MAX_DIGITS * itemsize + sizeof (PyObject*);
+	size_t longOffset = PyJPNumber_alignUp(rawNeeded, alignof (JPValue));
+	size_t totalNeeded = longOffset + sizeof (JPValue);
+	size_t extraBytes = totalNeeded - base;
+	gLongReserveItems = (Py_ssize_t) ((extraBytes + itemsize - 1) / itemsize);
 
 	JPPyObject bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
-	PyJPNumberLong_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberLongSpec, bases.get());
+	PyJPNumberLong_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberLongSpec, bases.get(), (Py_ssize_t) longOffset);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JNumberLong", (PyObject*) PyJPNumberLong_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
 	bases = JPPyTuple_Pack(&PyFloat_Type, PyJPObject_Type);
-	PyJPNumberFloat_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberFloatSpec, bases.get());
+	PyJPNumberFloat_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberFloatSpec, bases.get(),
+			offsetof (struct PyJPFloat, extra));
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JNumberFloat", (PyObject*) PyJPNumberFloat_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
+	// Boolean is its own family root (not a subclass of PyJPNumberLong_Type)
+	// but shares the identical PyLong_Type-based layout, so it reuses the
+	// same offset/reserve-items values computed above.
 	bases = JPPyTuple_Pack(&PyLong_Type, PyJPObject_Type);
-	PyJPNumberBool_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberBooleanSpec, bases.get());
+	PyJPNumberBool_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&numberBooleanSpec, bases.get(), (Py_ssize_t) longOffset);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JBoolean", (PyObject*) PyJPNumberBool_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
@@ -399,9 +555,7 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 		jlong l = 0;
 		if (value.getValue().l != nullptr)
 			l = frame.CallBooleanMethodA(value.getJavaObject(), context->_java_lang_Boolean->m_BooleanValueID, nullptr);
-		JPPyObject ln = JPPyObject::call(PyLong_FromLongLong(l));
-		JPPyObject args = JPPyTuple_Pack(ln.get());
-		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args.get(), nullptr));
+		return JPPyObject::call(PyJPNumber_longFromLongLong((PyTypeObject*) wrapper.get(), l));
 	}
 	if (PyObject_IsSubclass(wrapper.get(), (PyObject*) & PyLong_Type))
 	{
@@ -411,9 +565,7 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 			auto* jb = dynamic_cast<JPBoxedType*>( value.getClass());
 			l = frame.CallLongMethodA(value.getJavaObject(), jb->m_LongValueID, nullptr);
 		}
-		JPPyObject ln = JPPyObject::call(PyLong_FromLongLong(l));
-		JPPyObject args = JPPyTuple_Pack(ln.get());
-		return JPPyObject::call(PyLong_Type.tp_new((PyTypeObject*) wrapper.get(), args.get(), nullptr));
+		return JPPyObject::call(PyJPNumber_longFromLongLong((PyTypeObject*) wrapper.get(), l));
 	}
 	if (PyObject_IsSubclass(wrapper.get(), (PyObject*) & PyFloat_Type))
 	{
@@ -423,9 +575,7 @@ JPPyObject PyJPNumber_create(JPJavaFrame &frame, JPPyObject& wrapper, const JPVa
 			auto* jb = dynamic_cast<JPBoxedType*>( value.getClass());
 			l = frame.CallDoubleMethodA(value.getJavaObject(), jb->m_DoubleValueID, nullptr);
 		}
-		JPPyObject ln = JPPyObject::call(PyFloat_FromDouble(l));
-		JPPyObject args = JPPyTuple_Pack(ln.get());
-		return JPPyObject::call(PyFloat_Type.tp_new((PyTypeObject*) wrapper.get(), args.get(), nullptr));
+		return JPPyObject::call(newFloatFixed((PyTypeObject*) wrapper.get(), l));
 	}
 	JP_RAISE(PyExc_TypeError, "unable to convert");  //GCOVR_EXCL_LINE
 }

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -13,6 +13,7 @@
 
    See NOTICE file for details.
  *****************************************************************************/
+#include <cstddef>
 #include "jpype.h"
 #include "pyjp.h"
 
@@ -24,7 +25,10 @@ extern "C"
 static PyObject *PyJPObject_new(PyTypeObject *type, PyObject *pyargs, PyObject *kwargs)
 {
 	JP_PY_TRY("PyJPObject_new");
-	// Get the Java class from the type.
+	// Get the Java class from the type.  This must use the canonical/visible
+	// type -- the one the caller actually named -- since only it has
+	// m_Class populated; a hidden concrete companion (see
+	// PyJPClass_concrete) never does.
 	JPClass *cls = PyJPClass_getJPClass((PyObject*) type);
 	if (cls == nullptr)
 	{
@@ -37,11 +41,39 @@ static PyObject *PyJPObject_new(PyTypeObject *type, PyObject *pyargs, PyObject *
 	JPPyObjectVector args(pyargs);
 	JPValue jv = cls->newInstance(frame, args);
 
+	// If this type is abstract (kept layout-trivial so it stays compatible
+	// as a mixin base for any foreign family, e.g. boxed Number), redirect
+	// the actual allocation to its hidden concrete companion.
+	PyTypeObject *allocType = type;
+	if (PyJPClass_getOffset(type) == -1)
+	{
+		allocType = PyJPClass_getConcrete(type);
+		if (allocType == nullptr)
+		{
+			PyErr_SetString(PyExc_TypeError, "Concrete implementation missing for abstract type");
+			return nullptr;
+		}
+	}
+
 	// If it succeeded then allocate memory
-	PyObject *self = type->tp_alloc(type, 0);
+	PyObject *self = allocType->tp_alloc(allocType, 0);
 	JP_PY_CHECK();
 
 	JP_FAULT_RETURN("PyJPObject_init.null", self);
+
+	if (allocType != type)
+	{
+		// Polymorph back to the canonical/abstract type the caller actually
+		// named, so type(instance) stays consistent with jpype.JClass(...)
+		// and any other identity-sensitive code -- mirrors the legacy
+		// PyJPValue_alloc's own Py_SET_TYPE trick (see pyjp_value.cpp).
+		// The companion only ever exists as a transient allocation-sizing
+		// vehicle; no live object should ever report it as its type.
+		Py_INCREF(type);
+		Py_SET_TYPE(self, type);
+		Py_DECREF(allocType);
+	}
+
 	PyJPValue_assignJavaSlot(frame, self, jv);
 	return self;
 	JP_PY_CATCH(nullptr);
@@ -228,7 +260,6 @@ static PyMethodDef objectMethods[] = {
 };
 
 static PyType_Slot objectSlots[] = {
-	{Py_tp_alloc,    (void*) &PyJPValue_alloc},
 	{Py_tp_finalize,    (void*) &PyJPValue_finalize},
 	{Py_tp_new,      (void*) &PyJPObject_new},
 	{Py_tp_free,     (void*) &PyJPValue_free},
@@ -338,9 +369,22 @@ static PyType_Slot excSlots[] = {
 	{0}
 };
 
+// Exception has a real, compile-time-known C layout (unlike plain Object,
+// whose layout varies with whatever it's mixed with), so it can be given a
+// concrete fixed offset directly -- no abstract/companion dance needed.
+// Java exceptions are always single-inheritance below Throwable, so there's
+// never a risk of this concrete layout conflicting with a foreign family
+// (that risk is specific to Object-lineage interfaces getting mixed into
+// boxed Number/Buffer/Array/Char, which stay legacy).
+struct PyJPException
+{
+	PyBaseExceptionObject base;
+	JPValue extra;
+};
+
 static PyType_Spec excSpec = {
 	"_jpype._JException",
-	0,
+	sizeof (struct PyJPException),
 	0,
 	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
 	excSlots
@@ -367,18 +411,28 @@ static PyType_Spec comparableSpec = {
 
 void PyJPObject_initType(PyObject* module)
 {
-    PyJPObject_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&objectSpec, nullptr);
+    // -1: abstract.  Object's layout must stay byte-identical to `object` so
+    // it can be mixed, via ordinary Java interface implementation, into any
+    // foreign family (boxed Number/Buffer/Array/Char) without CPython
+    // raising "multiple bases have instance lay-out conflict".  A hidden
+    // concrete companion (see PyJPClass_concrete) is created immediately and
+    // used transparently at construction time (PyJPObject_new).
+    PyJPObject_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&objectSpec, nullptr, -1);
     JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JObject", (PyObject*) PyJPObject_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
     JPPyObject bases = JPPyTuple_Pack(PyExc_Exception, PyJPObject_Type);
-	PyJPException_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&excSpec, bases.get());
+	PyJPException_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&excSpec, bases.get(),
+			offsetof (struct PyJPException, extra));
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JException", (PyObject*) PyJPException_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 
+	// Comparable is a pure interface mixin: it adds no fields of its own, so
+	// it is abstract too (like Object) rather than concrete, and gets its
+	// own (never actually used in practice, but harmless) hidden companion.
 	bases = JPPyTuple_Pack(PyJPObject_Type);
-	PyJPComparable_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&comparableSpec, bases.get());
+	PyJPComparable_Type = (PyTypeObject*) PyJPClass_FromSpecWithBases(&comparableSpec, bases.get(), -1);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE
 	PyModule_AddObject(module, "_JComparable", (PyObject*) PyJPComparable_Type);
 	JP_PY_CHECK(); // GCOVR_EXCL_LINE

--- a/native/python/pyjp_value.cpp
+++ b/native/python/pyjp_value.cpp
@@ -24,57 +24,29 @@ extern "C"
 {
 #endif
 
-#ifndef Py_SET_TYPE
-static inline void _Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
-{
-    ob->ob_type = type;
-}
-#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), (type))
-#endif
-
-/**
- * Internal key for the thread-local allocator type.
- */
-static const char* JP_ALLOC_KEY = "_jpype_allocator";
-
 bool PyJPValue_hasJavaSlot(PyTypeObject* type)
 {
-       if (type == nullptr
-                       || type->tp_alloc != (allocfunc) PyJPValue_alloc
-                       || type->tp_finalize != (destructor) PyJPValue_finalize)
-               return false;  // GCOVR_EXCL_LINE
-       return true;
+	if (type == nullptr || type->tp_finalize != (destructor) PyJPValue_finalize)
+		return false;  // GCOVR_EXCL_LINE
+	// A live instance's type may legitimately be abstract (construction
+	// polymorphs back to the canonical type -- see PyJPObject_new), so
+	// resolve through its concrete companion rather than checking the raw
+	// offset directly.
+	return PyJPClass_getResolvedOffset(type) > 0;
 }
 
 Py_ssize_t PyJPValue_getJavaSlotOffset(PyObject* self)
 {
 	PyTypeObject *type = Py_TYPE(self);
-	if (type == nullptr
-			|| type->tp_alloc != (allocfunc) PyJPValue_alloc
-			|| type->tp_finalize != (destructor) PyJPValue_finalize)
-	{
+	if (type == nullptr)
 		return 0;
-	}
 
-	Py_ssize_t offset = 0;
-	Py_ssize_t sz = 0;
-	
-#if PY_VERSION_HEX>=0x030c0000
-	// starting in 3.12 there is no longer ob_size in PyLong
-	if (PyType_HasFeature(self->ob_type, Py_TPFLAGS_LONG_SUBCLASS))
-		sz = (((PyLongObject*)self)->long_value.lv_tag) >> 3;  // Private NON_SIZE_BITS
-	else 
-#endif
-	if (type->tp_itemsize != 0)
-		sz = Py_SIZE(self);
-	// PyLong abuses ob_size with negative values prior to 3.12
-	if (sz < 0)
-		sz = -sz;
-	if (type->tp_itemsize == 0)
-		offset = _PyObject_VAR_SIZE(type, 1);
-	else
-		offset = _PyObject_VAR_SIZE(type, sz + 1);
-	return offset;
+	// Families ported to the fixed-offset object model have their slot's
+	// location baked in at type-creation time on the metaclass. `type` may
+	// legitimately be abstract here (a live instance is always polymorphed
+	// back to the canonical type at construction time -- see
+	// PyJPObject_new), so resolve through its concrete companion.
+	return PyJPClass_getResolvedOffset(type);
 }
 
 /**
@@ -288,111 +260,5 @@ bool PyJPValue_isSetJavaSlot(PyObject* self)
 		return false;  // GCOVR_EXCL_LINE
 	auto* slot = (JPValue*) (((char*) self) + offset);
 	return slot->getClass() != nullptr;
-}
-
-/***************** Create a dummy type for use when allocating. ************************/
-static int PyJPAlloc_traverse(PyObject *self, visitproc visit, void *arg)
-{
-	return 0;
-}
-
-static int PyJPAlloc_clear(PyObject *self)
-{
-	return 0;
-}
-
-
-static PyType_Slot allocSlots[] = {
-	{ Py_tp_traverse, (void*) PyJPAlloc_traverse},
-	{ Py_tp_clear, (void*) PyJPAlloc_clear},
-	{0, NULL}  // Sentinel
-};
-
-static PyType_Spec allocSpec = {
-	"_jpype._JAlloc",
-	sizeof(PyObject),
-	0,
-	Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_GC,
-	allocSlots
-};
-
-/**
- * Allocate a new Python object with a slot for Java.
- *
- * We need extra space to store our values, but because there
- * is no way to do so without disturbing the object layout.
- * Fortunately, Python already handles this for dict and weakref.
- * Python aligns the ends of the structure and increases the
- * base type size to add additional slots to a standard object.
- *
- * We will use the same trick to add an additional slot for Java
- * after the end of the object outside of where Python is looking.
- * As the memory is aligned this is safe to do.  We will use
- * the alloc and finalize slot to recognize which objects have this
- * extra slot appended.
- */
-PyObject* PyJPValue_alloc(PyTypeObject* type, Py_ssize_t nitems)
-{
-    JP_PY_TRY("PyJPValue_alloc");
-
-#if PY_VERSION_HEX >= 0x030d0000
-    if (PyType_HasFeature(type, Py_TPFLAGS_INLINE_VALUES)) {
-        PyErr_Format(PyExc_RuntimeError, "Unhandled object layout");
-        return nullptr;
-    }
-#endif
-
-    // 1. Get the thread-specific dictionary
-    PyObject* thread_dict = PyThreadState_GetDict();
-    if (thread_dict == nullptr) {
-        PyErr_SetString(PyExc_RuntimeError, "Python thread state is corrupt or shutting down");
-        return nullptr;
-    }
-
-	// 2. Retrieve or create the thread-local allocator template
-	PyTypeObject* local_alloc_type = (PyTypeObject*)PyDict_GetItemString(thread_dict, JP_ALLOC_KEY);
-
-	if (local_alloc_type == nullptr) {
-		// Instead of memcpy, just create a fresh instance of a dummy type.
-		// This ensures the GC sees a perfectly clean, unique Type object.
-		PyObject *bases = PyTuple_Pack(1, &PyBaseObject_Type);
-		
-		// Use the same spec you used for the global PyJPAlloc_Type
-		local_alloc_type = (PyTypeObject*) PyType_FromSpecWithBases(&allocSpec, bases);
-		Py_DECREF(bases);
-
-		if (local_alloc_type == nullptr)
-			return nullptr;
-
-		// Store it in the thread dict so it lives as long as the thread
-		if (PyDict_SetItemString(thread_dict, JP_ALLOC_KEY, (PyObject*)local_alloc_type) < 0) {
-			Py_DECREF(local_alloc_type);
-			return nullptr;
-		}
-	}
-	else
-		// Promote the borrowed reference to hard reference for safety
-		Py_INCREF(local_alloc_type);
-
-
-    // 3. Mutate the thread-local type safely
-    local_alloc_type->tp_flags = type->tp_flags;
-    local_alloc_type->tp_basicsize = type->tp_basicsize + sizeof(JPValue);
-    local_alloc_type->tp_itemsize = type->tp_itemsize;
-
-    // 4. Perform the allocation
-    PyObject* obj = PyType_GenericAlloc(local_alloc_type, nitems);
-	Py_DECREF(local_alloc_type);
-
-    if (obj == nullptr)
-        return nullptr;
-
-    // 5. Polymorph the object to the target type
-    Py_SET_TYPE(obj, type);
-    Py_INCREF(type);
-
-    JP_TRACE("alloc", type->tp_name, obj);
-    return obj;
-    JP_PY_CATCH(nullptr);
 }
 

--- a/plan/ObjectModel.md
+++ b/plan/ObjectModel.md
@@ -1,0 +1,288 @@
+# ObjectModel: replace the JPValue thread-local allocator with a fixed per-type offset
+
+STATUS: DESIGN — not started. Blast radius confined to `native/python/` (per user:
+`native/common/`'s `JPClass` and everything Java-side stays untouched; `JPClass::m_Host`
+already caches the Python type object and is not being replaced).
+
+## Motivation
+
+Every Java-backed Python object today gets a `JPValue` (class pointer + jvalue) appended
+after its normal Python payload. The offset of that appended memory is **recomputed on
+every access** by `PyJPValue_getJavaSlotOffset()` (`native/python/pyjp_value.cpp:49-78`),
+which pokes at CPython-private fields (`PyLongObject::lv_tag`/`ob_size`) to figure out
+how big the object's variable part is. The memory itself is added at allocation time by
+`PyJPValue_alloc()` (`pyjp_value.cpp:334-397`), which fakes a `tp_basicsize` bump using a
+**thread-local dummy heap type** that gets its `tp_basicsize`/`tp_flags` mutated on every
+single object allocation, then the resulting object is re-polymorphed (`Py_SET_TYPE`) to
+the real type. This is fragile (depends on CPython internals that already changed once
+for 3.12, and again for 3.13's `Py_TPFLAGS_INLINE_VALUES`) and does real work per-allocation
+that is otherwise constant for a given type.
+
+`model/helloworld.c` is a working, standalone prototype (not integrated with the real
+JPClass/JVM machinery) proving out a different idea: **compute the offset once, when the
+type is created, and store it directly on the metaclass instance.** Every instance lookup
+then becomes a single stored-integer read instead of a runtime layout computation, and
+`tp_alloc` can go back to being whatever CPython's normal allocator is (`tp_basicsize`
+already includes our slot).
+
+The goal of this plan is to port that idea into the real `native/python/pyjp_class.cpp` /
+`pyjp_value.cpp` machinery, file by file, in order of increasing layout difficulty, and to
+scope out (not yet solve) the parts of the prototype that don't have a real-code analog yet
+(abstract-class auto-concretization, `java.lang.String` as a `PyUnicode` subclass).
+
+## Current architecture (recap, see also memory `jpype_model_replacement` — none yet, this
+doc supersedes ad hoc notes)
+
+- `JPClass::m_Host` (`native/common/include/jp_class.h:210`, get/set at `jp_class.h:34-39`)
+  — cached `PyTypeObject*` per Java class. **Stays as-is.**
+- `PyJPClass` metaclass instance struct (`pyjp_class.cpp:30-35`): `PyHeapTypeObject ht_type;
+  JPClass *m_Class; PyObject *m_Doc;`. No offset field today — **this is where the new field(s)
+  go.**
+- `PyJPClass_FromSpecWithBases(spec, bases)` (`pyjp_class.cpp:63-261`) builds a **shared base
+  type** (e.g. `PyJPObject_Type`, `PyJPNumberLong_Type`, `PyJPException_Type`, `PyJPChar_Type`,
+  `PyJPArray_Type`) via `PyType_FromMetaclass`/hand-rolled fallback pre-3.12, and always installs
+  `tp_alloc = PyJPValue_alloc`, `tp_finalize = PyJPValue_finalize`.
+- `PyJPClass_init` (`pyjp_class.cpp:263-365`) is the metaclass `tp_init`, invoked when a live
+  wrapper type for a **specific `JPClass`** is created through `PyJPClass_hook`
+  (`pyjp_class.cpp:1164-1231`, not shown above but referenced by the research pass). Re-asserts
+  the alloc/finalize pair and has "conflict" sanity checks.
+- `PyJPClass_getBases` chooses, per `JPClass` (dispatching on `dynamic_cast<JPBoxedType*>`,
+  `isArray()`, `cls == context->_java_lang_Throwable`, etc.), which shared base type(s) a given
+  Java class's Python wrapper derives from.
+- The `PyJPValue_*` slot API (`pyjp_value.cpp`) is consumed from ~14 files, ~90 call sites,
+  heaviest in `pyjp_object.cpp`, `pyjp_array.cpp`, `pyjp_char.cpp`, `pyjp_number.cpp`,
+  `pyjp_class.cpp`, and the primitive/boxed `jp_*type.cpp` value-construction sites.
+
+## Guiding constraint: the ~90 call sites are not really 90 problems
+
+The research pass counted ~90 call sites of the `PyJPValue_*` slot API across ~14 files, but
+almost all of them only call the **public** functions (`PyJPValue_getJavaSlot`,
+`_assignJavaSlot`, `_isSetJavaSlot`, `_hasJavaSlot`) with no knowledge of how the slot is
+found. None of those callers need to change at all if the public function *signatures* and
+*behavior* stay identical. The only files that need to know about the new offset mechanism
+are:
+
+- `pyjp_value.cpp` — where the offset is read/written and where the allocator hack currently
+  lives. This is where nearly all of the real work happens.
+- `pyjp_class.cpp` — the metaclass, which needs the new `offset` field on `struct PyJPClass`
+  and must compute it once at type-creation time instead of leaving it to be derived later.
+- `pyjp_number.cpp` — not a call-site tweak but a planned **full rewrite**. Its `tp_new`
+  (`PyJPNumber_new`) and the boxed long/float allocation path are inherently tied to how the
+  slot is placed relative to `PyLongObject`'s variable-length digits (Phase 3 below), so this
+  file changes wholesale alongside `pyjp_value.cpp`, not as a downstream call-site fixup.
+  Expect `pyjp_char.cpp` (Phase 4) and possibly `pyjp_object.cpp`'s exception/array `tp_new`
+  functions (Phases 5-6) to end up in the same "rewritten, not patched" category once their
+  phases are reached — only the *plain-call-site* files (jp_*type.cpp, jp_method.cpp,
+  jp_classhints.cpp, pyjp_field.cpp, pyjp_monitor.cpp, pyjp_module.cpp, pyjp_buffer.cpp,
+  jp_class.cpp, jp_exception.cpp) are expected to need zero changes.
+
+So the real fight is **not** 14 files of call-site churn — it's getting `model/helloworld.c`'s
+approach to produce the *same object layouts* the current code already produces (same
+`tp_basicsize` per family, same base-class chains) so that `pyjp_value.cpp` can be swapped out
+underneath everything else unchanged. First-step strategy: treat `model/helloworld.c` as a
+sandbox to prove out layout compatibility (does `PyLongObject` boxing still fit, does the
+exception diamond still work, etc.) in isolation, file it down until it's a drop-in swap for
+`pyjp_value.cpp`'s two changed entry points (`PyJPValue_alloc` disappears; `getJavaSlotOffset`
+becomes a stored-field read), and only then touch `pyjp_class.cpp` to add the field it reads
+from. Everything else in the ~14-file call-site list should require zero changes.
+
+## Target design
+
+1. **Metaclass gains an `offset` field** (`Py_ssize_t offset` on `PyJPClass`, mirroring
+   `model/helloworld.c:70`), plus, only where abstract/interface auto-concretization is in
+   scope (see Phase 5), an `other` pointer for the paired concrete/abstract stand-in
+   (`helloworld.c:71`).
+2. **Offset is computed once**, at the point a concrete Python layout is finalized for a
+   base family (`PyJPObject_Type`, `PyJPNumberLong_Type`, `PyJPNumberFloat_Type`,
+   `PyJPChar_Type`, `PyJPException_Type`, `PyJPArray_Type`/`PyJPArrayPrimitive_Type`) — i.e.
+   inside `PyJPClass_FromSpecWithBases`/`PyJPClass_init`, analogous to `jclass_init`
+   (`helloworld.c:469-548`) — and inherited unchanged by every subsequent per-Java-class type
+   built on that base (individual `Integer`/`Long`/user exception subtypes etc. all reuse the
+   *same* offset as their shared base, since they don't add further Python-visible fields).
+3. **`PyJPValue_getJavaSlot`/`_assignJavaSlot`/`_isSetJavaSlot`** stop calling
+   `PyJPValue_getJavaSlotOffset()` and instead read `((PyJPClass*) Py_TYPE(self))->offset`
+   (walking to the metaclass of `Py_TYPE(self)`, i.e. `Py_TYPE(Py_TYPE(self))`, exactly as
+   `model/helloworld.c:212-225` does for `getValue`/`setValue`).
+4. **`PyJPValue_alloc` becomes unnecessary as a special allocator** for offset purposes: once
+   `tp_basicsize` correctly includes the slot for every type at creation time, plain
+   `PyType_GenericAlloc` (or the type's inherited `tp_alloc`) is sufficient. The thread-local
+   dummy-type trick in `pyjp_value.cpp:334-397` is deleted entirely. (`tp_finalize`/`tp_free`
+   stay — they're about JNI global-ref cleanup, unrelated to slot placement.)
+5. Each Python-visible layout family is migrated **in order of difficulty**, verified
+   independently before moving to the next (see Phases below), because each has a different
+   answer to "where does `tp_basicsize` need to grow and by how much."
+
+## Phases (increasing difficulty; each phase should compile + pass the existing test suite
+before starting the next)
+
+### Phase 1 — Metaclass plumbing (no behavior change yet)
+- Add `offset` (and, if needed early, `other`) to `struct PyJPClass` in `pyjp_class.cpp`.
+- Add `PyJPClass_traverse`/`_clear` handling for `other` once it exists (Phase 5).
+- Add a new `PyJPValue_getJavaSlotOffsetFixed(PyObject* self)` (name TBD) that just reads
+  the stored `offset` field, alongside (not yet replacing) the existing runtime-computed
+  `PyJPValue_getJavaSlotOffset`, so both can be diffed/asserted equal in debug builds during
+  migration.
+
+### Phase 2 — Plain object family (`PyJPObject_Type`, easiest: fixed non-variable layout)
+- `PyJPObject_Type` (`pyjp_object.cpp`) has no variable-length base and no CPython-internal
+  struct poking — this is the `java.lang.Object`/generic-object case, directly analogous to
+  `PyJPObject_Type`/`jobject_new` in the prototype (`helloworld.c:634-665`).
+- Compute the offset once in `PyJPClass_FromSpecWithBases`/`PyJPClass_init` by
+  `align_up(tp_basicsize, sizeof(void*))`, bump `tp_basicsize` by `sizeof(JPValue)`, store the
+  offset on the metaclass instance.
+- Switch `PyJPValue_getJavaSlot`/`_assignJavaSlot`/`_isSetJavaSlot` to the fixed-offset path
+  **only for types whose base chain bottoms out at `PyJPObject_Type`** (i.e. leave boxed/char/
+  exception/array on the legacy runtime path until their own phases land) — gate this with a
+  per-type flag or by having `PyJPValue_getJavaSlot` prefer the stored offset when non-zero and
+  fall back to the runtime computation otherwise, so migration can proceed file-by-file without
+  a single flag-day rewrite.
+- Delete the special-case thread-local allocator path for this family; confirm `tp_alloc`
+  reverts to ordinary `PyType_GenericAlloc`-derived allocation.
+- Run full test suite; specifically stress subclassing depth (Python subclasses of Java
+  object wrappers already exist and must keep working — this is the `U(_JObject)`/`V(_JObject)`
+  case from `model/test.py`).
+- **Concrete implementation plan derived 2026-07-12, not yet executed** — see the
+  `jpype_phase2_real_port_plan` memory entry for the exact call-site inventory (9 total
+  `PyJPClass_FromSpecWithBases` calls, only `PyJPObject_Type`/`PyJPException_Type`/
+  `PyJPComparable_Type` in scope this pass), struct/signature changes, and — most
+  important — the critical guard fix: `PyJPValue_getJavaSlotOffset`/`_hasJavaSlot`'s entry
+  guard currently checks `tp_alloc == PyJPValue_alloc`, which will start returning false
+  negatives the moment migrated families stop forcing that allocator, silently breaking
+  ~40+ call sites. That check must be dropped (keep only the `tp_finalize` check) in the
+  SAME commit as removing the `Py_tp_alloc` override — never split across commits.
+  Acceptance gate: real project build (see `jpype_build_env_gotchas` memory for this
+  machine's environment fixes) + full test suite back at the 451/451 baseline.
+
+### Phase 3 — Boxed numeric types (`PyJPNumberLong_Type`/`PyJPNumberFloat_Type`,
+`Integer`/`Long`/`Byte`/`Short`/`Boolean` on `PyLong_Type`; `Float`/`Double` on `PyFloat_Type`)
+- **Hardest case, RESOLVED 2026-07-12 in `model/pyjp_number.cpp`.** `PyFloat_Type` base is
+  fixed-size, so it degrades to the Phase 2 pattern (`offsetof`-style fixed offset) — trivial.
+- `PyLong_Type` base is variable-length, and the real wart turned out to be CPython's own:
+  `long_subtype_new` (`Objects/longobject.c`) is, verbatim in CPython's own comment, a
+  "wimpy, slow approach ... first create a regular int from whatever arguments we got, then
+  allocate a subtype instance and initialize it from the regular int. The regular int is then
+  thrown away." That build-then-copy is unavoidable if construction routes through
+  `PyLong_Type.tp_new` at all (it's gated on `type != &PyLong_Type` inside `long_subtype_new`
+  itself) — our old prototype code reproduced exactly this shape. Fix: never call into it.
+  `PyJPNumberLong_new` now parses the argument via the stable public
+  `PyLong_AsLongLongAndOverflow` and hand-writes digits directly into a fixed-size buffer — one
+  allocation, no copy, no throwaway object.
+- Digit/sign layout confirmed against the actual CPython source (`~/jcef/cpython`, tags
+  v3.10.0-v3.14.0, checked out and diffed directly): `<=3.11` uses `ob_size`'s sign
+  (identical between 3.10/3.11); `>=3.12` uses `lv_tag` (low 2 bits = sign
+  0/1/2=positive/zero/negative, bit 2 = immortal flag, `>>3` = digit count) and is
+  byte-for-byte identical across 3.12/3.13/3.14 (only doc comments and unrelated new APIs
+  like 3.14's `PyLongWriter` differ). `PyLong_SHIFT`/`PyLong_MASK`/`digit`/
+  `PYLONG_BITS_IN_DIGIT` are all public headers, so digit width (30 or 15 bits) is a
+  compile-time constant. Fixed budget `JLONG_MAX_DIGITS` = 3 (30-bit digits) or 5 (15-bit
+  digits) covers the full 64-bit signed range Java's boxed `Long` needs — no arbitrary-
+  precision case exists for real Java values, so the overflow path (one past
+  `Long.MAX_VALUE`) is a real, reachable, correctly-rejected error, not dead code.
+- Validated: full boundary sweep (0, ±1, int16/int32/int64 boundaries, overflow rejection)
+  passes under Python 3.12 through the real `model/` extension; the `<=3.11` `ob_size` branch
+  was validated in an isolated standalone extension (outside the `PyJPClass` metaclass, since
+  `model/pyjp_class.cpp` only implements the 3.12+ `PyType_FromMetaclass` path) under Python
+  3.10 — same sweep, all passing.
+- **Correction, 2026-07-12, after decomposing the benchmark:** skipping the wimpy path is
+  NOT where the speedup comes from. Isolated apples-to-apples test (a plain `int` subclass
+  using stock `long_subtype_new` vs. an identical subclass using our direct digit-write, both
+  going through the same single `type->tp_alloc(type, n)` call, no jpype machinery at all)
+  measured statistically identical throughput (~15.8M vs ~16.1M ops/s, ~2% apart — noise).
+  Why: CPython's `long_new_impl` fast-paths an already-exact-`int` argument by returning it
+  via `Py_INCREF` with no new allocation — which is exactly JPype's realistic input shape
+  (boxing an already-Python-int value). So `long_subtype_new`'s "throwaway" step costs a free
+  incref + a cheap 1-2 digit copy riding on top of the one allocation both approaches need
+  anyway, not a second allocation. The ~1.7-1.9x `int_new`/`float_new`/`object_new` speedups
+  measured between `model/` and `model2/` come almost entirely from **the allocator
+  mechanism** (fixed offset vs. the thread-local dummy-heap-type mutation), not from
+  bypassing `PyLong_Type.tp_new`. Bypassing it is still correct and worth keeping (removes a
+  dependency on CPython's general-purpose parsing machinery and guarantees the fixed offset
+  outright rather than incidentally), but it should not be sold as the source of the speedup.
+- jpype's Python floor is moving to 3.10 (dropping 3.8/3.9); this phase's version gate already
+  matches with no changes needed, since 3.8/3.9 share the same pre-3.12 `ob_size` layout as
+  3.10/3.11.
+- **Not yet ported to the real `native/python/`** — proven out in `model/` only so far.
+  `model/pyjp_class.cpp`'s metaclass still needs the pre-3.12 hand-rolled
+  `PyType_FromSpecWithBases`-style fallback (present in the real `pyjp_class.cpp` today, see
+  its pre-3.12 branch at `pyjp_class.cpp:72-251`) ported over before the sandbox itself can
+  build/test end-to-end on 3.10/3.11; right now that branch is validated in isolation only.
+
+### Phase 4 — `java.lang.Character` (`PyJPChar_Type`, `pyjp_char.cpp`)
+- Already bespoke (manual `PyCompactUnicodeObject` field patching, direct `PyJPValue_alloc`
+  call instead of going through `tp_new`) — this phase is mostly "recompute the fixed offset
+  analytically instead of via `PyJPValue_getJavaSlotOffset`'s generic `_PyObject_VAR_SIZE`
+  path," since `PyJPChar`'s layout (`m_Obj` + `m_Data[4]`) is already fully known at compile
+  time (`pyjp_char.cpp:28-32`). Should be low-risk once Phase 2's plumbing exists.
+
+### Phase 5 — Exceptions (`PyJPException_Type`, `pyjp_object.cpp`)
+- Real diamond: `PyExc_Exception` + `PyJPObject_Type`. Offset must sit after
+  `PyBaseExceptionObject`'s tail, which is itself fixed-size, so this is mechanically like
+  Phase 2 but based on a different concrete ancestor. Confirm user-defined Java exception
+  subclasses (arbitrary further Python subclassing of a generated exception wrapper) don't
+  need a *second* offset — they shouldn't, since Python subclasses of a fixed-layout type don't
+  usually grow `tp_basicsize` unless they add slots, which Java-generated wrapper types don't.
+
+### Phase 6 — Arrays (`PyJPArray_Type`/`PyJPArrayPrimitive_Type`, `pyjp_array.cpp`)
+- Already carries compiled-in `m_Array`/`m_View` fields ahead of the generic slot — this
+  should be closer to Phase 2 (fixed struct, offset = `align_up(sizeof(PyJPArray), ...)`)
+  once the buffer-protocol subclass (`PyJPArrayPrimitive_Type`) is confirmed not to add
+  further per-instance fields beyond what the buffer protocol needs from the base.
+
+### Phase 7 (open, needs a follow-up design pass, not scoped in detail here) — Abstract
+classes / interfaces auto-concretization
+- The prototype's `jclass_concrete`/`other`-pointer pattern (`helloworld.c:366-379`,
+  `jclass_init` lines 522-541) has **no real-code analog today** — currently abstract
+  Java classes/interfaces are simply not instantiable as generic wrappers (Python-side
+  proxies for interfaces are a wholly separate mechanism, `jpype/_jproxy.py`, going through
+  `JPProxyType`/`pyjp_proxy.cpp`, untouched by this plan). Whether this plan *needs* to add
+  auto-concretization at all is an open question for the user — the model prototype does it
+  because it's exploring general Python-subclassing of interfaces, but the real codebase may
+  not need that capability for this migration to be complete. **Do not implement Phase 7
+  until Phases 1-6 are done and the user confirms it's actually in scope.**
+- `java.lang.String`-as-`PyUnicode`-subclass is similarly new territory (no existing
+  `pyjp_string.cpp`) and explicitly **out of scope** unless the user asks for it — today
+  String wrapping either copies to a native `str` (`convert_strings`) or falls back to the
+  generic `PyJPObject_Type` layout, and this plan doesn't need to change that to remove the
+  fragile allocator.
+
+## Call-site migration checklist (per phase, update only the files relevant to that phase)
+
+- `pyjp_value.cpp` — replace offset computation, delete thread-local alloc hack once no
+  phase still depends on it.
+- `pyjp_class.cpp` — add offset field + computation in `PyJPClass_FromSpecWithBases`/`_init`.
+- `pyjp_object.cpp`, `pyjp_number.cpp`, `pyjp_char.cpp`, `pyjp_array.cpp` — per-phase `tp_new`
+  updates.
+- `jp_exception.cpp`, `jp_classhints.cpp`, `jp_method.cpp`, `pyjp_monitor.cpp`,
+  `pyjp_module.cpp`, `pyjp_field.cpp`, `jp_longtype.cpp`, `jp_floattype.cpp`, `jp_inttype.cpp`,
+  `jp_chartype.cpp`, `jp_shorttype.cpp`, `jp_bytetype.cpp`, `jp_doubletype.cpp`,
+  `jp_boxedtype.cpp`, `jp_class.cpp`, `pyjp_buffer.cpp` — all call the public
+  `PyJPValue_getJavaSlot`/`_assignJavaSlot`/`_isSetJavaSlot`/`_hasJavaSlot` API only; **no
+  changes needed** in these files as long as the public function signatures stay stable —
+  the offset-vs-runtime-computation swap is fully encapsulated in `pyjp_value.cpp`.
+
+## Testing strategy
+
+- Existing full test suite (`test/` — see `jpype_reverse_bridge_testing` memory, 451/451
+  baseline) must stay green after every phase.
+- Add a targeted micro-test per phase asserting `PyJPValue_getJavaSlot`/`_assignJavaSlot`
+  round-trip correctly, and that `sys.getsizeof`/`__basicsize__` matches the expected fixed
+  layout (catches silent double-counting of the slot).
+- Phase 3 (boxed long) needs an explicit boundary test at the digit-budget edge (largest
+  representable `long`/smallest that would overflow the fixed budget, if such a path is
+  reachable at all per the open question above).
+- Run under both a debug CPython build and at least 3.11/3.12/3.13 if available, since the
+  whole point of this migration is removing dependence on version-specific private-field
+  layouts — worth confirming the new fixed-offset path is actually version-independent where
+  claimed.
+
+## Open questions for the user
+
+1. Is Phase 7 (abstract-class auto-concretization, String-as-PyUnicode-subclass) actually in
+   scope for this effort, or is the goal solely to remove the fragile allocator for the
+   *existing* set of wrapped layouts?
+2. ~~For Phase 3, can boxed `Long`/`Integer`/etc. ever be constructed from a Python `int`
+   wider than 64 bits?~~ RESOLVED: no — Java's boxed types top out at 64-bit `Long`, so the
+   overflow path is real and load-bearing, not dead code.
+3. Do we want per-phase feature-branch commits (mirroring the `array-region-copy`/`spi`-style
+   branch history seen elsewhere in this repo), or one running branch (`model`) with all
+   phases landing as sequential commits?


### PR DESCRIPTION
This is a WIP prototype that resolves problem of the Python unstable allocator by tricking Python into accepting a Java slot in every class.  It works by splitting the model into abstract classes that are object sized and concrete classes that contain a slot.  The only horrible hacks have  to do with variable sized objects which are fortunately resolvable using a slot trick.

Still a lot of clean up before it can be considered