### PR TITLE
Gc exception race2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ cmake_install.cmake
 _jpype.so
 org.jpype.jar
 .build_history
+CLAUDE.md
+plan/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,18 +220,7 @@ elseif(APPLE)
             VERBATIM
     )
 elseif(LINUX OR UNIX) # make sure APPLE is handled before this.
-    # Linux and OSX settings.
-#    find_library(LIBSTDCXX_SHARED NAMES stdc++ DOC "LibStdC++ runtime library required." REQUIRED)
-#
-#    target_link_libraries(_jpype PRIVATE
-#            dl # dynamic linker
-#            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
-#    )
-    #target_compile_options(_jpype PRIVATE "-shared-libgcc")
-    #target_link_options(_jpype PRIVATE "-shared-libgcc" "-shared-libstdc++")
-    target_link_libraries(_jpype PRIVATE
-            dl
-            )
+    target_link_libraries(_jpype PRIVATE dl)
     target_link_options(_jpype PRIVATE "-Wl,-l:libstdc++.so.6")
 
     # Keep frame pointers for better stack unwinding.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,15 +202,24 @@ if(WIN32)
     # Ensure /MD and exception model are set
     target_compile_options(_jpype PRIVATE /EHsc /MD)
 else()
-    # Additional libraries for non-Windows
+    # Linux and OSX settings.
+    find_library(LIBSTDCXX_SHARED NAMES stdc++)
+
     target_link_libraries(_jpype PRIVATE
             dl # dynamic linker
+            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
     )
     # Keep frame pointers for better stack unwinding.
     add_compile_options(-fno-omit-frame-pointer)
 
     # even on OSX Python uses .so suffix instead of .dylib
     set_target_properties(_jpype PROPERTIES SUFFIX ".so")
