### PR TITLE
Comprehensive segfault PR: Libstdc++, Normalization, GC Race, and Shutdown signal fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,5 @@ cmake_install.cmake
 _jpype.so
 org.jpype.jar
 .build_history
+CLAUDE.md
+plan/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,18 +220,7 @@ elseif(APPLE)
             VERBATIM
     )
 elseif(LINUX OR UNIX) # make sure APPLE is handled before this.
-    # Linux and OSX settings.
-#    find_library(LIBSTDCXX_SHARED NAMES stdc++ DOC "LibStdC++ runtime library required." REQUIRED)
-#
-#    target_link_libraries(_jpype PRIVATE
-#            dl # dynamic linker
-#            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
-#    )
-    #target_compile_options(_jpype PRIVATE "-shared-libgcc")
-    #target_link_options(_jpype PRIVATE "-shared-libgcc" "-shared-libstdc++")
-    target_link_libraries(_jpype PRIVATE
-            dl
-            )
+    target_link_libraries(_jpype PRIVATE dl)
     target_link_options(_jpype PRIVATE "-Wl,-l:libstdc++.so.6")
 
     # Keep frame pointers for better stack unwinding.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,15 +202,24 @@ if(WIN32)
     # Ensure /MD and exception model are set
     target_compile_options(_jpype PRIVATE /EHsc /MD)
 else()
-    # Additional libraries for non-Windows
+    # Linux and OSX settings.
+    find_library(LIBSTDCXX_SHARED NAMES stdc++)
+
     target_link_libraries(_jpype PRIVATE
             dl # dynamic linker
+            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
     )
     # Keep frame pointers for better stack unwinding.
     add_compile_options(-fno-omit-frame-pointer)
 
     # even on OSX Python uses .so suffix instead of .dylib
     set_target_properties(_jpype PROPERTIES SUFFIX ".so")