+
+    # safe-guard to prevent static linkage of libstdc++
+    add_custom_command(TARGET _jpype POST_BUILD
+            COMMAND sh -c "readelf -d $<TARGET_FILE:_jpype> | grep -q libstdc++.so.6 || (echo 'FATAL: _jpype.so not dynamically linked against libstdc++!' >&2 && exit 1)"
+            VERBATIM
+    )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
+
+if(CMAKE_VERSION VERSION_LESS 3.25 AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(LINUX true)
+endif()
+
 project(jpype-native)
 
 option(ENABLE_TRACING "Enable tracing in the extension" OFF)
@@ -201,14 +206,34 @@ if(WIN32)
 
     # Ensure /MD and exception model are set
     target_compile_options(_jpype PRIVATE /EHsc /MD)
-else()
-    # Linux and OSX settings.
-    find_library(LIBSTDCXX_SHARED NAMES stdc++)
+elseif(APPLE)
+    # 1. Force the compiler to target the native Apple libc++
+    target_compile_options(_jpype PRIVATE "-stdlib=libc++")
+    target_link_options(_jpype PRIVATE "-stdlib=libc++")
 
-    target_link_libraries(_jpype PRIVATE
-            dl # dynamic linker
-            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
+    # 2. Tell the linker to prioritize dynamic lookup (.dylib) over static (.a)
+    target_link_options(_jpype PRIVATE "-Wl,-search_paths_first")
+    # Keep frame pointers for better stack unwinding.
+    add_compile_options(-fno-omit-frame-pointer)
+    add_custom_command(TARGET _jpype POST_BUILD
+            COMMAND sh -c "otool -L $<TARGET_FILE:_jpype> | grep -q libc++.1.dylib || (echo 'FATAL: _jpype.so not dynamically linked against libc++!' >&2 && exit 1)"
+            VERBATIM
     )
+elseif(LINUX OR UNIX) # make sure APPLE is handled before this.
+    # Linux and OSX settings.
+#    find_library(LIBSTDCXX_SHARED NAMES stdc++ DOC "LibStdC++ runtime library required." REQUIRED)
+#
+#    target_link_libraries(_jpype PRIVATE
+#            dl # dynamic linker
+#            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
+#    )
+    #target_compile_options(_jpype PRIVATE "-shared-libgcc")
+    #target_link_options(_jpype PRIVATE "-shared-libgcc" "-shared-libstdc++")
+    target_link_libraries(_jpype PRIVATE
+            dl
+            )
+    target_link_options(_jpype PRIVATE "-Wl,-l:libstdc++.so.6")
+
     # Keep frame pointers for better stack unwinding.
     add_compile_options(-fno-omit-frame-pointer)
 
@@ -220,6 +245,8 @@ else()
             COMMAND sh -c "readelf -d $<TARGET_FILE:_jpype> | grep -q libstdc++.so.6 || (echo 'FATAL: _jpype.so not dynamically linked against libstdc++!' >&2 && exit 1)"
             VERBATIM
     )
+else()
+    message(WARNING "unhandled OS found!")
 endif()
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,24 @@ coverage:
         threshold: 2%
         paths:
         - "native/java/"
+    patch:
+      default: false
+      python:
+        target: 85%
+        threshold: 1%
+        paths:
+          - "jpype/"
+      cpp:
+        target: 70%
+        threshold: 5%
+        paths:
+          - "native/common/"
+          - "native/python/"
+      java:
+        target: 75%
+        threshold: 2%
+        paths:
+          - "native/java/"
 
 parsers:
   gcov:

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -7,6 +7,10 @@ Latest Changes:
 
 - **1.7.2.dev0**
 
+  - Fixed a rare crash where Python's cyclic garbage collector firing
+    while a Python exception was mid-unwind through the reverse-bridge
+    C++ layer could corrupt the in-flight exception. #1415
+
   - Fixed memory leak with int and float conversions. #1379
 
   - Fixed instablity in threading for method dispatch. #1366

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -27,8 +27,9 @@
  * when returning to the native code.
  *
  * If we are returning to python, and it is a
- * - _python_error, then we assume that a python exception has already been
- *   placed in the python virtual machine.
+ * - _python_error, then the exception was fetched off the thread state and
+ *   normalized at the moment of the throw (not left live on the thread state
+ *   for the duration of the C++ unwind), and toPython()/toJava() restore it.
  * - _java_error, then we will convert it to a python object with the correct
  *   object type.
  * - otherwise, then we will convert it to the requested python error.
@@ -146,6 +147,15 @@ public:
 	/** Transfer handling of this exception to java. */
 	void toJava();
 
+	/** Put a captured _python_error exception back on the thread state.
+	 *
+	 * For callers that need the original Python exception live (e.g. to
+	 * chain it as a cause) before they finish handling this JPypeException
+	 * themselves, rather than going through toPython()/toJava(). No-op for
+	 * any other exception type, or if there is nothing captured.
+	 */
+	void restorePythonError();
+
 	int getExceptionType() const
 	{
 		return m_Type;
@@ -162,6 +172,18 @@ private:
 	JPStackTrace m_Trace;
 	JPThrowableRef m_Throwable;
 	std::string m_Message;
+
+	// For _python_error only: the exception is fetched and normalized at the
+	// moment of the throw (see JP_RAISE_PYTHON), not left live on the thread
+	// state for the length of the C++ unwind. A pending exception left on the
+	// thread state is visible to, and can be disturbed by, an incidental GC
+	// pass triggered anywhere during that unwind - fetching claims sole
+	// ownership so nothing else can touch it before toPython()/toJava()
+	// restore it. Only the (already-normalized) instance is held - its class
+	// and traceback are recoverable from the instance itself at restore time
+	// (see JPPyErr::restore(JPPyObject&)), so there's no need to separately
+	// hold references to them too.
+	JPPyObject m_PyExcValue;
 };
 
 #endif

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -40,6 +40,19 @@ JPypeException::JPypeException(int type, void* error, const JPStackInfo& stackIn
 {
 	JP_TRACE("EXCEPTION THROWN with error", error);
 	m_Error.l = error;
+	if (type == JPError::_python_error)
+	{
+		// Fetch and normalize the pending Python exception right now, at the
+		// moment of the throw, rather than leaving it live on the thread
+		// state for the whole C++ unwind (see m_PyExcValue in jp_exception.h
+		// for why). JPPyErrFrame::fetch() already removes it from the thread
+		// state; clear() below just stops its destructor from putting it
+		// straight back before we are ready for that in toPython()/toJava().
+		JPPyErrFrame eframe;
+		eframe.normalize();
+		m_PyExcValue = eframe.m_ExceptionValue;
+		eframe.clear();
+	}
 	from(stackInfo);
 }
 
@@ -65,7 +78,7 @@ JPypeException::JPypeException(int type,  const string& msn, int errType, const 
 
 JPypeException::JPypeException(const JPypeException &ex) noexcept
         : runtime_error(ex.what()), m_Type(ex.m_Type),  m_Error(ex.m_Error),
-        m_Trace(ex.m_Trace), m_Throwable(ex.m_Throwable)
+        m_Trace(ex.m_Trace), m_Throwable(ex.m_Throwable), m_PyExcValue(ex.m_PyExcValue)
 {
 }
 
@@ -79,6 +92,7 @@ JPypeException& JPypeException::operator = (const JPypeException& ex)
 	m_Trace = ex.m_Trace;
 	m_Throwable = ex.m_Throwable;
 	m_Error = ex.m_Error;
+	m_PyExcValue = ex.m_PyExcValue;
 	return *this;
 }
 // GCOVR_EXCL_STOP
@@ -87,6 +101,12 @@ void JPypeException::from(const JPStackInfo& info)
 {
 	JP_TRACE("EXCEPTION FROM: ", info.getFile(), info.getLine());
 	m_Trace.push_back(info);
+}
+
+void JPypeException::restorePythonError()
+{
+	if (m_Type == JPError::_python_error && m_PyExcValue.get() != nullptr)
+		JPPyErr::restore(m_PyExcValue);
 }
 
 bool isJavaThrowable(PyObject* exceptionClass)
@@ -244,6 +264,42 @@ void JPypeException::convertPythonToJava()
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
+/**
+ * Print a user-facing crash banner for the deliberate fail-fast crashes
+ * below (JPypeException::toPython/toJava's catch blocks).
+ *
+ * These crashes fire only when JPype's own exception-conversion code -
+ * which is not allowed to fail - fails anyway, leaving interpreter/JNI
+ * error state too corrupted to unwind safely. Terminating immediately is
+ * safer than continuing to run on corrupted state, but from a user's
+ * perspective this looks exactly like a spontaneous segfault, so we say
+ * plainly what happened and how to report it, before the process dies.
+ */
+static void reportFatalFailFast(const char* detail)
+{
+	fprintf(stderr,
+			"================================================================================\n"
+			"JPype has hit an internal error it cannot safely recover from and must stop the\n"
+			"JVM immediately.\n"
+			"\n"
+			"This is not something you did wrong in your own code - it means JPype's own\n"
+			"exception-handling machinery hit a case it doesn't know how to handle. Please\n"
+			"help fix it by reporting this at:\n"
+			"\n"
+			"    https://github.com/jpype-project/jpype/issues\n"
+			"\n"
+			"along with the smallest script you can find that reproduces it, and the detail\n"
+			"below:\n"
+			"\n"
+			"    %s\n"
+			"\n"
+			"JPype is intentionally crashing now rather than continuing to run with\n"
+			"corrupted internal state.\n"
+			"================================================================================\n",
+			detail);
+	fflush(stderr);
+}
+
 void JPypeException::toPython()
 {
 	const char* mesg = nullptr;
@@ -272,7 +328,11 @@ void JPypeException::toPython()
 			return;
 		} else if (m_Type == JPError::_python_error)
 		{
-			// Already on the stack
+			// Restore the exception fetched and normalized at the moment of
+			// the throw (see JPypeException's _python_error ctor). It was
+			// deliberately held off the thread state for the whole unwind so
+			// no incidental GC pass during that window could disturb it.
+			JPPyErr::restore(m_PyExcValue);
 		}// This section is only reachable during startup of the JVM.
 			// GCOVR_EXCL_START
 		else if (m_Type == JPError::_os_error_unix)
@@ -330,7 +390,12 @@ void JPypeException::toPython()
 			JPPyObject args = JPPyObject::call(Py_BuildValue("(s)", "C++ Exception"));
 			JPPyObject trace = JPPyObject::call(PyTrace_FromJPStackTrace(m_Trace));
 			JPPyObject cause = JPPyObject::accept(PyObject_Call(PyExc_Exception, args.get(), nullptr));
-			if (!cause.isNull())
+			// eframe.m_ExceptionValue can be null here - e.g. if the Python
+			// error state was already cleared by the time this runs (see
+			// JPPyErrFrame::normalize()'s own null-guard for the same class
+			// of issue) - PyException_SetCause requires a real exception
+			// instance as self and segfaults on null.
+			if (!cause.isNull() && eframe.m_ExceptionValue.get() != nullptr)
 			{
 				PyException_SetTraceback(cause.get(), trace.get());
 				PyException_SetCause(eframe.m_ExceptionValue.get(), cause.keep());
@@ -345,8 +410,13 @@ void JPypeException::toPython()
 		JPTracer::trace("Type:", m_Error.l);
 		if (ex.m_Type == JPError::_python_error)
 		{
-			JPPyErrFrame eframe;
-			JPTracer::trace("Inner Python:", ((PyTypeObject*) eframe.m_ExceptionClass.get())->tp_name);
+			// The inner exception was captured off the thread state at its
+			// own throw time (see JPypeException's _python_error ctor), not
+			// left sitting on the stack - trace from, then restore, the
+			// captured state directly rather than fetching.
+			JPTracer::trace("Inner Python:", ex.m_PyExcValue.get() != nullptr
+					? Py_TYPE(ex.m_PyExcValue.get())->tp_name : "(none!)");
+			JPPyErr::restore(ex.m_PyExcValue);
 			return;  // Let these go to Python, so we can see the error
 		} else if (ex.m_Type == JPError::_java_error)
 			JPTracer::trace("Inner Java:", ex.what());
@@ -365,6 +435,8 @@ void JPypeException::toPython()
 		JPTracer::trace("Fatal error in exception handling");
 
 		// You shall not pass!
+		reportFatalFailFast("An unexpected error occurred while converting a Java exception "
+				"back to Python (JPypeException::toPython).");
 		int *i = nullptr;
 		*i = 0;
 	}
@@ -397,6 +469,10 @@ void JPypeException::toJava()
 		{
 			JPPyCallAcquire callback;
 			JP_TRACE("Python exception");
+			// Restore what was fetched off the thread state at throw time
+			// (see JPypeException's _python_error ctor) - convertPythonToJava()
+			// expects to find the exception live on the thread state.
+			JPPyErr::restore(m_PyExcValue);
 			convertPythonToJava();
 			return;
 		}
@@ -423,6 +499,14 @@ void JPypeException::toJava()
 		JPTracer::trace(info.getFile(), info.getFunction(), info.getLine());
 
 		// Take one for the team.
+		{
+			std::stringstream detail;
+			detail << "A second error (\"" << ex.what() << "\") occurred while JPype was "
+					"converting a Python exception into its Java equivalent, at "
+					<< info.getFile() << ":" << info.getFunction() << ":" << info.getLine()
+					<< " (JPypeException::toJava).";
+			reportFatalFailFast(detail.str().c_str());
+		}
 		int *i = nullptr;
 		*i = 0;
 		// GCOVR_EXCL_STOP
@@ -433,6 +517,8 @@ void JPypeException::toJava()
 		JPTracer::trace("Fatal error in exception handling");
 
 		// It is pointless, I can't go on.
+		reportFatalFailFast("An unexpected, non-Python error occurred while JPype was "
+				"converting a Python exception into its Java equivalent (JPypeException::toJava).");
 		int *i = nullptr;
 		*i = 0;
 		// GCOVR_EXCL_STOP

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -493,7 +493,7 @@ PyObject* PyTrace_FromJPStackTrace(JPStackTrace& trace)
 	}
 	if (last_traceback == nullptr)
 		Py_RETURN_NONE;
-	return (PyObject*) last_traceback;
+	return last_traceback;
 }
 
 JPPyObject PyTrace_FromJavaException(JPJavaFrame& frame, jthrowable th, jthrowable prev)

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -211,9 +211,9 @@ void JPypeException::convertPythonToJava()
 	JPContext *context = frame.getContext();
 	jthrowable th;
 	JPPyErrFrame eframe;
-	if (eframe.good && isJavaThrowable(eframe.m_ExceptionClass.get()))
+	if (eframe.m_good && isJavaThrowable(eframe.m_ExceptionClass.get()))
 	{
-		eframe.good = false;
+		eframe.m_good = false;
 		JPValue* javaExc = PyJPValue_getJavaSlot(eframe.m_ExceptionValue.get());
 		if (javaExc != nullptr)
 		{

--- a/native/python/include/jp_pythontypes.h
+++ b/native/python/include/jp_pythontypes.h
@@ -116,9 +116,7 @@ public:
 	 */
 	static JPPyObject call(PyObject* obj);
 
-	JPPyObject() : m_PyObject(nullptr)
-	{
-	}
+	JPPyObject() = default;
 
 	JPPyObject(const JPPyObject &self);
 
@@ -320,7 +318,7 @@ public:
 	JPPyObject m_ExceptionClass;
 	JPPyObject m_ExceptionValue;
 	JPPyObject m_ExceptionTrace;
-	bool good;
+	bool m_good{false};
 
 	JPPyErrFrame();
 	~JPPyErrFrame();

--- a/native/python/include/jp_pythontypes.h
+++ b/native/python/include/jp_pythontypes.h
@@ -309,6 +309,15 @@ namespace JPPyErr
 {
 bool fetch(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JPPyObject& exceptionTrace);
 void restore(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JPPyObject& exceptionTrace);
+
+/** Restore a single already-normalized exception instance.
+ *
+ * Once normalized, the instance's class and traceback are recoverable
+ * from the instance itself (Py_TYPE() and PyException_GetTraceback()),
+ * so a normalized exception only needs one owned reference held for it,
+ * not three.
+ */
+void restore(JPPyObject& exceptionValue);
 }
 
 /** Memory management for handling a python exception currently in progress. */

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -488,9 +488,9 @@ void JPPyErrFrame::normalize()
 	auto excValue = m_ExceptionValue.get();
 	if (excValue && !PyExceptionInstance_Check(excValue))
 	{
-		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
+		JPPyObject args = JPPyTuple_Pack(excValue);
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());
+		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -485,12 +485,11 @@ void JPPyErrFrame::normalize()
 {
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
-	auto excValue = m_ExceptionValue.get();
-	if (excValue && !PyExceptionInstance_Check(excValue))
+	if (m_ExceptionValue.get() && !PyExceptionInstance_Check(m_ExceptionValue.get()))
 	{
-		JPPyObject args = JPPyTuple_Pack(excValue);
+		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());   // fixed
+		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -390,6 +390,17 @@ void JPPyErr::restore(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JP
 	PyErr_Restore(exceptionClass.keepNull(), exceptionValue.keepNull(), exceptionTrace.keepNull());
 }
 
+void JPPyErr::restore(JPPyObject& exceptionValue)
+{
+	// Only valid for an already-normalized instance: its class and
+	// traceback are then recoverable from the instance itself, so there
+	// is no need to have held separate references to them.
+	PyObject *value = exceptionValue.keepNull();
+	PyObject *type = (PyObject*) Py_TYPE(value);
+	Py_INCREF(type);
+	PyErr_Restore(type, value, PyException_GetTraceback(value));
+}
+
 JPPyCallAcquire::JPPyCallAcquire()
 {
 	m_State = (long) PyGILState_Ensure();

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -485,7 +485,8 @@ void JPPyErrFrame::normalize()
 {
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
-	if (!PyExceptionInstance_Check(m_ExceptionValue.get()))
+	auto excValue = m_ExceptionValue.get();
+	if (excValue && !PyExceptionInstance_Check(excValue))
 	{
 		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -490,7 +490,7 @@ void JPPyErrFrame::normalize()
 	{
 		JPPyObject args = JPPyTuple_Pack(excValue);
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
+		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());   // fixed
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -486,20 +486,12 @@ void JPPyErrFrame::normalize()
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
 	auto excValue = m_ExceptionValue.get();
-	//std::cerr << "JPPyErrFrame::normalize(): exc value is_null: " << m_ExceptionValue.isNull() << '\n';
-	//std::cerr << "JPPyErrFrame::normalize(): excValue=" << excValue <<
-	//		" exception_class=" << m_ExceptionClass.get() <<
-	//		" exception_trace=" << m_ExceptionTrace.get() << '\n';
-	if (excValue) {
-		if ( !PyExceptionInstance_Check(excValue))
-		{
-			JPPyObject args = JPPyTuple_Pack(excValue);
-			m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-			PyException_SetTraceback(excValue, m_ExceptionTrace.get());
-			JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
-			JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
-		}
-	} else {
-		std::cerr << "JPPyErrFrame::normalize(): excValue was null!" << std::endl;
+	if (excValue && !PyExceptionInstance_Check(excValue))
+	{
+		JPPyObject args = JPPyTuple_Pack(excValue);
+		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
+		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
+		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}
 }

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -461,14 +461,14 @@ char *JPPyBuffer::getBufferPtr(std::vector<Py_ssize_t>& indices) const
 
 JPPyErrFrame::JPPyErrFrame()
 {
-	good = JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+	m_good = JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 }
 
 JPPyErrFrame::~JPPyErrFrame()
 {
 	try
 	{
-		if (good)
+		if (m_good)
 			JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}	catch (...)  // GCOVR_EXCL_LINE
 	{
@@ -478,7 +478,7 @@ JPPyErrFrame::~JPPyErrFrame()
 
 void JPPyErrFrame::clear()
 {
-	good = false;
+	m_good = false;
 }
 
 void JPPyErrFrame::normalize()
@@ -486,12 +486,20 @@ void JPPyErrFrame::normalize()
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
 	auto excValue = m_ExceptionValue.get();
-	if (excValue && !PyExceptionInstance_Check(excValue))
-	{
-		JPPyObject args = JPPyTuple_Pack(excValue);
-		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
-		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
-		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+	//std::cerr << "JPPyErrFrame::normalize(): exc value is_null: " << m_ExceptionValue.isNull() << '\n';
+	//std::cerr << "JPPyErrFrame::normalize(): excValue=" << excValue <<
+	//		" exception_class=" << m_ExceptionClass.get() <<
+	//		" exception_trace=" << m_ExceptionTrace.get() << '\n';
+	if (excValue) {
+		if ( !PyExceptionInstance_Check(excValue))
+		{
+			JPPyObject args = JPPyTuple_Pack(excValue);
+			m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
+			PyException_SetTraceback(excValue, m_ExceptionTrace.get());
+			JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+			JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+		}
+	} else {
+		std::cerr << "JPPyErrFrame::normalize(): excValue was null!" << std::endl;
 	}
 }

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -132,9 +132,14 @@ void PyJPModule_loadResources(PyObject* module)
 
 		_JObjectKey = PyCapsule_New(module, "constructor key", nullptr);
 
-	}	catch (JPypeException&)  // GCOVR_EXCL_LINE
+	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
 	{
 		// GCOVR_EXCL_START
+		// PyJP_SetStringWithCause needs the original exception live on the
+		// thread state to chain it as a cause - restorePythonError() puts
+		// back what our throw-time-fetch fix (see jp_exception.cpp) deliberately
+		// held privately instead of leaving pending for the whole unwind.
+		ex.restorePythonError();
 		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
 		JP_RAISE_PYTHON();
 		// GCOVR_EXCL_STOP
@@ -156,13 +161,19 @@ void PyJP_SetStringWithCause(PyObject *exception,
 	// See _PyErr_TrySetFromCause
 	PyObject *exc1, *val1, *tb1;
 	PyErr_Fetch(&exc1, &val1, &tb1);
-	PyErr_NormalizeException(&exc1, &val1, &tb1);
-	if (tb1 != nullptr)
+	// A caller may have nothing pending (e.g. it was already claimed
+	// elsewhere) - PyErr_NormalizeException() is a no-op on a null type,
+	// so exc1/val1 stay null too; guard rather than assume one is set.
+	if (exc1 != nullptr)
 	{
-		PyException_SetTraceback(val1, tb1);
-		Py_DECREF(tb1);
+		PyErr_NormalizeException(&exc1, &val1, &tb1);
+		if (tb1 != nullptr)
+		{
+			PyException_SetTraceback(val1, tb1);
+			Py_DECREF(tb1);
+		}
+		Py_DECREF(exc1);
 	}
-	Py_DECREF(exc1);
 	PyErr_SetString(exception, str);
 	PyObject *exc2, *val2, *tb2;
 	PyErr_Fetch(&exc2, &val2, &tb2);
@@ -581,6 +592,18 @@ static PyObject *PyJPModule_arrayFromBuffer(PyObject *module, PyObject *args, Py
 
 PyObject *PyJPModule_collect(PyObject* module, PyObject *obj)
 {
+	// This is a gc.callbacks entry, invoked by Python's own cyclic GC
+	// whenever it happens to run - which can be in the middle of unwinding
+	// from an unrelated pending exception (GC isn't aware of, or triggered
+	// by, our own exception-handling code; enough temporary objects
+	// created/destroyed during unwind can cross its allocation threshold).
+	// The RSS-based bookkeeping in onStart/onEnd (including the JNI call to
+	// System.gc() onEnd may make) is a heuristic, not safety-critical - it's
+	// not worth the risk of touching Java/global state while some unrelated
+	// exception is already in flight on this thread, so just skip this
+	// invocation entirely rather than try to save/restore around it.
+	if (PyErr_Occurred())
+		Py_RETURN_NONE;
 	JPContext* context = JPContext_global;
 	if (!context->isRunning())
 		Py_RETURN_NONE;

--- a/native/python/pyjp_package.cpp
+++ b/native/python/pyjp_package.cpp
@@ -260,8 +260,9 @@ static PyObject *PyJPPackage_dir(PyObject *self)
 	JPPyObject out = JPPyObject::call(PyList_New(len));
 	for (Py_ssize_t i = 0;  i < len; ++i)
 	{
-		string str = frame.toStringUTF8((jstring)
-				frame.GetObjectArrayElement((jobjectArray) o, (jsize) i));
+		jobject element = frame.GetObjectArrayElement((jobjectArray) o, (jsize) i);
+		string str = frame.toStringUTF8((jstring) element);
+		frame.DeleteLocalRef(element);
 		PyList_SetItem(out.get(), i, PyUnicode_FromFormat("%s", str.c_str()));
 	}
 	return out.keep();

--- a/project/bugs/gc_exception_race_soak.py
+++ b/project/bugs/gc_exception_race_soak.py
@@ -1,0 +1,186 @@
+"""Soak harness for jpype-project#1415 (GC-reentrancy corruption of an
+in-flight Python exception mid-C++-unwind).
+
+This is NOT a deterministic reproducer - the underlying race depends on
+CPython's generational GC allocation counters and JVM GC scheduling, both
+of which are opaque and non-reproducible on demand. Its job is to run the
+suspect path under sustained, heavy contention on both the Python and
+Java side of the boundary, for long enough to give a still-present bug
+many chances to fire, so a clean run here is meaningful evidence rather
+than luck.
+
+The confirmed trigger (see plan/GCExceptionRace.md): a reverse-bridge
+call into Python raises mid-conversion (JArray(JBoolean) assignment
+calling __bool__ on each element), producing a _python_error exception
+that C++ has to unwind through. Racing that against:
+  - gc.set_threshold(1, 1, 1) - the original bug required heavy
+    accumulated allocation state (~40 preceding test files' worth) to
+    trip CPython's cyclic GC mid-unwind at any reasonable hit rate;
+    forcing collection on (almost) every allocation reproduces the same
+    window deterministically instead of relying on incidental churn,
+  - Python-side allocation pressure on a second thread (cyclic garbage,
+    so there is always something for that aggressive threshold to find),
+  - a proxy/reverse-bridge workload (a JImplements(Comparator) invoked
+    via Collections.sort, pulling and pushing real Java objects) running
+    interleaved with the provoke calls, so the unwind path is exercised
+    alongside realistic reverse-bridge traffic rather than in isolation,
+    and
+  - a Java thread hammering System.gc() concurrently (to also stress the
+    cross-thread/JNI angle, even though the confirmed mechanism was
+    single-threaded reentrancy, not a cross-thread race)
+maximizes the odds of catching a regression. With gc.set_threshold(1, 1,
+1), this harness reliably reproduces the original corruption
+(SystemError: "error return without exception set") in a few thousand
+iterations against a pre-fix checkout - see plan/GCExceptionRace.md.
+
+Usage:
+    python gc_exception_race_soak.py [iterations] [seconds]
+
+Exits non-zero (and prints full detail) the moment a single iteration
+observes anything other than exactly "SystemError: nope" - any other
+exception type, message, or a hang - is a corruption signal. A true
+memory-safety violation may instead just crash the process; that is
+also a failure, it will just not print this script's summary.
+"""
+import gc
+import sys
+import threading
+import time
+
+import jpype
+import jpype.imports  # noqa: F401
+
+
+class _RaisesOnBool:
+    """Object whose __bool__ raises - the confirmed jpype-project#1415
+    trigger when used in a JArray(JBoolean) slice assignment."""
+
+    def __bool__(self):
+        raise SystemError("nope")
+
+
+def _provoke_once():
+    ja = jpype.JArray(jpype.JBoolean)(5)
+    values = [True, False, _RaisesOnBool(), True, False]
+    try:
+        ja[:] = values
+    except SystemError as ex:
+        if str(ex) != "nope":
+            raise AssertionError(
+                "CORRUPTION: expected SystemError('nope'), got "
+                "SystemError(%r)" % (str(ex),)
+            )
+        return
+    except BaseException as ex:  # noqa: BLE001 - detection, not handling
+        raise AssertionError(
+            "CORRUPTION: expected SystemError('nope'), got "
+            "%s(%r)" % (type(ex).__name__, str(ex))
+        )
+    else:
+        raise AssertionError("CORRUPTION: no exception raised at all")
+
+
+def _python_gc_pressure(stop_event):
+    """Continuously build and drop cyclic garbage on a second Python
+    thread, to raise the odds CPython's generational GC fires while the
+    main thread is mid-unwind through the C++ exception path."""
+    while not stop_event.is_set():
+        for _ in range(1000):
+            a = {}
+            b = {"a": a}
+            a["b"] = b
+        del a, b
+
+
+def _start_java_gc_hammer(stop_event):
+    """A Java thread that calls System.gc() back-to-back for the
+    duration of the soak, to stress the JNI/cross-thread angle too."""
+    from java.lang import Runnable, System, Thread
+
+    @jpype.JImplements(Runnable)
+    class GcHammer:
+        @jpype.JOverride
+        def run(self):
+            while not stop_event.is_set():
+                System.gc()
+
+    hammer = GcHammer()
+    thread = Thread(hammer)
+    thread.setDaemon(True)
+    thread.start()
+    return thread
+
+
+def _make_proxy_workload():
+    """Build a reverse-bridge workload: a JImplements(Comparator) proxy
+    invoked via Collections.sort, pulling boxed Java Integers into Python
+    and pushing a Python int comparison result back out - so the provoke
+    loop below runs interleaved with realistic proxy dispatch/object
+    traffic, not just isolated array-assignment calls."""
+    from java.util import ArrayList, Collections, Comparator
+
+    @jpype.JImplements(Comparator)
+    class ReverseIntComparator:
+        @jpype.JOverride
+        def compare(self, a, b):
+            # Pull both boxed values into Python, build some short-lived
+            # cyclic garbage of our own, then push a plain Python int back.
+            x, y = int(a), int(b)
+            tmp = {"x": x}
+            tmp["self"] = tmp
+            del tmp
+            return y - x
+
+        @jpype.JOverride
+        def equals(self, other):
+            return self is other
+
+    comparator = ReverseIntComparator()
+
+    def _run_once():
+        lst = ArrayList()
+        for v in (5, 3, 1, 4, 2):
+            lst.add(v)
+        Collections.sort(lst, comparator)
+
+    return _run_once
+
+
+def main():
+    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 200000
+    seconds = float(sys.argv[2]) if len(sys.argv) > 2 else 60.0
+
+    # The original bug needed heavy accumulated allocation state (an
+    # entire preceding test suite) to trip CPython's cyclic GC mid-unwind
+    # at any reasonable hit rate. Forcing collection aggressively
+    # reproduces that same window without needing to replay the suite.
+    gc.set_threshold(1, 1, 1)
+
+    jpype.startJVM()
+
+    stop_event = threading.Event()
+    gc_thread = threading.Thread(target=_python_gc_pressure, args=(stop_event,))
+    gc_thread.daemon = True
+    gc_thread.start()
+    _start_java_gc_hammer(stop_event)
+    proxy_workload = _make_proxy_workload()
+
+    start = time.time()
+    completed = 0
+    try:
+        while completed < iterations and (time.time() - start) < seconds:
+            _provoke_once()
+            proxy_workload()
+            completed += 1
+            if completed % 10000 == 0:
+                print("iteration %d clean (%.1fs elapsed)" %
+                      (completed, time.time() - start))
+    finally:
+        stop_event.set()
+        gc_thread.join(timeout=5)
+
+    print("DONE: %d iterations clean, no corruption detected" % completed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -54,13 +54,8 @@ def jvm_session(request):
     logger = logging.getLogger(__name__)
 
     assert not jpype.isJVMStarted()
-    try:
-        import faulthandler
-        faulthandler.enable()
-        faulthandler.disable()
-    except:
-        pass
-
+    import faulthandler
+    faulthandler.enable()
 
     classpath = request.config.getoption("--classpath")
     convertStrings = request.config.getoption("--convertStrings")
@@ -72,7 +67,9 @@ def jvm_session(request):
     jvm_path = jpype.getDefaultJVMPath()
     logger.info("Running testsuite using JVM %s" % jvm_path)
     classpath_arg = "-Djava.class.path=%s"
-    args = ["-ea", "-Xmx256M", "-Xms16M"]
+    args = ["-ea", "-Xmx256M", "-Xms16M",
+            "-Xrs"  # disable signal handler for sigsegv, sigabrt
+            ]
     if checkjni:
         args.append("-Xcheck:jni")
     if classpath:


### PR DESCRIPTION
Okay this is the completed work for the exception race condition.  The problem is that any actions between the python exception being thrown and being normalized are dangerous.  If the GIL is ever lost a separate thread can come in an stomp the in flight exception causing corruption of memory.  The GC ping was the culprit, but it was in no way exclusive.  

We fixed this by moving normalization directly into the constructor for throw and then created a soak test to verify that it is fixed under stressful conditions.    I think this is a good candidate for review and then rebasing the existing PR as that will clear up our  PR board as only real errors will appear going forward.  

I will submit a separate PR that does  refactor of this exception code with the goal of making it more rational an direct to minimize this in the future.  The original monoexception path is the root cause of many of these bugs as we are constantly probing to confirm the current path.