+
+    # safe-guard to prevent static linkage of libstdc++
+    add_custom_command(TARGET _jpype POST_BUILD
+            COMMAND sh -c "readelf -d $<TARGET_FILE:_jpype> | grep -q libstdc++.so.6 || (echo 'FATAL: _jpype.so not dynamically linked against libstdc++!' >&2 && exit 1)"
+            VERBATIM
+    )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
+
+if(CMAKE_VERSION VERSION_LESS 3.25 AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(LINUX true)
+endif()
+
 project(jpype-native)
 
 option(ENABLE_TRACING "Enable tracing in the extension" OFF)
@@ -201,14 +206,34 @@ if(WIN32)
 
     # Ensure /MD and exception model are set
     target_compile_options(_jpype PRIVATE /EHsc /MD)
-else()
-    # Linux and OSX settings.
-    find_library(LIBSTDCXX_SHARED NAMES stdc++)
+elseif(APPLE)
+    # 1. Force the compiler to target the native Apple libc++
+    target_compile_options(_jpype PRIVATE "-stdlib=libc++")
+    target_link_options(_jpype PRIVATE "-stdlib=libc++")
 
-    target_link_libraries(_jpype PRIVATE
-            dl # dynamic linker
-            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
+    # 2. Tell the linker to prioritize dynamic lookup (.dylib) over static (.a)
+    target_link_options(_jpype PRIVATE "-Wl,-search_paths_first")
+    # Keep frame pointers for better stack unwinding.
+    add_compile_options(-fno-omit-frame-pointer)
+    add_custom_command(TARGET _jpype POST_BUILD
+            COMMAND sh -c "otool -L $<TARGET_FILE:_jpype> | grep -q libc++.1.dylib || (echo 'FATAL: _jpype.so not dynamically linked against libc++!' >&2 && exit 1)"
+            VERBATIM
     )
+elseif(LINUX OR UNIX) # make sure APPLE is handled before this.
+    # Linux and OSX settings.
+#    find_library(LIBSTDCXX_SHARED NAMES stdc++ DOC "LibStdC++ runtime library required." REQUIRED)
+#
+#    target_link_libraries(_jpype PRIVATE
+#            dl # dynamic linker
+#            "${LIBSTDCXX_SHARED}" # we have to link dynamically against libstdc++ to avoid conflicts with JVM.
+#    )
+    #target_compile_options(_jpype PRIVATE "-shared-libgcc")
+    #target_link_options(_jpype PRIVATE "-shared-libgcc" "-shared-libstdc++")
+    target_link_libraries(_jpype PRIVATE
+            dl
+            )
+    target_link_options(_jpype PRIVATE "-Wl,-l:libstdc++.so.6")
+
     # Keep frame pointers for better stack unwinding.
     add_compile_options(-fno-omit-frame-pointer)
 
@@ -220,6 +245,8 @@ else()
             COMMAND sh -c "readelf -d $<TARGET_FILE:_jpype> | grep -q libstdc++.so.6 || (echo 'FATAL: _jpype.so not dynamically linked against libstdc++!' >&2 && exit 1)"
             VERBATIM
     )
+else()
+    message(WARNING "unhandled OS found!")
 endif()
 
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -24,6 +24,24 @@ coverage:
         threshold: 2%
         paths:
         - "native/java/"
+    patch:
+      default: false
+      python:
+        target: 85%
+        threshold: 1%
+        paths:
+          - "jpype/"
+      cpp:
+        target: 70%
+        threshold: 5%
+        paths:
+          - "native/common/"
+          - "native/python/"
+      java:
+        target: 75%
+        threshold: 2%
+        paths:
+          - "native/java/"
 
 parsers:
   gcov:

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -7,6 +7,12 @@ Latest Changes:
 
 - **1.7.2.dev0**
 
+  - Fixed a random segmentation fault at JVM shutdown when Python tooling
+    (such as pytest's built-in faulthandler plugin) restored pre-JVM signal
+    handlers over HotSpot's, leaving safepoint polls in compiled code
+    unserviced.  JPype now snapshots the JVM's fault handlers at startup and
+    reinstates them before shutdown if they were replaced.
+
   - Fixed a rare crash where Python's cyclic garbage collector firing
     while a Python exception was mid-unwind through the reverse-bridge
     C++ layer could corrupt the in-flight exception. #1415

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -7,6 +7,10 @@ Latest Changes:
 
 - **1.7.2.dev0**
 
+  - Fixed a rare crash where Python's cyclic garbage collector firing
+    while a Python exception was mid-unwind through the reverse-bridge
+    C++ layer could corrupt the in-flight exception. #1415
+
   - Fixed memory leak with int and float conversions. #1379
 
   - Fixed instablity in threading for method dispatch. #1366

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -10,8 +10,10 @@ Latest Changes:
   - Fixed a random segmentation fault at JVM shutdown when Python tooling
     (such as pytest's built-in faulthandler plugin) restored pre-JVM signal
     handlers over HotSpot's, leaving safepoint polls in compiled code
-    unserviced.  JPype now snapshots the JVM's fault handlers at startup and
-    reinstates them before shutdown if they were replaced.
+    unserviced.  JPype now snapshots the JVM's fault handlers at startup,
+    reinstates them before shutdown if they were replaced, and restores the
+    pre-JVM handlers once the JVM is destroyed, making the JVM's lifetime
+    signal-handler transparent on POSIX systems.
 
   - Fixed a rare crash where Python's cyclic garbage collector firing
     while a Python exception was mid-unwind through the reverse-bridge

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -6629,6 +6629,21 @@ does so), and once the JVM has been destroyed it restores the pre-JVM
 handlers — so a faulthandler enabled before ``startJVM`` is functional again
 after shutdown, rather than leaving faults routed into a destroyed JVM.
 
+This safety net covers the specific enable-before/disable-after sequence
+described above, plus any handler replacement still in place at
+``shutdownJVM``.  It does **not** cover every possible case: if code installs
+a new SIGSEGV/SIGBUS/SIGILL/SIGFPE handler *after* ``startJVM`` and that
+handler is still active, unremoved, at the moment a safepoint or JIT
+implicit-fault poll fires (i.e. before the next ``shutdownJVM`` call has a
+chance to detect and restore it), the JVM's fault will be routed into that
+handler instead of HotSpot's.  JPype cannot intercept arbitrary third-party
+calls to ``signal.signal()`` or ``sigaction()`` to prevent this — there is no
+portable hook that fires on every signal-handler change.  **The rule remains:
+do not replace SIGSEGV/SIGBUS/SIGILL/SIGFPE handlers while a JVM is
+running.** Disable or restore any such handler before the JVM would next
+need its own (in particular before ``shutdownJVM``), rather than relying on
+JPype to detect and repair every possible handler replacement window.
+
 
 
 .. _miscellaneous_topics_unsupported_java_versions:

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -6610,6 +6610,21 @@ module has enabled it, using
 For example, absl installs faulthandlers in ``app.run``, thus the first call to
 main routine would need to disable faulthandlers to avoid potential crashes.
 
+The reverse direction is equally dangerous.  ``faulthandler.disable()``
+restores the signal handlers that were saved when ``faulthandler.enable()``
+was called.  If faulthandler was enabled *before* the JVM started and disabled
+*after*, the pre-JVM handlers are reinstalled over the JVM's own, leaving the
+JVM without the SIGSEGV handler it requires to service safepoint polls and
+implicit null checks in compiled code.  The process then dies with a raw
+segmentation fault the next time a safepoint arms — typically during JVM
+shutdown, well after the code that caused it has run.  pytest's built-in
+``faulthandler`` plugin performs exactly this enable-early/disable-late
+sequence, so test suites that start a JVM should run pytest with
+``-p no:faulthandler`` (JPype's own test suite sets this in ``addopts``).
+As a safety net, JPype snapshots the JVM's fault handlers at ``startJVM`` and
+reinstates them at ``shutdownJVM`` if they have been replaced, emitting a
+warning on stderr when it does so.
+
 
 
 .. _miscellaneous_topics_unsupported_java_versions:

--- a/doc/userguide.rst
+++ b/doc/userguide.rst
@@ -6621,9 +6621,13 @@ shutdown, well after the code that caused it has run.  pytest's built-in
 ``faulthandler`` plugin performs exactly this enable-early/disable-late
 sequence, so test suites that start a JVM should run pytest with
 ``-p no:faulthandler`` (JPype's own test suite sets this in ``addopts``).
-As a safety net, JPype snapshots the JVM's fault handlers at ``startJVM`` and
-reinstates them at ``shutdownJVM`` if they have been replaced, emitting a
-warning on stderr when it does so.
+As a safety net, JPype makes the JVM's lifetime handler-transparent on POSIX
+systems: it snapshots the fault handlers both immediately before and
+immediately after the JVM starts; at ``shutdownJVM`` it reinstates the JVM's
+own handlers if they have been replaced (emitting a warning on stderr when it
+does so), and once the JVM has been destroyed it restores the pre-JVM
+handlers — so a faulthandler enabled before ``startJVM`` is functional again
+after shutdown, rather than leaving faults routed into a destroyed JVM.
 
 
 

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -27,8 +27,9 @@
  * when returning to the native code.
  *
  * If we are returning to python, and it is a
- * - _python_error, then we assume that a python exception has already been
- *   placed in the python virtual machine.
+ * - _python_error, then the exception was fetched off the thread state and
+ *   normalized at the moment of the throw (not left live on the thread state
+ *   for the duration of the C++ unwind), and toPython()/toJava() restore it.
  * - _java_error, then we will convert it to a python object with the correct
  *   object type.
  * - otherwise, then we will convert it to the requested python error.
@@ -146,6 +147,15 @@ public:
 	/** Transfer handling of this exception to java. */
 	void toJava();
 
+	/** Put a captured _python_error exception back on the thread state.
+	 *
+	 * For callers that need the original Python exception live (e.g. to
+	 * chain it as a cause) before they finish handling this JPypeException
+	 * themselves, rather than going through toPython()/toJava(). No-op for
+	 * any other exception type, or if there is nothing captured.
+	 */
+	void restorePythonError();
+
 	int getExceptionType() const
 	{
 		return m_Type;
@@ -162,6 +172,18 @@ private:
 	JPStackTrace m_Trace;
 	JPThrowableRef m_Throwable;
 	std::string m_Message;
+
+	// For _python_error only: the exception is fetched and normalized at the
+	// moment of the throw (see JP_RAISE_PYTHON), not left live on the thread
+	// state for the length of the C++ unwind. A pending exception left on the
+	// thread state is visible to, and can be disturbed by, an incidental GC
+	// pass triggered anywhere during that unwind - fetching claims sole
+	// ownership so nothing else can touch it before toPython()/toJava()
+	// restore it. Only the (already-normalized) instance is held - its class
+	// and traceback are recoverable from the instance itself at restore time
+	// (see JPPyErr::restore(JPPyObject&)), so there's no need to separately
+	// hold references to them too.
+	JPPyObject m_PyExcValue;
 };
 
 #endif

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -53,30 +53,35 @@ static bool jvmSignalsSaved = false;
 
 static void saveJVMSignals()
 {
-	jvmSignalsSaved = true;
+	// Querying a valid signal cannot fail, so no error handling here.
 	for (size_t i = 0; i < jvmSignalCount; i++)
-		if (sigaction(jvmSignals[i], nullptr, &jvmSignalSnapshot[i]) != 0)
-			jvmSignalsSaved = false;
+		sigaction(jvmSignals[i], nullptr, &jvmSignalSnapshot[i]);
+	jvmSignalsSaved = true;
+}
+
+// sa_handler and sa_sigaction may share storage, so a handler must be read
+// from the field selected by SA_SIGINFO.
+static void* activeHandler(const struct sigaction& sa)
+{
+	if ((sa.sa_flags & SA_SIGINFO) != 0)
+		return (void*) sa.sa_sigaction;
+	return (void*) sa.sa_handler;
 }
 
 static void restoreJVMSignals()
 {
+	// Only reachable without a snapshot in embedded mode, where startJVM
+	// never ran; restoring a zeroed snapshot would install SIG_DFL and
+	// cause the very crash this guards against.
 	if (!jvmSignalsSaved)
-		return;
+		return;  // GCOVR_EXCL_LINE
 	bool changed = false;
 	for (size_t i = 0; i < jvmSignalCount; i++)
 	{
 		struct sigaction current;
 		if (sigaction(jvmSignals[i], nullptr, &current) != 0)
-			continue;
-		bool sameHandler;
-		if ((current.sa_flags & SA_SIGINFO) != (jvmSignalSnapshot[i].sa_flags & SA_SIGINFO))
-			sameHandler = false;
-		else if ((current.sa_flags & SA_SIGINFO) != 0)
-			sameHandler = current.sa_sigaction == jvmSignalSnapshot[i].sa_sigaction;
-		else
-			sameHandler = current.sa_handler == jvmSignalSnapshot[i].sa_handler;
-		if (sameHandler)
+			continue;  // GCOVR_EXCL_LINE
+		if (activeHandler(current) == activeHandler(jvmSignalSnapshot[i]))
 			continue;
 		changed = true;
 		sigaction(jvmSignals[i], &jvmSignalSnapshot[i], nullptr);

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -31,10 +31,61 @@
 #include <dlfcn.h>
 #endif // HPUX
 #include <errno.h>
+#include <signal.h>
+#include <stdio.h>
 #endif
 
 
 JPResource::~JPResource() = default;
+
+#ifndef WIN32
+// HotSpot depends on its own SIGSEGV/SIGBUS/SIGILL/SIGFPE handlers to service
+// safepoint polls and implicit null checks in compiled code.  Python tooling
+// that saves and restores signal handlers around the JVM's lifetime (e.g.
+// faulthandler via pytest's default plugin) reinstalls the pre-JVM handlers,
+// after which the first armed safepoint kills the process with a raw SIGSEGV.
+// Snapshot the handlers the JVM installs and reinstate them before driving
+// shutdown, which is when safepoints are guaranteed to arm.
+static const int jvmSignals[] = {SIGSEGV, SIGBUS, SIGILL, SIGFPE};
+static const size_t jvmSignalCount = sizeof (jvmSignals) / sizeof (jvmSignals[0]);
+static struct sigaction jvmSignalSnapshot[jvmSignalCount];
+static bool jvmSignalsSaved = false;
+
+static void saveJVMSignals()
+{
+	jvmSignalsSaved = true;
+	for (size_t i = 0; i < jvmSignalCount; i++)
+		if (sigaction(jvmSignals[i], nullptr, &jvmSignalSnapshot[i]) != 0)
+			jvmSignalsSaved = false;
+}
+
+static void restoreJVMSignals()
+{
+	if (!jvmSignalsSaved)
+		return;
+	bool changed = false;
+	for (size_t i = 0; i < jvmSignalCount; i++)
+	{
+		struct sigaction current;
+		if (sigaction(jvmSignals[i], nullptr, &current) != 0)
+			continue;
+		bool sameHandler;
+		if ((current.sa_flags & SA_SIGINFO) != (jvmSignalSnapshot[i].sa_flags & SA_SIGINFO))
+			sameHandler = false;
+		else if ((current.sa_flags & SA_SIGINFO) != 0)
+			sameHandler = current.sa_sigaction == jvmSignalSnapshot[i].sa_sigaction;
+		else
+			sameHandler = current.sa_handler == jvmSignalSnapshot[i].sa_handler;
+		if (sameHandler)
+			continue;
+		changed = true;
+		sigaction(jvmSignals[i], &jvmSignalSnapshot[i], nullptr);
+	}
+	if (changed)
+		fprintf(stderr, "JPype: the JVM's signal handlers were replaced while it was"
+				" running (faulthandler?); restoring them for JVM shutdown.\n");
+}
+#endif
 
 
 #define USE_JNI_VERSION JNI_VERSION_1_4
@@ -174,6 +225,10 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 
 	// Mark running for assert
 	m_Running = true;
+
+#ifndef WIN32
+	saveJVMSignals();
+#endif
 
 	jint jni_version = env->GetVersion();
 	if (jni_version < 0x00090000)
@@ -386,6 +441,12 @@ void JPContext::shutdownJVM(bool destroyJVM, bool freeJVM)
 		JP_RAISE(PyExc_RuntimeError, "Attempt to shutdown without a live JVM");
 	//	if (m_Embedded)
 	//		JP_RAISE(PyExc_RuntimeError, "Cannot shutdown from embedded Python");
+
+#ifndef WIN32
+	// Shutdown arms safepoints while hook threads run compiled code; make
+	// sure the JVM's signal handlers are still in place before starting.
+	restoreJVMSignals();
+#endif
 
 	// Wait for all non-demon threads to terminate
 	if (destroyJVM)

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -48,15 +48,16 @@ JPResource::~JPResource() = default;
 // shutdown, which is when safepoints are guaranteed to arm.
 static const int jvmSignals[] = {SIGSEGV, SIGBUS, SIGILL, SIGFPE};
 static const size_t jvmSignalCount = sizeof (jvmSignals) / sizeof (jvmSignals[0]);
+static struct sigaction preJVMSignalSnapshot[jvmSignalCount];
 static struct sigaction jvmSignalSnapshot[jvmSignalCount];
+static bool preJVMSignalsSaved = false;
 static bool jvmSignalsSaved = false;
 
-static void saveJVMSignals()
+static void snapshotSignals(struct sigaction* dest)
 {
 	// Querying a valid signal cannot fail, so no error handling here.
 	for (size_t i = 0; i < jvmSignalCount; i++)
-		sigaction(jvmSignals[i], nullptr, &jvmSignalSnapshot[i]);
-	jvmSignalsSaved = true;
+		sigaction(jvmSignals[i], nullptr, &dest[i]);
 }
 
 // sa_handler and sa_sigaction may share storage, so a handler must be read
@@ -89,6 +90,19 @@ static void restoreJVMSignals()
 	if (changed)
 		fprintf(stderr, "JPype: the JVM's signal handlers were replaced while it was"
 				" running (faulthandler?); restoring them for JVM shutdown.\n");
+}
+
+// Once the JVM is destroyed its handlers point into a dead VM, so return the
+// process to the handlers it had before startJVM (faulthandler's, or the
+// defaults).  The JVM's lifetime is thereby handler-transparent.  Safe
+// because VM_Exit parks all remaining daemon threads at the final safepoint;
+// nothing executes Java code after DestroyJavaVM returns.
+static void restorePreJVMSignals()
+{
+	if (!preJVMSignalsSaved)
+		return;  // GCOVR_EXCL_LINE
+	for (size_t i = 0; i < jvmSignalCount; i++)
+		sigaction(jvmSignals[i], &preJVMSignalSnapshot[i], nullptr);
 }
 #endif
 
@@ -212,6 +226,10 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 	// Launch the JVM
 	JNIEnv* env = nullptr;
 	JP_TRACE("Create JVM");
+#ifndef WIN32
+	snapshotSignals(preJVMSignalSnapshot);
+	preJVMSignalsSaved = true;
+#endif
 	try
 	{
 		CreateJVM_Method(&m_JavaVM, (void**) &env, (void*) jniArgs);
@@ -232,7 +250,8 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 	m_Running = true;
 
 #ifndef WIN32
-	saveJVMSignals();
+	snapshotSignals(jvmSignalSnapshot);
+	jvmSignalsSaved = true;
 #endif
 
 	jint jni_version = env->GetVersion();
@@ -457,8 +476,13 @@ void JPContext::shutdownJVM(bool destroyJVM, bool freeJVM)
 	if (destroyJVM)
 	{
 		JP_TRACE("Destroy JVM");
-		JPPyCallRelease call;
-		m_JavaVM->DestroyJavaVM();
+		{
+			JPPyCallRelease call;
+			m_JavaVM->DestroyJavaVM();
+		}
+#ifndef WIN32
+		restorePreJVMSignals();
+#endif
 	}
 
 	// unload the jvm library

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -40,6 +40,19 @@ JPypeException::JPypeException(int type, void* error, const JPStackInfo& stackIn
 {
 	JP_TRACE("EXCEPTION THROWN with error", error);
 	m_Error.l = error;
+	if (type == JPError::_python_error)
+	{
+		// Fetch and normalize the pending Python exception right now, at the
+		// moment of the throw, rather than leaving it live on the thread
+		// state for the whole C++ unwind (see m_PyExcValue in jp_exception.h
+		// for why). JPPyErrFrame::fetch() already removes it from the thread
+		// state; clear() below just stops its destructor from putting it
+		// straight back before we are ready for that in toPython()/toJava().
+		JPPyErrFrame eframe;
+		eframe.normalize();
+		m_PyExcValue = eframe.m_ExceptionValue;
+		eframe.clear();
+	}
 	from(stackInfo);
 }
 
@@ -65,7 +78,7 @@ JPypeException::JPypeException(int type,  const string& msn, int errType, const 
 
 JPypeException::JPypeException(const JPypeException &ex) noexcept
         : runtime_error(ex.what()), m_Type(ex.m_Type),  m_Error(ex.m_Error),
-        m_Trace(ex.m_Trace), m_Throwable(ex.m_Throwable)
+        m_Trace(ex.m_Trace), m_Throwable(ex.m_Throwable), m_PyExcValue(ex.m_PyExcValue)
 {
 }
 
@@ -79,6 +92,7 @@ JPypeException& JPypeException::operator = (const JPypeException& ex)
 	m_Trace = ex.m_Trace;
 	m_Throwable = ex.m_Throwable;
 	m_Error = ex.m_Error;
+	m_PyExcValue = ex.m_PyExcValue;
 	return *this;
 }
 // GCOVR_EXCL_STOP
@@ -87,6 +101,12 @@ void JPypeException::from(const JPStackInfo& info)
 {
 	JP_TRACE("EXCEPTION FROM: ", info.getFile(), info.getLine());
 	m_Trace.push_back(info);
+}
+
+void JPypeException::restorePythonError()
+{
+	if (m_Type == JPError::_python_error && m_PyExcValue.get() != nullptr)
+		JPPyErr::restore(m_PyExcValue);
 }
 
 bool isJavaThrowable(PyObject* exceptionClass)
@@ -244,6 +264,42 @@ void JPypeException::convertPythonToJava()
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
+/**
+ * Print a user-facing crash banner for the deliberate fail-fast crashes
+ * below (JPypeException::toPython/toJava's catch blocks).
+ *
+ * These crashes fire only when JPype's own exception-conversion code -
+ * which is not allowed to fail - fails anyway, leaving interpreter/JNI
+ * error state too corrupted to unwind safely. Terminating immediately is
+ * safer than continuing to run on corrupted state, but from a user's
+ * perspective this looks exactly like a spontaneous segfault, so we say
+ * plainly what happened and how to report it, before the process dies.
+ */
+static void reportFatalFailFast(const char* detail)
+{
+	fprintf(stderr,
+			"================================================================================\n"
+			"JPype has hit an internal error it cannot safely recover from and must stop the\n"
+			"JVM immediately.\n"
+			"\n"
+			"This is not something you did wrong in your own code - it means JPype's own\n"
+			"exception-handling machinery hit a case it doesn't know how to handle. Please\n"
+			"help fix it by reporting this at:\n"
+			"\n"
+			"    https://github.com/jpype-project/jpype/issues\n"
+			"\n"
+			"along with the smallest script you can find that reproduces it, and the detail\n"
+			"below:\n"
+			"\n"
+			"    %s\n"
+			"\n"
+			"JPype is intentionally crashing now rather than continuing to run with\n"
+			"corrupted internal state.\n"
+			"================================================================================\n",
+			detail);
+	fflush(stderr);
+}
+
 void JPypeException::toPython()
 {
 	const char* mesg = nullptr;
@@ -272,7 +328,11 @@ void JPypeException::toPython()
 			return;
 		} else if (m_Type == JPError::_python_error)
 		{
-			// Already on the stack
+			// Restore the exception fetched and normalized at the moment of
+			// the throw (see JPypeException's _python_error ctor). It was
+			// deliberately held off the thread state for the whole unwind so
+			// no incidental GC pass during that window could disturb it.
+			JPPyErr::restore(m_PyExcValue);
 		}// This section is only reachable during startup of the JVM.
 			// GCOVR_EXCL_START
 		else if (m_Type == JPError::_os_error_unix)
@@ -330,7 +390,12 @@ void JPypeException::toPython()
 			JPPyObject args = JPPyObject::call(Py_BuildValue("(s)", "C++ Exception"));
 			JPPyObject trace = JPPyObject::call(PyTrace_FromJPStackTrace(m_Trace));
 			JPPyObject cause = JPPyObject::accept(PyObject_Call(PyExc_Exception, args.get(), nullptr));
-			if (!cause.isNull())
+			// eframe.m_ExceptionValue can be null here - e.g. if the Python
+			// error state was already cleared by the time this runs (see
+			// JPPyErrFrame::normalize()'s own null-guard for the same class
+			// of issue) - PyException_SetCause requires a real exception
+			// instance as self and segfaults on null.
+			if (!cause.isNull() && eframe.m_ExceptionValue.get() != nullptr)
 			{
 				PyException_SetTraceback(cause.get(), trace.get());
 				PyException_SetCause(eframe.m_ExceptionValue.get(), cause.keep());
@@ -345,8 +410,13 @@ void JPypeException::toPython()
 		JPTracer::trace("Type:", m_Error.l);
 		if (ex.m_Type == JPError::_python_error)
 		{
-			JPPyErrFrame eframe;
-			JPTracer::trace("Inner Python:", ((PyTypeObject*) eframe.m_ExceptionClass.get())->tp_name);
+			// The inner exception was captured off the thread state at its
+			// own throw time (see JPypeException's _python_error ctor), not
+			// left sitting on the stack - trace from, then restore, the
+			// captured state directly rather than fetching.
+			JPTracer::trace("Inner Python:", ex.m_PyExcValue.get() != nullptr
+					? Py_TYPE(ex.m_PyExcValue.get())->tp_name : "(none!)");
+			JPPyErr::restore(ex.m_PyExcValue);
 			return;  // Let these go to Python, so we can see the error
 		} else if (ex.m_Type == JPError::_java_error)
 			JPTracer::trace("Inner Java:", ex.what());
@@ -365,6 +435,8 @@ void JPypeException::toPython()
 		JPTracer::trace("Fatal error in exception handling");
 
 		// You shall not pass!
+		reportFatalFailFast("An unexpected error occurred while converting a Java exception "
+				"back to Python (JPypeException::toPython).");
 		int *i = nullptr;
 		*i = 0;
 	}
@@ -397,6 +469,10 @@ void JPypeException::toJava()
 		{
 			JPPyCallAcquire callback;
 			JP_TRACE("Python exception");
+			// Restore what was fetched off the thread state at throw time
+			// (see JPypeException's _python_error ctor) - convertPythonToJava()
+			// expects to find the exception live on the thread state.
+			JPPyErr::restore(m_PyExcValue);
 			convertPythonToJava();
 			return;
 		}
@@ -423,6 +499,14 @@ void JPypeException::toJava()
 		JPTracer::trace(info.getFile(), info.getFunction(), info.getLine());
 
 		// Take one for the team.
+		{
+			std::stringstream detail;
+			detail << "A second error (\"" << ex.what() << "\") occurred while JPype was "
+					"converting a Python exception into its Java equivalent, at "
+					<< info.getFile() << ":" << info.getFunction() << ":" << info.getLine()
+					<< " (JPypeException::toJava).";
+			reportFatalFailFast(detail.str().c_str());
+		}
 		int *i = nullptr;
 		*i = 0;
 		// GCOVR_EXCL_STOP
@@ -433,6 +517,8 @@ void JPypeException::toJava()
 		JPTracer::trace("Fatal error in exception handling");
 
 		// It is pointless, I can't go on.
+		reportFatalFailFast("An unexpected, non-Python error occurred while JPype was "
+				"converting a Python exception into its Java equivalent (JPypeException::toJava).");
 		int *i = nullptr;
 		*i = 0;
 		// GCOVR_EXCL_STOP

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -493,7 +493,7 @@ PyObject* PyTrace_FromJPStackTrace(JPStackTrace& trace)
 	}
 	if (last_traceback == nullptr)
 		Py_RETURN_NONE;
-	return (PyObject*) last_traceback;
+	return last_traceback;
 }
 
 JPPyObject PyTrace_FromJavaException(JPJavaFrame& frame, jthrowable th, jthrowable prev)

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -211,9 +211,9 @@ void JPypeException::convertPythonToJava()
 	JPContext *context = frame.getContext();
 	jthrowable th;
 	JPPyErrFrame eframe;
-	if (eframe.good && isJavaThrowable(eframe.m_ExceptionClass.get()))
+	if (eframe.m_good && isJavaThrowable(eframe.m_ExceptionClass.get()))
 	{
-		eframe.good = false;
+		eframe.m_good = false;
 		JPValue* javaExc = PyJPValue_getJavaSlot(eframe.m_ExceptionValue.get());
 		if (javaExc != nullptr)
 		{

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -274,7 +274,11 @@ void JPypeException::convertPythonToJava()
  * safer than continuing to run on corrupted state, but from a user's
  * perspective this looks exactly like a spontaneous segfault, so we say
  * plainly what happened and how to report it, before the process dies.
+ *
+ * Coverage is excluded: exercising this path requires corrupting the
+ * interpreter state and killing the test process.
  */
+// GCOVR_EXCL_START
 static void reportFatalFailFast(const char* detail)
 {
 	fprintf(stderr,
@@ -299,6 +303,7 @@ static void reportFatalFailFast(const char* detail)
 			detail);
 	fflush(stderr);
 }
+// GCOVR_EXCL_STOP
 
 void JPypeException::toPython()
 {

--- a/native/python/include/jp_pythontypes.h
+++ b/native/python/include/jp_pythontypes.h
@@ -116,9 +116,7 @@ public:
 	 */
 	static JPPyObject call(PyObject* obj);
 
-	JPPyObject() : m_PyObject(nullptr)
-	{
-	}
+	JPPyObject() = default;
 
 	JPPyObject(const JPPyObject &self);
 
@@ -320,7 +318,7 @@ public:
 	JPPyObject m_ExceptionClass;
 	JPPyObject m_ExceptionValue;
 	JPPyObject m_ExceptionTrace;
-	bool good;
+	bool m_good{false};
 
 	JPPyErrFrame();
 	~JPPyErrFrame();

--- a/native/python/include/jp_pythontypes.h
+++ b/native/python/include/jp_pythontypes.h
@@ -309,6 +309,15 @@ namespace JPPyErr
 {
 bool fetch(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JPPyObject& exceptionTrace);
 void restore(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JPPyObject& exceptionTrace);
+
+/** Restore a single already-normalized exception instance.
+ *
+ * Once normalized, the instance's class and traceback are recoverable
+ * from the instance itself (Py_TYPE() and PyException_GetTraceback()),
+ * so a normalized exception only needs one owned reference held for it,
+ * not three.
+ */
+void restore(JPPyObject& exceptionValue);
 }
 
 /** Memory management for handling a python exception currently in progress. */

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -488,9 +488,9 @@ void JPPyErrFrame::normalize()
 	auto excValue = m_ExceptionValue.get();
 	if (excValue && !PyExceptionInstance_Check(excValue))
 	{
-		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
+		JPPyObject args = JPPyTuple_Pack(excValue);
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());
+		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -485,12 +485,11 @@ void JPPyErrFrame::normalize()
 {
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
-	auto excValue = m_ExceptionValue.get();
-	if (excValue && !PyExceptionInstance_Check(excValue))
+	if (m_ExceptionValue.get() && !PyExceptionInstance_Check(m_ExceptionValue.get()))
 	{
-		JPPyObject args = JPPyTuple_Pack(excValue);
+		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());   // fixed
+		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -390,6 +390,17 @@ void JPPyErr::restore(JPPyObject& exceptionClass, JPPyObject& exceptionValue, JP
 	PyErr_Restore(exceptionClass.keepNull(), exceptionValue.keepNull(), exceptionTrace.keepNull());
 }
 
+void JPPyErr::restore(JPPyObject& exceptionValue)
+{
+	// Only valid for an already-normalized instance: its class and
+	// traceback are then recoverable from the instance itself, so there
+	// is no need to have held separate references to them.
+	PyObject *value = exceptionValue.keepNull();
+	PyObject *type = (PyObject*) Py_TYPE(value);
+	Py_INCREF(type);
+	PyErr_Restore(type, value, PyException_GetTraceback(value));
+}
+
 JPPyCallAcquire::JPPyCallAcquire()
 {
 	m_State = (long) PyGILState_Ensure();

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -485,7 +485,8 @@ void JPPyErrFrame::normalize()
 {
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
-	if (!PyExceptionInstance_Check(m_ExceptionValue.get()))
+	auto excValue = m_ExceptionValue.get();
+	if (excValue && !PyExceptionInstance_Check(excValue))
 	{
 		JPPyObject args = JPPyTuple_Pack(m_ExceptionValue.get());
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -490,7 +490,7 @@ void JPPyErrFrame::normalize()
 	{
 		JPPyObject args = JPPyTuple_Pack(excValue);
 		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
+		PyException_SetTraceback(m_ExceptionValue.get(), m_ExceptionTrace.get());   // fixed
 		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -486,20 +486,12 @@ void JPPyErrFrame::normalize()
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
 	auto excValue = m_ExceptionValue.get();
-	//std::cerr << "JPPyErrFrame::normalize(): exc value is_null: " << m_ExceptionValue.isNull() << '\n';
-	//std::cerr << "JPPyErrFrame::normalize(): excValue=" << excValue <<
-	//		" exception_class=" << m_ExceptionClass.get() <<
-	//		" exception_trace=" << m_ExceptionTrace.get() << '\n';
-	if (excValue) {
-		if ( !PyExceptionInstance_Check(excValue))
-		{
-			JPPyObject args = JPPyTuple_Pack(excValue);
-			m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-			PyException_SetTraceback(excValue, m_ExceptionTrace.get());
-			JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
-			JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
-		}
-	} else {
-		std::cerr << "JPPyErrFrame::normalize(): excValue was null!" << std::endl;
+	if (excValue && !PyExceptionInstance_Check(excValue))
+	{
+		JPPyObject args = JPPyTuple_Pack(excValue);
+		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
+		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
+		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}
 }

--- a/native/python/jp_pythontypes.cpp
+++ b/native/python/jp_pythontypes.cpp
@@ -461,14 +461,14 @@ char *JPPyBuffer::getBufferPtr(std::vector<Py_ssize_t>& indices) const
 
 JPPyErrFrame::JPPyErrFrame()
 {
-	good = JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+	m_good = JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 }
 
 JPPyErrFrame::~JPPyErrFrame()
 {
 	try
 	{
-		if (good)
+		if (m_good)
 			JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
 	}	catch (...)  // GCOVR_EXCL_LINE
 	{
@@ -478,7 +478,7 @@ JPPyErrFrame::~JPPyErrFrame()
 
 void JPPyErrFrame::clear()
 {
-	good = false;
+	m_good = false;
 }
 
 void JPPyErrFrame::normalize()
@@ -486,12 +486,20 @@ void JPPyErrFrame::normalize()
 	// Python uses lazy evaluation on exceptions thus we can't modify it until
 	// we have forced it to realize the exception.
 	auto excValue = m_ExceptionValue.get();
-	if (excValue && !PyExceptionInstance_Check(excValue))
-	{
-		JPPyObject args = JPPyTuple_Pack(excValue);
-		m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
-		PyException_SetTraceback(excValue, m_ExceptionTrace.get());
-		JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
-		JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+	//std::cerr << "JPPyErrFrame::normalize(): exc value is_null: " << m_ExceptionValue.isNull() << '\n';
+	//std::cerr << "JPPyErrFrame::normalize(): excValue=" << excValue <<
+	//		" exception_class=" << m_ExceptionClass.get() <<
+	//		" exception_trace=" << m_ExceptionTrace.get() << '\n';
+	if (excValue) {
+		if ( !PyExceptionInstance_Check(excValue))
+		{
+			JPPyObject args = JPPyTuple_Pack(excValue);
+			m_ExceptionValue = JPPyObject::call(PyObject_Call(m_ExceptionClass.get(), args.get(), nullptr));
+			PyException_SetTraceback(excValue, m_ExceptionTrace.get());
+			JPPyErr::restore(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+			JPPyErr::fetch(m_ExceptionClass, m_ExceptionValue, m_ExceptionTrace);
+		}
+	} else {
+		std::cerr << "JPPyErrFrame::normalize(): excValue was null!" << std::endl;
 	}
 }

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -132,9 +132,14 @@ void PyJPModule_loadResources(PyObject* module)
 
 		_JObjectKey = PyCapsule_New(module, "constructor key", nullptr);
 
-	}	catch (JPypeException&)  // GCOVR_EXCL_LINE
+	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
 	{
 		// GCOVR_EXCL_START
+		// PyJP_SetStringWithCause needs the original exception live on the
+		// thread state to chain it as a cause - restorePythonError() puts
+		// back what our throw-time-fetch fix (see jp_exception.cpp) deliberately
+		// held privately instead of leaving pending for the whole unwind.
+		ex.restorePythonError();
 		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
 		JP_RAISE_PYTHON();
 		// GCOVR_EXCL_STOP
@@ -156,13 +161,19 @@ void PyJP_SetStringWithCause(PyObject *exception,
 	// See _PyErr_TrySetFromCause
 	PyObject *exc1, *val1, *tb1;
 	PyErr_Fetch(&exc1, &val1, &tb1);
-	PyErr_NormalizeException(&exc1, &val1, &tb1);
-	if (tb1 != nullptr)
+	// A caller may have nothing pending (e.g. it was already claimed
+	// elsewhere) - PyErr_NormalizeException() is a no-op on a null type,
+	// so exc1/val1 stay null too; guard rather than assume one is set.
+	if (exc1 != nullptr)
 	{
-		PyException_SetTraceback(val1, tb1);
-		Py_DECREF(tb1);
+		PyErr_NormalizeException(&exc1, &val1, &tb1);
+		if (tb1 != nullptr)
+		{
+			PyException_SetTraceback(val1, tb1);
+			Py_DECREF(tb1);
+		}
+		Py_DECREF(exc1);
 	}
-	Py_DECREF(exc1);
 	PyErr_SetString(exception, str);
 	PyObject *exc2, *val2, *tb2;
 	PyErr_Fetch(&exc2, &val2, &tb2);
@@ -581,6 +592,18 @@ static PyObject *PyJPModule_arrayFromBuffer(PyObject *module, PyObject *args, Py
 
 PyObject *PyJPModule_collect(PyObject* module, PyObject *obj)
 {
+	// This is a gc.callbacks entry, invoked by Python's own cyclic GC
+	// whenever it happens to run - which can be in the middle of unwinding
+	// from an unrelated pending exception (GC isn't aware of, or triggered
+	// by, our own exception-handling code; enough temporary objects
+	// created/destroyed during unwind can cross its allocation threshold).
+	// The RSS-based bookkeeping in onStart/onEnd (including the JNI call to
+	// System.gc() onEnd may make) is a heuristic, not safety-critical - it's
+	// not worth the risk of touching Java/global state while some unrelated
+	// exception is already in flight on this thread, so just skip this
+	// invocation entirely rather than try to save/restore around it.
+	if (PyErr_Occurred())
+		Py_RETURN_NONE;
 	JPContext* context = JPContext_global;
 	if (!context->isRunning())
 		Py_RETURN_NONE;

--- a/native/python/pyjp_package.cpp
+++ b/native/python/pyjp_package.cpp
@@ -260,8 +260,9 @@ static PyObject *PyJPPackage_dir(PyObject *self)
 	JPPyObject out = JPPyObject::call(PyList_New(len));
 	for (Py_ssize_t i = 0;  i < len; ++i)
 	{
-		string str = frame.toStringUTF8((jstring)
-				frame.GetObjectArrayElement((jobjectArray) o, (jsize) i));
+		jobject element = frame.GetObjectArrayElement((jobjectArray) o, (jsize) i);
+		string str = frame.toStringUTF8((jstring) element);
+		frame.DeleteLocalRef(element);
 		PyList_SetItem(out.get(), i, PyUnicode_FromFormat("%s", str.c_str()));
 	}
 	return out.keep();

--- a/project/bugs/gc_exception_race_soak.py
+++ b/project/bugs/gc_exception_race_soak.py
@@ -1,0 +1,186 @@
+"""Soak harness for jpype-project#1415 (GC-reentrancy corruption of an
+in-flight Python exception mid-C++-unwind).
+
+This is NOT a deterministic reproducer - the underlying race depends on
+CPython's generational GC allocation counters and JVM GC scheduling, both
+of which are opaque and non-reproducible on demand. Its job is to run the
+suspect path under sustained, heavy contention on both the Python and
+Java side of the boundary, for long enough to give a still-present bug
+many chances to fire, so a clean run here is meaningful evidence rather
+than luck.
+
+The confirmed trigger (see plan/GCExceptionRace.md): a reverse-bridge
+call into Python raises mid-conversion (JArray(JBoolean) assignment
+calling __bool__ on each element), producing a _python_error exception
+that C++ has to unwind through. Racing that against:
+  - gc.set_threshold(1, 1, 1) - the original bug required heavy
+    accumulated allocation state (~40 preceding test files' worth) to
+    trip CPython's cyclic GC mid-unwind at any reasonable hit rate;
+    forcing collection on (almost) every allocation reproduces the same
+    window deterministically instead of relying on incidental churn,
+  - Python-side allocation pressure on a second thread (cyclic garbage,
+    so there is always something for that aggressive threshold to find),
+  - a proxy/reverse-bridge workload (a JImplements(Comparator) invoked
+    via Collections.sort, pulling and pushing real Java objects) running
+    interleaved with the provoke calls, so the unwind path is exercised
+    alongside realistic reverse-bridge traffic rather than in isolation,
+    and
+  - a Java thread hammering System.gc() concurrently (to also stress the
+    cross-thread/JNI angle, even though the confirmed mechanism was
+    single-threaded reentrancy, not a cross-thread race)
+maximizes the odds of catching a regression. With gc.set_threshold(1, 1,
+1), this harness reliably reproduces the original corruption
+(SystemError: "error return without exception set") in a few thousand
+iterations against a pre-fix checkout - see plan/GCExceptionRace.md.
+
+Usage:
+    python gc_exception_race_soak.py [iterations] [seconds]
+
+Exits non-zero (and prints full detail) the moment a single iteration
+observes anything other than exactly "SystemError: nope" - any other
+exception type, message, or a hang - is a corruption signal. A true
+memory-safety violation may instead just crash the process; that is
+also a failure, it will just not print this script's summary.
+"""
+import gc
+import sys
+import threading
+import time
+
+import jpype
+import jpype.imports  # noqa: F401
+
+
+class _RaisesOnBool:
+    """Object whose __bool__ raises - the confirmed jpype-project#1415
+    trigger when used in a JArray(JBoolean) slice assignment."""
+
+    def __bool__(self):
+        raise SystemError("nope")
+
+
+def _provoke_once():
+    ja = jpype.JArray(jpype.JBoolean)(5)
+    values = [True, False, _RaisesOnBool(), True, False]
+    try:
+        ja[:] = values
+    except SystemError as ex:
+        if str(ex) != "nope":
+            raise AssertionError(
+                "CORRUPTION: expected SystemError('nope'), got "
+                "SystemError(%r)" % (str(ex),)
+            )
+        return
+    except BaseException as ex:  # noqa: BLE001 - detection, not handling
+        raise AssertionError(
+            "CORRUPTION: expected SystemError('nope'), got "
+            "%s(%r)" % (type(ex).__name__, str(ex))
+        )
+    else:
+        raise AssertionError("CORRUPTION: no exception raised at all")
+
+
+def _python_gc_pressure(stop_event):
+    """Continuously build and drop cyclic garbage on a second Python
+    thread, to raise the odds CPython's generational GC fires while the
+    main thread is mid-unwind through the C++ exception path."""
+    while not stop_event.is_set():
+        for _ in range(1000):
+            a = {}
+            b = {"a": a}
+            a["b"] = b
+        del a, b
+
+
+def _start_java_gc_hammer(stop_event):
+    """A Java thread that calls System.gc() back-to-back for the
+    duration of the soak, to stress the JNI/cross-thread angle too."""
+    from java.lang import Runnable, System, Thread
+
+    @jpype.JImplements(Runnable)
+    class GcHammer:
+        @jpype.JOverride
+        def run(self):
+            while not stop_event.is_set():
+                System.gc()
+
+    hammer = GcHammer()
+    thread = Thread(hammer)
+    thread.setDaemon(True)
+    thread.start()
+    return thread
+
+
+def _make_proxy_workload():
+    """Build a reverse-bridge workload: a JImplements(Comparator) proxy
+    invoked via Collections.sort, pulling boxed Java Integers into Python
+    and pushing a Python int comparison result back out - so the provoke
+    loop below runs interleaved with realistic proxy dispatch/object
+    traffic, not just isolated array-assignment calls."""
+    from java.util import ArrayList, Collections, Comparator
+
+    @jpype.JImplements(Comparator)
+    class ReverseIntComparator:
+        @jpype.JOverride
+        def compare(self, a, b):
+            # Pull both boxed values into Python, build some short-lived
+            # cyclic garbage of our own, then push a plain Python int back.
+            x, y = int(a), int(b)
+            tmp = {"x": x}
+            tmp["self"] = tmp
+            del tmp
+            return y - x
+
+        @jpype.JOverride
+        def equals(self, other):
+            return self is other
+
+    comparator = ReverseIntComparator()
+
+    def _run_once():
+        lst = ArrayList()
+        for v in (5, 3, 1, 4, 2):
+            lst.add(v)
+        Collections.sort(lst, comparator)
+
+    return _run_once
+
+
+def main():
+    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else 200000
+    seconds = float(sys.argv[2]) if len(sys.argv) > 2 else 60.0
+
+    # The original bug needed heavy accumulated allocation state (an
+    # entire preceding test suite) to trip CPython's cyclic GC mid-unwind
+    # at any reasonable hit rate. Forcing collection aggressively
+    # reproduces that same window without needing to replay the suite.
+    gc.set_threshold(1, 1, 1)
+
+    jpype.startJVM()
+
+    stop_event = threading.Event()
+    gc_thread = threading.Thread(target=_python_gc_pressure, args=(stop_event,))
+    gc_thread.daemon = True
+    gc_thread.start()
+    _start_java_gc_hammer(stop_event)
+    proxy_workload = _make_proxy_workload()
+
+    start = time.time()
+    completed = 0
+    try:
+        while completed < iterations and (time.time() - start) < seconds:
+            _provoke_once()
+            proxy_workload()
+            completed += 1
+            if completed % 10000 == 0:
+                print("iteration %d clean (%.1fs elapsed)" %
+                      (completed, time.time() - start))
+    finally:
+        stop_event.set()
+        gc_thread.join(timeout=5)
+
+    print("DONE: %d iterations clean, no corruption detected" % completed)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,12 @@ module = [
 ignore_missing_imports = true
 
 [tool.pytest]
-addopts = ["--verbose"]
+# pytest's built-in faulthandler plugin calls faulthandler.enable() before the
+# JVM exists and faulthandler.disable() at exit, which reinstalls the pre-JVM
+# SIGSEGV handler over HotSpot's.  The JVM then dies on the first armed
+# safepoint poll during shutdown (random ~25% crash rate in CI).  Keep the
+# plugin off; conftest.py enables faulthandler itself before startJVM.
+addopts = ["--verbose", "-p", "no:faulthandler"]
 testpaths = ["test", "jpype/_pyinstaller"]
 
 

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -54,13 +54,8 @@ def jvm_session(request):
     logger = logging.getLogger(__name__)
 
     assert not jpype.isJVMStarted()
-    try:
-        import faulthandler
-        faulthandler.enable()
-        faulthandler.disable()
-    except:
-        pass
-
+    import faulthandler
+    faulthandler.enable()
 
     classpath = request.config.getoption("--classpath")
     convertStrings = request.config.getoption("--convertStrings")
@@ -72,7 +67,9 @@ def jvm_session(request):
     jvm_path = jpype.getDefaultJVMPath()
     logger.info("Running testsuite using JVM %s" % jvm_path)
     classpath_arg = "-Djava.class.path=%s"
-    args = ["-ea", "-Xmx256M", "-Xms16M"]
+    args = ["-ea", "-Xmx256M", "-Xms16M",
+            "-Xrs"  # disable signal handler for sigsegv, sigabrt
+            ]
     if checkjni:
         args.append("-Xcheck:jni")
     if classpath:

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -51,6 +51,7 @@ def jvm_session(request):
     import warnings
     import faulthandler
 
+    # This installs signal handlers before the JVM is started.
     faulthandler.enable()
 
 
@@ -70,7 +71,7 @@ def jvm_session(request):
     logger.info("Running testsuite using JVM %s" % jvm_path)
     classpath_arg = "-Djava.class.path=%s"
     args = ["-ea", "-Xmx256M", "-Xms16M",
-            "-Xrs"  # disable signal handler for sigsegv, sigabrt
+            #"-Xrs"  # disable signal handler for sigsegv, sigabrt
             ]
     if checkjni:
         args.append("-Xcheck:jni")

--- a/test/jpypetest/conftest.py
+++ b/test/jpypetest/conftest.py
@@ -49,10 +49,11 @@ def jvm_session(request):
     from pathlib import Path
     import logging
     import warnings
-    import faulthandler
+    #import faulthandler
 
     # This installs signal handlers before the JVM is started.
-    faulthandler.enable()
+    # Note, that these handler most likely will be overridden by the JVMs own handlers.
+    #faulthandler.enable()
 
 
     logging.basicConfig(level=logging.DEBUG)

--- a/test/jpypetest/test_shutdown.py
+++ b/test/jpypetest/test_shutdown.py
@@ -63,6 +63,30 @@ class ShutdownSignalWarningTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn(b"signal handlers were replaced", result.stderr)
 
+    def testPreJVMHandlerRestored(self):
+        # The JVM's lifetime must be handler-transparent: a handler installed
+        # before startJVM works again after shutdownJVM.  The signal is sent
+        # with os.kill so it is delivered asynchronously (no fault context);
+        # without the post-destroy restore it would land in the dead JVM's
+        # handler instead of Python's.
+        if sys.platform == "win32":
+            raise unittest.SkipTest("POSIX signal handling only")
+        script = (
+            "import jpype, os, signal\n"
+            "hits = []\n"
+            "signal.signal(signal.SIGSEGV, lambda s, f: hits.append(s))\n"
+            "jpype.startJVM(convertStrings=False)\n"
+            "jpype.shutdownJVM()\n"
+            "os.kill(os.getpid(), signal.SIGSEGV)\n"
+            "assert hits == [signal.SIGSEGV], hits\n"
+            "print('PRE-JVM-RESTORED')\n"
+        )
+        result = subprocess.run([sys.executable, "-c", script],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                timeout=120)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"PRE-JVM-RESTORED", result.stdout)
+
 
 @subrun.TestCase
 class ShutdownTest(unittest.TestCase):

--- a/test/jpypetest/test_shutdown.py
+++ b/test/jpypetest/test_shutdown.py
@@ -15,9 +15,53 @@
 #   See NOTICE file for details.
 #
 # *****************************************************************************
+import subprocess
+import sys
 import unittest
 import jpype
 import subrun
+
+
+@subrun.TestCase
+class ShutdownSignalRestoreTest(unittest.TestCase):
+    """The JVM's fault handlers can be replaced while it runs; shutdownJVM
+    must reinstate them before destroying the JVM or the first armed
+    safepoint kills the process (see userguide, "Errors reported by Python
+    fault handler").  This reproduces the exact kill chain: faulthandler
+    enabled before the JVM exists, disabled after, restoring pre-JVM
+    handlers over HotSpot's."""
+
+    @classmethod
+    def setUpClass(cls):
+        import faulthandler
+        faulthandler.enable()
+        jpype.startJVM(convertStrings=False)
+        faulthandler.disable()
+        jpype.shutdownJVM()
+
+    def testShutdownSurvived(self):
+        # Reaching this line at all means the subprocess survived a shutdown
+        # with the JVM's fault handlers clobbered.
+        self.assertFalse(jpype.isJVMStarted())
+
+
+class ShutdownSignalWarningTest(unittest.TestCase):
+
+    def testRestoreWarning(self):
+        if sys.platform == "win32":
+            raise unittest.SkipTest("POSIX signal handling only")
+        script = (
+            "import faulthandler, jpype\n"
+            "faulthandler.enable()\n"
+            "jpype.startJVM(convertStrings=False)\n"
+            "faulthandler.disable()\n"
+            "jpype.shutdownJVM()\n"
+        )
+        result = subprocess.run([sys.executable, "-c", script],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                timeout=120)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"signal handlers were replaced", result.stderr)
 
 
 @subrun.TestCase


### PR DESCRIPTION
This is aimed at resolving all the remaining shutdown hazards.  Built on the prior #1416 and #1447.   

Fixes  #1144, #1141, #842

This fix was sampled 500 times under different conditions on linux (all runs were clean).  We suspect a second error on Windows branch as the current signal handler would not explain the faults in #1447 windows run.  (extended testing found one hazard in the addition 500 runs and documented the root cause).