### PR TITLE
Exception refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ org.jpype.jar
 .build_history
 CLAUDE.md
 plan/
+project/issues
+project/pr

--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -15,6 +15,13 @@ Latest Changes:
     pre-JVM handlers once the JVM is destroyed, making the JVM's lifetime
     signal-handler transparent on POSIX systems.
 
+  - Refactored internal exception handling: replaced the single
+    ``JPypeException`` tag-plus-union class with distinct C++ types per
+    exception origin (``JPJavaError``, ``JPPythonError``,
+    ``JPInternalError``), so each type only carries the payload valid for
+    it instead of relying on convention. No user-facing behavior change;
+    done to prevent future bugs of the class fixed by #1415 below.
+
   - Fixed a rare crash where Python's cyclic garbage collector firing
     while a Python exception was mid-unwind through the reverse-bridge
     C++ layer could corrupt the in-flight exception. #1415

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -111,6 +111,12 @@ public:
 	friend class JPJavaFrame;
 	friend class JPypeException;
 	friend class JPClass;
+	// Free functions in jp_exception.cpp factored out of JPypeException's
+	// member functions so both it and the new JPBaseError hierarchy (see
+	// jp_error.h / plan/ExceptionRefactor.md) share one tested conversion
+	// path.
+	friend void convertJavaToPython(jthrowable th);
+	friend void convertPythonToJava(const char* mesg);
 
 	JPContext();
 	virtual ~JPContext();

--- a/native/common/include/jp_context.h
+++ b/native/common/include/jp_context.h
@@ -109,12 +109,9 @@ class JPContext
 {
 public:
 	friend class JPJavaFrame;
-	friend class JPypeException;
 	friend class JPClass;
-	// Free functions in jp_exception.cpp factored out of JPypeException's
-	// member functions so both it and the new JPBaseError hierarchy (see
-	// jp_error.h / plan/ExceptionRefactor.md) share one tested conversion
-	// path.
+	// Free functions in jp_exception.cpp used by the JPBaseError hierarchy's
+	// toPython()/toJava() (see jp_error.h / plan/ExceptionRefactor.md).
 	friend void convertJavaToPython(jthrowable th);
 	friend void convertPythonToJava(const char* mesg);
 

--- a/native/common/include/jp_error.h
+++ b/native/common/include/jp_error.h
@@ -56,6 +56,16 @@ public:
 		return m_Trace;
 	}
 
+	/** Transfer handling of this exception to Python: set the appropriate
+	 * Python exception state (PyErr_Occurred() true on return).
+	 */
+	virtual void toPython() = 0;
+
+	/** Transfer handling of this exception to Java: throw the appropriate
+	 * Java exception on the current JNI frame.
+	 */
+	virtual void toJava() = 0;
+
 private:
 	JPStackTrace m_Trace;
 };
@@ -77,6 +87,9 @@ public:
 	{
 		return m_Throwable.get();
 	}
+
+	void toPython() override;
+	void toJava() override;
 
 private:
 	JPThrowableRef m_Throwable;
@@ -102,6 +115,9 @@ public:
 	{
 		return m_PyExcValue;
 	}
+
+	void toPython() override;
+	void toJava() override;
 
 private:
 	JPPyObject m_PyExcValue;
@@ -145,6 +161,9 @@ public:
 	{
 		return m_OSErrorCode;
 	}
+
+	void toPython() override;
+	void toJava() override;
 
 private:
 	void* m_PyExcType;

--- a/native/common/include/jp_error.h
+++ b/native/common/include/jp_error.h
@@ -1,0 +1,155 @@
+/*****************************************************************************
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   See NOTICE file for details.
+ *****************************************************************************/
+#ifndef _JP_ERROR_H_
+#define _JP_ERROR_H_
+
+/* Stage 1 of the exception-model split (see plan/ExceptionRefactor.md).
+ *
+ * These classes are the target replacement for JPypeException's single
+ * type-tag-plus-union design: one concrete C++ type per exception origin,
+ * so each type only carries (and only knows how to convert) the payload
+ * that is actually valid for it, instead of relying on convention/comments
+ * to track which union member and m_Type value go together.
+ *
+ * Not wired into any construction/catch site yet - introduced here purely
+ * to compile alongside the existing JPypeException while the migration is
+ * staged. See plan/ExceptionRefactor.md for the staged migration order.
+ */
+
+/**
+ * Shared base: the stack-trace bookkeeping (JP_CATCH's from()) that every
+ * origin needs, and nothing origin-specific.
+ */
+class JPBaseError : public std::runtime_error
+{
+public:
+	explicit JPBaseError(const std::string& msg, const JPStackInfo& stackInfo)
+	: std::runtime_error(msg)
+	{
+		from(stackInfo);
+	}
+
+	JPBaseError(const JPBaseError& ex) noexcept = default;
+	JPBaseError& operator=(const JPBaseError& ex) = default;
+	~JPBaseError() override = default;
+
+	void from(const JPStackInfo& info)
+	{
+		m_Trace.push_back(info);
+	}
+
+	const JPStackTrace& trace() const
+	{
+		return m_Trace;
+	}
+
+private:
+	JPStackTrace m_Trace;
+};
+
+/**
+ * A Java-originated exception: always carries the live jthrowable that was
+ * thrown. Converts to Python by wrapping/finding the matching Python
+ * exception class; converts to Java by rethrowing m_Throwable directly.
+ */
+class JPJavaError : public JPBaseError
+{
+public:
+	JPJavaError(JPJavaFrame& frame, jthrowable th, const JPStackInfo& stackInfo)
+	: JPBaseError(frame.toString(th), stackInfo), m_Throwable(frame, th)
+	{
+	}
+
+	jthrowable getThrowable() const
+	{
+		return m_Throwable.get();
+	}
+
+private:
+	JPThrowableRef m_Throwable;
+};
+
+/**
+ * A Python-originated exception. The exception is fetched and normalized
+ * at the moment of the throw (not left live on the thread state for the
+ * duration of the C++ unwind - see the equivalent note on JPypeException's
+ * m_PyExcValue for why), so this type's own invariant is: if constructed,
+ * an already-normalized instance is held. Converts to Python by restoring
+ * it directly; converts to Java via the existing convertPythonToJava path.
+ */
+class JPPythonError : public JPBaseError
+{
+public:
+	JPPythonError(JPPyObject excValue, const JPStackInfo& stackInfo)
+	: JPBaseError("Python exception", stackInfo), m_PyExcValue(std::move(excValue))
+	{
+	}
+
+	JPPyObject& value()
+	{
+		return m_PyExcValue;
+	}
+
+private:
+	JPPyObject m_PyExcValue;
+};
+
+/**
+ * Everything else JPype itself raises directly: a Python exception class
+ * plus message to install fresh (formerly _python_exc), or a startup-only
+ * OS error (formerly _os_error_unix/_os_error_windows). These don't have
+ * an existing external exception object to preserve - they are folded into
+ * one type rather than three, since none of them need the same live-object
+ * bookkeeping the two hot paths above do.
+ */
+class JPInternalError : public JPBaseError
+{
+public:
+	JPInternalError(void* pyExcType, const std::string& msg, const JPStackInfo& stackInfo)
+	: JPBaseError(msg, stackInfo), m_PyExcType(pyExcType), m_OSErrorCode(0), m_IsOSError(false)
+	{
+	}
+
+	// GCOVR_EXCL_START
+	// This constructor is only used during startup for OSError.
+	JPInternalError(const std::string& msg, int osErrorCode, const JPStackInfo& stackInfo)
+	: JPBaseError(msg, stackInfo), m_PyExcType(nullptr), m_OSErrorCode(osErrorCode), m_IsOSError(true)
+	{
+	}
+	// GCOVR_EXCL_STOP
+
+	void* getPyExcType() const
+	{
+		return m_PyExcType;
+	}
+
+	bool isOSError() const
+	{
+		return m_IsOSError;
+	}
+
+	int getOSErrorCode() const
+	{
+		return m_OSErrorCode;
+	}
+
+private:
+	void* m_PyExcType;
+	int m_OSErrorCode;
+	bool m_IsOSError;
+};
+
+#endif

--- a/native/common/include/jp_error.h
+++ b/native/common/include/jp_error.h
@@ -16,17 +16,12 @@
 #ifndef _JP_ERROR_H_
 #define _JP_ERROR_H_
 
-/* Stage 1 of the exception-model split (see plan/ExceptionRefactor.md).
- *
- * These classes are the target replacement for JPypeException's single
- * type-tag-plus-union design: one concrete C++ type per exception origin,
- * so each type only carries (and only knows how to convert) the payload
- * that is actually valid for it, instead of relying on convention/comments
- * to track which union member and m_Type value go together.
- *
- * Not wired into any construction/catch site yet - introduced here purely
- * to compile alongside the existing JPypeException while the migration is
- * staged. See plan/ExceptionRefactor.md for the staged migration order.
+/* The result of the exception-model split (see plan/ExceptionRefactor.md):
+ * one concrete C++ type per exception origin, replacing the single
+ * type-tag-plus-union design JPypeException used to have, so each type only
+ * carries (and only knows how to convert) the payload that is actually valid
+ * for it, instead of relying on convention/comments to track which union
+ * member and tag value go together.
  */
 
 /**
@@ -107,10 +102,13 @@ private:
 /**
  * A Python-originated exception. The exception is fetched and normalized
  * at the moment of the throw (not left live on the thread state for the
- * duration of the C++ unwind - see the equivalent note on JPypeException's
- * m_PyExcValue for why), so this type's own invariant is: if constructed,
- * an already-normalized instance is held. Converts to Python by restoring
- * it directly; converts to Java via the existing convertPythonToJava path.
+ * duration of the C++ unwind - a pending exception left on the thread state
+ * is visible to, and can be disturbed by, an incidental GC pass triggered
+ * anywhere during that unwind, so fetching claims sole ownership before
+ * anything else can touch it), so this type's own invariant is: if
+ * constructed, an already-normalized instance is held. Converts to Python
+ * by restoring it directly; converts to Java via the existing
+ * convertPythonToJava path.
  */
 class JPPythonError : public JPBaseError
 {

--- a/native/common/include/jp_error.h
+++ b/native/common/include/jp_error.h
@@ -66,6 +66,15 @@ public:
 	 */
 	virtual void toJava() = 0;
 
+	/** Put a captured Python exception back on the thread state, for
+	 * callers that need it live (e.g. to chain it as a cause) before they
+	 * finish handling this error themselves, rather than going through
+	 * toPython()/toJava(). No-op except on JPPythonError.
+	 */
+	virtual void restorePythonError()
+	{
+	}
+
 private:
 	JPStackTrace m_Trace;
 };
@@ -111,6 +120,20 @@ public:
 	{
 	}
 
+	/** Fetch and normalize the currently-pending Python exception off the
+	 * thread state right now, at the moment of the throw, rather than
+	 * leaving it live on the thread state for the whole C++ unwind - see
+	 * the class-level note above for why. Used by JP_RAISE_PYTHON().
+	 */
+	static JPPythonError fetch(const JPStackInfo& stackInfo)
+	{
+		JPPyErrFrame eframe;
+		eframe.normalize();
+		JPPyObject excValue = eframe.m_ExceptionValue;
+		eframe.clear();
+		return JPPythonError(std::move(excValue), stackInfo);
+	}
+
 	JPPyObject& value()
 	{
 		return m_PyExcValue;
@@ -118,6 +141,12 @@ public:
 
 	void toPython() override;
 	void toJava() override;
+
+	void restorePythonError() override
+	{
+		if (m_PyExcValue.get() != nullptr)
+			JPPyErr::restore(m_PyExcValue);
+	}
 
 private:
 	JPPyObject m_PyExcValue;

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -73,7 +73,7 @@ _os_error_windows,
 #define ASSERT_NOT_NULL(X) {if ((X)==NULL) { JP_RAISE(PyExc_RuntimeError,  "Null Pointer Exception");} }
 
 // Macro to add stack trace info when multiple paths lead to the same trouble spot
-#define JP_CATCH catch (JPypeException& ex) { ex.from(JP_STACKINFO()); throw; }
+#define JP_CATCH catch (JPBaseError& ex) { ex.from(JP_STACKINFO()); throw; }
 
 /** Structure to pass around the location within a C++ source file.
  */

--- a/native/common/include/jp_exception.h
+++ b/native/common/include/jp_exception.h
@@ -16,29 +16,12 @@
 #ifndef _JP_EXCEPTION_H_
 #define _JP_EXCEPTION_H_
 
-/* All exception are passed as JPypeException.  The type of the exception
- * is specified at creation.  Exceptions may be of type
- * - _java_error - exception generated from within java.
- * - _python_error - exception generated from within python.
- * - _runtime_error - Failure that will issue a runtime error in python and java.
- * - _type_error - Failure that will issue a type error in python.
- *
- * We must throw the correct exception so that it can properly be handled
- * when returning to the native code.
- *
- * If we are returning to python, and it is a
- * - _python_error, then the exception was fetched off the thread state and
- *   normalized at the moment of the throw (not left live on the thread state
- *   for the duration of the C++ unwind), and toPython()/toJava() restore it.
- * - _java_error, then we will convert it to a python object with the correct
- *   object type.
- * - otherwise, then we will convert it to the requested python error.
- *
- * If we are returning to java, and it is a
- * - _java_error, then we assume there is already a Java exception queue
- *   in the virtual machine.
- * - otherwise convert to a RuntimeException.
- *
+/* Stack-trace bookkeeping infrastructure shared by the JPBaseError hierarchy
+ * (see jp_error.h). This file used to also define JPypeException, the single
+ * mono-class every exception crossing the Java/Python/C++ boundary was
+ * carried as (see plan/ExceptionRefactor.md for the history) - that class
+ * has been fully replaced by JPJavaError/JPPythonError/JPInternalError and
+ * is gone; only the pieces they still depend on remain here.
  */
 #include <stdexcept>
 #ifndef __FUNCTION_NAME__
@@ -48,18 +31,6 @@
 #define __FUNCTION_NAME__   __func__
 #endif
 #endif
-
-/**
- * This is the type of the exception to issue.
- */
-enum JPError
-{
-_java_error,
-_python_error,
-_python_exc,
-_os_error_unix,
-_os_error_windows,
-};
 
 // Create a stackinfo for a particular location in the code that can then
 // be passed to the handler routine for auditing.
@@ -105,85 +76,5 @@ public:
 	}
 } ;
 using JPStackTrace = vector<JPStackInfo>;
-
-typedef union
-{
-    int  i;
-    void*  l;
-} JPErrorUnion;
-
-/**
- * Exception issued by JPype to indicate an internal problem.
- *
- * This is primarily focused on transferring exception handling
- * to Python as the majority of errors are reported there.
- *
- */
-class JPypeException : std::runtime_error
-{
-public:
-	JPypeException(JPJavaFrame &frame, jthrowable, const JPStackInfo& stackInfo);
-	JPypeException(int type, void* error, const JPStackInfo& stackInfo);
-	JPypeException(int type, void* error, const string& msn, const JPStackInfo& stackInfo);
-	JPypeException(int type, const string& msn, int error, const JPStackInfo& stackInfo);
-    // The copy constructor for an object thrown as an exception must be declared noexcept, including any implicitly-defined copy constructors.
-    // Any function declared noexcept that terminates by throwing an exception violates ERR55-CPP. Honor exception specifications.
-    JPypeException(const JPypeException &ex) noexcept;
-	JPypeException& operator = (const JPypeException& ex);
-	~JPypeException() override = default;
-
-	void from(const JPStackInfo& info);
-
-	void convertJavaToPython();
-	void convertPythonToJava();
-
-	/** Transfer handling of this exception to python.
-	 *
-	 * This should appear in the catch block whenever we return to python.
-	 *
-	 */
-	void toPython();
-
-	/** Transfer handling of this exception to java. */
-	void toJava();
-
-	/** Put a captured _python_error exception back on the thread state.
-	 *
-	 * For callers that need the original Python exception live (e.g. to
-	 * chain it as a cause) before they finish handling this JPypeException
-	 * themselves, rather than going through toPython()/toJava(). No-op for
-	 * any other exception type, or if there is nothing captured.
-	 */
-	void restorePythonError();
-
-	int getExceptionType() const
-	{
-		return m_Type;
-	}
-
-	jthrowable getThrowable()
-	{
-		return m_Throwable.get();
-	}
-
-private:
-	int m_Type;
-	JPErrorUnion m_Error{};
-	JPStackTrace m_Trace;
-	JPThrowableRef m_Throwable;
-	std::string m_Message;
-
-	// For _python_error only: the exception is fetched and normalized at the
-	// moment of the throw (see JP_RAISE_PYTHON), not left live on the thread
-	// state for the length of the C++ unwind. A pending exception left on the
-	// thread state is visible to, and can be disturbed by, an incidental GC
-	// pass triggered anywhere during that unwind - fetching claims sole
-	// ownership so nothing else can touch it before toPython()/toJava()
-	// restore it. Only the (already-normalized) instance is held - its class
-	// and traceback are recoverable from the instance itself at restore time
-	// (see JPPyErr::restore(JPPyObject&)), so there's no need to separately
-	// hold references to them too.
-	JPPyObject m_PyExcValue;
-};
 
 #endif

--- a/native/common/include/jp_javaframe.h
+++ b/native/common/include/jp_javaframe.h
@@ -62,7 +62,7 @@ public:
 	 * @param size determines how many objects can be
 	 * created in this scope without additional overhead.
 	 *
-	 * @throws JPypeException if the jpype cannot
+	 * @throws JPBaseError if the jpype cannot
 	 * acquire an env handle to work with jvm.
 	 */
 	static JPJavaFrame outer(int size = LOCAL_FRAME_DEFAULT)
@@ -76,7 +76,7 @@ public:
 	 * @param size determines how many objects can be
 	 * created in this scope without additional overhead.
 	 *
-	 * @throws JPypeException if the jpype cannot
+	 * @throws JPBaseError if the jpype cannot
 	 * acquire an env handle to work with jvm.
 	 */
 	static JPJavaFrame inner(int size = LOCAL_FRAME_DEFAULT)
@@ -91,7 +91,7 @@ public:
 	 * @param size determines how many objects can be
 	 * created in this scope without additional overhead.
 	 *
-	 * @throws JPypeException if the jpype cannot
+	 * @throws JPBaseError if the jpype cannot
 	 * acquire an env handle to work with jvm.
 	 */
 	static JPJavaFrame external(JNIEnv* env, int size = LOCAL_FRAME_DEFAULT)

--- a/native/common/include/jp_primitive_accessor.h
+++ b/native/common/include/jp_primitive_accessor.h
@@ -49,7 +49,7 @@ public:
 		{
 			if (_array)
 				((&_frame)->*_release)(_array, _elem, JNI_ABORT);
-		}		catch (JPypeException&) // GCOVR_EXCL_LINE
+		}		catch (...) // GCOVR_EXCL_LINE
 		{
 			// We can't throw here because it would abort.
 			// But this is called on a non-op release, so

--- a/native/common/include/jp_tracer.h
+++ b/native/common/include/jp_tracer.h
@@ -39,7 +39,7 @@
 #ifndef JP_INSTRUMENTATION
 #define JP_TRACE_IN(...) try { do {} while (0)
 #endif
-#define JP_TRACE_OUT } catch (JPypeException &ex) { ex.from(JP_STACKINFO()); throw; }
+#define JP_TRACE_OUT } catch (JPBaseError &ex) { ex.from(JP_STACKINFO()); throw; }
 #define JP_TRACE(...)
 #define JP_TRACE_LOCKS(...)
 #define JP_TRACE_PY(m, obj)
@@ -67,7 +67,7 @@ public:
 		try
 		{
 			throw; // lgtm [cpp/rethrow-no-exception]
-		} catch (JPypeException& ex)
+		} catch (JPBaseError& ex)
 		{
 			ex.from(info);
 			throw;

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -186,6 +186,7 @@ static inline JPPyObject JPPyTuple_Pack(T... args) {
 #include "jp_javaframe.h"
 #include "jp_context.h"
 #include "jp_exception.h"
+#include "jp_error.h"
 #include "jp_tracer.h"
 #include "jp_typemanager.h"
 #include "jp_encoding.h"

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -168,7 +168,7 @@ public:
 #define JP_RAISE_PYTHON()                   { throw JPypeException(JPError::_python_error, nullptr, JP_STACKINFO()); }
 #define JP_RAISE_OS_ERROR_UNIX(err, msg)    { throw JPypeException(JPError::_os_error_unix,  msg, err, JP_STACKINFO()); }
 #define JP_RAISE_OS_ERROR_WINDOWS(err, msg) { throw JPypeException(JPError::_os_error_windows,  msg, err, JP_STACKINFO()); }
-#define JP_RAISE(type, msg)                 { throw JPypeException(JPError::_python_exc, type, msg, JP_STACKINFO()); }
+#define JP_RAISE(type, msg)                 { throw JPInternalError(type, msg, JP_STACKINFO()); }
 
 #ifndef PyObject_HEAD
 struct _object;

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -166,8 +166,8 @@ public:
 //   maintain the appropriate auditing information.  C++ does not
 //   have a lot for facilities to make this easy.
 #define JP_RAISE_PYTHON()                   { throw JPPythonError::fetch(JP_STACKINFO()); }
-#define JP_RAISE_OS_ERROR_UNIX(err, msg)    { throw JPypeException(JPError::_os_error_unix,  msg, err, JP_STACKINFO()); }
-#define JP_RAISE_OS_ERROR_WINDOWS(err, msg) { throw JPypeException(JPError::_os_error_windows,  msg, err, JP_STACKINFO()); }
+#define JP_RAISE_OS_ERROR_UNIX(err, msg)    { throw JPInternalError(msg, err, JP_STACKINFO()); }
+#define JP_RAISE_OS_ERROR_WINDOWS(err, msg) { throw JPInternalError(msg, err, JP_STACKINFO()); }
 #define JP_RAISE(type, msg)                 { throw JPInternalError(type, msg, JP_STACKINFO()); }
 
 #ifndef PyObject_HEAD

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -47,7 +47,7 @@
 #if (_MSVC_LAND >= 201402)
 #define NO_EXCEPT_FALSE noexcept(false)
 #else
-#define NO_EXCEPT_FALSE throw(JPypeException)
+#define NO_EXCEPT_FALSE throw(JPBaseError)
 #endif
 
 #else
@@ -56,7 +56,7 @@
 #if (__cplusplus >= 201103L)
 #define NO_EXCEPT_FALSE noexcept(false)
 #else
-#define NO_EXCEPT_FALSE throw(JPypeException)
+#define NO_EXCEPT_FALSE throw(JPBaseError)
 #endif
 
 #endif

--- a/native/common/include/jpype.h
+++ b/native/common/include/jpype.h
@@ -165,7 +165,7 @@ public:
 //   These must be macros so that we can update the pattern and
 //   maintain the appropriate auditing information.  C++ does not
 //   have a lot for facilities to make this easy.
-#define JP_RAISE_PYTHON()                   { throw JPypeException(JPError::_python_error, nullptr, JP_STACKINFO()); }
+#define JP_RAISE_PYTHON()                   { throw JPPythonError::fetch(JP_STACKINFO()); }
 #define JP_RAISE_OS_ERROR_UNIX(err, msg)    { throw JPypeException(JPError::_os_error_unix,  msg, err, JP_STACKINFO()); }
 #define JP_RAISE_OS_ERROR_WINDOWS(err, msg) { throw JPypeException(JPError::_os_error_windows,  msg, err, JP_STACKINFO()); }
 #define JP_RAISE(type, msg)                 { throw JPInternalError(type, msg, JP_STACKINFO()); }

--- a/native/common/jp_booleantype.cpp
+++ b/native/common/jp_booleantype.cpp
@@ -328,7 +328,7 @@ void JPBooleanType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseBooleanArrayElements((jbooleanArray) view.m_Array->getJava(),
 				(jboolean*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_bytetype.cpp
+++ b/native/common/jp_bytetype.cpp
@@ -261,7 +261,7 @@ void JPByteType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseByteArrayElements((jbyteArray) view.m_Array->getJava(),
 				(jbyte*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -264,7 +264,7 @@ void JPCharType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseCharArrayElements((jcharArray) view.m_Array->getJava(),
 				(jchar*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -137,7 +137,7 @@ bool JPContext::isRunning()
 }
 
 /**
-	throw a JPypeException if the JVM is not started
+	throw a JPInternalError if the JVM is not started
  */
 void assertJVMRunning(JPContext* context, const JPStackInfo& info)
 {

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -179,15 +179,8 @@ void JPContext::startJVM(const string& vmPath, const StringVector& args,
 	m_ConvertStrings = convertStrings;
 
 	// Get the entry points in the shared library
-	try
-	{
-		JP_TRACE("Load entry points");
-		loadEntryPoints(vmPath);
-	} catch (JPypeException& ex)
-	{
-		(void) ex;
-		throw;
-	}
+	JP_TRACE("Load entry points");
+	loadEntryPoints(vmPath);
 
 	// Determine the memory requirements
 #define PAD(x) ((x+31)&~31)

--- a/native/common/jp_context.cpp
+++ b/native/common/jp_context.cpp
@@ -150,12 +150,12 @@ void assertJVMRunning(JPContext* context, const JPStackInfo& info)
 
 	if (context == nullptr)
 	{
-		throw JPypeException(JPError::_python_exc, _JVMNotRunning, "Java Context is null", info);
+		throw JPInternalError(_JVMNotRunning, "Java Context is null", info);
 	}
 
 	if (!context->isRunning())
 	{
-		throw JPypeException(JPError::_python_exc, _JVMNotRunning, "Java Virtual Machine is not running", info);
+		throw JPInternalError(_JVMNotRunning, "Java Virtual Machine is not running", info);
 	}
 }
 

--- a/native/common/jp_doubletype.cpp
+++ b/native/common/jp_doubletype.cpp
@@ -299,7 +299,7 @@ void JPDoubleType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseDoubleArrayElements((jdoubleArray) view.m_Array->getJava(),
 				(jdouble*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -117,10 +117,15 @@ bool isJavaThrowable(PyObject* exceptionClass)
 	return cls->isThrowable();
 }
 
-void JPypeException::convertJavaToPython()
+/** Shared conversion logic for a Java-originated exception, used by both the
+ * legacy JPypeException and JPJavaError - factored out so both stay backed
+ * by the exact same tested code path during the staged migration (see
+ * plan/ExceptionRefactor.md).
+ */
+void convertJavaToPython(jthrowable th)
 {
 	// Welcome to paranoia land, where they really are out to get you!
-	JP_TRACE_IN("JPypeException::convertJavaToPython");
+	JP_TRACE_IN("convertJavaToPython");
 	// GCOVR_EXCL_START
 	JPContext* context = JPContext_global;
 	if (context == nullptr)
@@ -132,7 +137,6 @@ void JPypeException::convertJavaToPython()
 
 	// Okay we can get to a frame to talk to the object
 	JPJavaFrame frame = JPJavaFrame::external(context->getEnv());
-	jthrowable th = m_Throwable.get();
 	jvalue v;
 	v.l = th;
 	// GCOVR_EXCL_START
@@ -211,9 +215,8 @@ void JPypeException::convertJavaToPython()
 		if (trace.get() != nullptr)
 			PyException_SetTraceback(cause.get(), trace.get());
 		PyException_SetCause(pyvalue.get(), cause.keep());
-	}	catch (JPypeException& ex)
+	}	catch (...)
 	{
-		(void) ex;
 		JP_TRACE("FAILURE IN CAUSE");
 		// Any failures in this optional action should be ignored.
 		// worst case we don't print as much diagnostics.
@@ -224,9 +227,19 @@ void JPypeException::convertJavaToPython()
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
-void JPypeException::convertPythonToJava()
+void JPypeException::convertJavaToPython()
 {
-	JP_TRACE_IN("JPypeException::convertPythonToJava");
+	::convertJavaToPython(m_Throwable.get());
+}
+
+/** Shared conversion logic for a Python-originated exception (already set
+ * on the thread state at call time). Factored out for the same reason as
+ * convertJavaToPython() above; mesg is only used for the extremely early
+ * startup fallback where no JPContext exists yet to build a real exception.
+ */
+void convertPythonToJava(const char* mesg)
+{
+	JP_TRACE_IN("convertPythonToJava");
 	JPJavaFrame frame = JPJavaFrame::outer();
 	JPContext *context = frame.getContext();
 	jthrowable th;
@@ -246,7 +259,7 @@ void JPypeException::convertPythonToJava()
 
 	if (context->m_Context_CreateExceptionID == nullptr)
 	{
-		frame.ThrowNew(frame.FindClass("java/lang/RuntimeException"), std::runtime_error::what());
+		frame.ThrowNew(frame.FindClass("java/lang/RuntimeException"), mesg);
 		return;
 	}
 
@@ -262,6 +275,11 @@ void JPypeException::convertPythonToJava()
 	eframe.clear();
 	frame.Throw(th);
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+void JPypeException::convertPythonToJava()
+{
+	::convertPythonToJava(what());
 }
 
 /**
@@ -524,6 +542,205 @@ void JPypeException::toJava()
 		// It is pointless, I can't go on.
 		reportFatalFailFast("An unexpected, non-Python error occurred while JPype was "
 				"converting a Python exception into its Java equivalent (JPypeException::toJava).");
+		int *i = nullptr;
+		*i = 0;
+		// GCOVR_EXCL_STOP
+	}
+	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+/** Shared "attach our C++ stack trace as the cause" tail behavior, common to
+ * every JPBaseError::toPython() except JPJavaError's (which already attaches
+ * its own Java-side cause inside convertJavaToPython()). Mirrors the tail of
+ * the legacy JPypeException::toPython() above.
+ */
+static void attachCppCause(const JPStackTrace& trace)
+{
+	if (!_jp_cpp_exceptions)
+		return;
+	JPPyErrFrame eframe;
+	eframe.normalize();
+	JPPyObject args = JPPyObject::call(Py_BuildValue("(s)", "C++ Exception"));
+	JPPyObject tb = JPPyObject::call(PyTrace_FromJPStackTrace(const_cast<JPStackTrace&>(trace)));
+	JPPyObject cause = JPPyObject::accept(PyObject_Call(PyExc_Exception, args.get(), nullptr));
+	// eframe.m_ExceptionValue can be null here - e.g. if the Python error
+	// state was already cleared by the time this runs (see
+	// JPPyErrFrame::normalize()'s own null-guard for the same class of
+	// issue) - PyException_SetCause requires a real exception instance as
+	// self and segfaults on null.
+	if (!cause.isNull() && eframe.m_ExceptionValue.get() != nullptr)
+	{
+		PyException_SetTraceback(cause.get(), tb.get());
+		PyException_SetCause(eframe.m_ExceptionValue.get(), cause.keep());
+	}
+}
+
+void JPJavaError::toPython()
+{
+	JP_TRACE_IN("JPJavaError::toPython");
+	try
+	{
+		if (PyErr_CheckSignals() != 0)
+			return;
+		if (PyErr_Occurred())
+			return;
+		convertJavaToPython(getThrowable());
+	} catch (...) // GCOVR_EXCL_LINE
+	{
+		// GCOVR_EXCL_START
+		JPTracer::trace("Fatal error in exception handling");
+		reportFatalFailFast("An unexpected error occurred while converting a Java exception "
+				"back to Python (JPJavaError::toPython).");
+		int *i = nullptr;
+		*i = 0;
+		// GCOVR_EXCL_STOP
+	}
+	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+void JPJavaError::toJava()
+{
+	JP_TRACE_IN("JPJavaError::toJava");
+	if (getThrowable() != nullptr)
+	{
+		JPContext* context = JPContext_global;
+		JPJavaFrame frame = JPJavaFrame::external(context->getEnv());
+		JP_TRACE("Java rethrow");
+		frame.Throw(getThrowable());
+	}
+	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+void JPPythonError::toPython()
+{
+	JP_TRACE_IN("JPPythonError::toPython");
+	try
+	{
+		if (PyErr_CheckSignals() != 0)
+			return;
+		if (PyErr_Occurred())
+			return;
+		// Restore the exception fetched and normalized at throw time (see
+		// JPPythonError's ctor / the equivalent note on JPypeException's
+		// m_PyExcValue) - it was deliberately held off the thread state for
+		// the whole unwind so no incidental GC pass could disturb it.
+		JPPyErr::restore(m_PyExcValue);
+		attachCppCause(trace());
+	} catch (...) // GCOVR_EXCL_LINE
+	{
+		// GCOVR_EXCL_START
+		JPTracer::trace("Fatal error in exception handling");
+		reportFatalFailFast("An unexpected error occurred while restoring a Python exception "
+				"(JPPythonError::toPython).");
+		int *i = nullptr;
+		*i = 0;
+		// GCOVR_EXCL_STOP
+	}
+	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+void JPPythonError::toJava()
+{
+	JP_TRACE_IN("JPPythonError::toJava");
+	try
+	{
+		JPPyCallAcquire callback;
+		// convertPythonToJava() expects to find the exception live on the
+		// thread state - restore what was fetched off it at throw time.
+		JPPyErr::restore(m_PyExcValue);
+		convertPythonToJava(what());
+	} catch (...) // GCOVR_EXCL_LINE
+	{
+		// GCOVR_EXCL_START
+		JPTracer::trace("Fatal error in exception handling");
+		reportFatalFailFast("An unexpected error occurred while JPype was converting a Python "
+				"exception into its Java equivalent (JPPythonError::toJava).");
+		int *i = nullptr;
+		*i = 0;
+		// GCOVR_EXCL_STOP
+	}
+	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+void JPInternalError::toPython()
+{
+	JP_TRACE_IN("JPInternalError::toPython");
+	try
+	{
+		if (PyErr_CheckSignals() != 0)
+			return;
+		if (PyErr_Occurred())
+			return;
+
+		const char* mesg = what();
+		if (isOSError())
+		{
+			// This section is only reachable during startup of the JVM.
+			// GCOVR_EXCL_START
+			std::stringstream ss;
+			ss << "JVM DLL not found: " << mesg;
+#ifdef WIN32
+			PyObject* val = Py_BuildValue("(izzi)", 2, ss.str().c_str(), NULL, getOSErrorCode());
+#else
+			PyObject* val = Py_BuildValue("(iz)", getOSErrorCode(), ss.str().c_str());
+#endif
+			if (val != nullptr)
+			{
+				PyObject* exc = PyObject_Call(PyExc_OSError, val, nullptr);
+				Py_DECREF(val);
+				if (exc != nullptr)
+				{
+					PyErr_SetObject(PyExc_OSError, exc);
+					Py_DECREF(exc);
+				}
+			}
+			// GCOVR_EXCL_STOP
+		} else
+		{
+			PyErr_SetString((PyObject*) getPyExcType(), mesg);
+		}
+
+		attachCppCause(trace());
+	} catch (...) // GCOVR_EXCL_LINE
+	{
+		// GCOVR_EXCL_START
+		JPTracer::trace("Fatal error in exception handling");
+		reportFatalFailFast("An unexpected error occurred while issuing a JPype-internal "
+				"exception (JPInternalError::toPython).");
+		int *i = nullptr;
+		*i = 0;
+		// GCOVR_EXCL_STOP
+	}
+	JP_TRACE_OUT; // GCOVR_EXCL_LINE
+}
+
+void JPInternalError::toJava()
+{
+	JP_TRACE_IN("JPInternalError::toJava");
+	try
+	{
+		JPContext* context = JPContext_global;
+		JPJavaFrame frame = JPJavaFrame::external(context->getEnv());
+		const char* mesg = what();
+		if (!isOSError())
+		{
+			JPPyCallAcquire callback;
+			PyErr_SetString((PyObject*) getPyExcType(), mesg);
+			convertPythonToJava(mesg);
+			return;
+		}
+		// GCOVR_EXCL_START
+		// OS errors are startup-only and never reach toJava() in practice
+		// (no JVM/JNI frame exists yet at that point) - issued as a
+		// RuntimeException for parity with the legacy fallback branch.
+		frame.ThrowNew(context->m_RuntimeException.get(), mesg);
+		// GCOVR_EXCL_STOP
+	} catch (...) // GCOVR_EXCL_LINE
+	{
+		// GCOVR_EXCL_START
+		JPTracer::trace("Fatal error in exception handling");
+		reportFatalFailFast("An unexpected error occurred while JPype was converting an "
+				"internal exception into its Java equivalent (JPInternalError::toJava).");
 		int *i = nullptr;
 		*i = 0;
 		// GCOVR_EXCL_STOP

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -20,94 +20,7 @@
 #include "jp_exception.h"
 #include "pyjp.h"
 
-static_assert(std::is_nothrow_copy_constructible<JPypeException>::value,
-              "S must be nothrow copy constructible");
-
 PyObject* PyTrace_FromJPStackTrace(JPStackTrace& trace);
-
-JPypeException::JPypeException(JPJavaFrame &frame, jthrowable th, const JPStackInfo& stackInfo)
-: std::runtime_error(frame.toString(th)),
-  m_Type(JPError::_java_error),
-  m_Throwable(frame, th)
-{
-	JP_TRACE("JAVA EXCEPTION THROWN with java throwable");
-	m_Error.l = nullptr;
-	from(stackInfo);
-}
-
-JPypeException::JPypeException(int type, void* error, const JPStackInfo& stackInfo)
-: std::runtime_error("None"), m_Type(type)
-{
-	JP_TRACE("EXCEPTION THROWN with error", error);
-	m_Error.l = error;
-	if (type == JPError::_python_error)
-	{
-		// Fetch and normalize the pending Python exception right now, at the
-		// moment of the throw, rather than leaving it live on the thread
-		// state for the whole C++ unwind (see m_PyExcValue in jp_exception.h
-		// for why). JPPyErrFrame::fetch() already removes it from the thread
-		// state; clear() below just stops its destructor from putting it
-		// straight back before we are ready for that in toPython()/toJava().
-		JPPyErrFrame eframe;
-		eframe.normalize();
-		m_PyExcValue = eframe.m_ExceptionValue;
-		eframe.clear();
-	}
-	from(stackInfo);
-}
-
-JPypeException::JPypeException(int type, void* errType, const string& msn, const JPStackInfo& stackInfo)
-: std::runtime_error(msn), m_Type(type)
-{
-	JP_TRACE("EXCEPTION THROWN", errType, msn);
-	m_Error.l = errType;
-	//m_Message = msn;
-	from(stackInfo);
-}
-
-// GCOVR_EXCL_START
-// This is only used during startup for OSError
-
-JPypeException::JPypeException(int type,  const string& msn, int errType, const JPStackInfo& stackInfo)
-: std::runtime_error(msn), m_Type(type)
-{
-	JP_TRACE("EXCEPTION THROWN", errType, msn);
-	m_Error.i = errType;
-	from(stackInfo);
-}
-
-JPypeException::JPypeException(const JPypeException &ex) noexcept
-        : runtime_error(ex.what()), m_Type(ex.m_Type),  m_Error(ex.m_Error),
-        m_Trace(ex.m_Trace), m_Throwable(ex.m_Throwable), m_PyExcValue(ex.m_PyExcValue)
-{
-}
-
-JPypeException& JPypeException::operator = (const JPypeException& ex)
-{
-	if(this == &ex)
-	{
-		return *this;
-	}
-	m_Type = ex.m_Type;
-	m_Trace = ex.m_Trace;
-	m_Throwable = ex.m_Throwable;
-	m_Error = ex.m_Error;
-	m_PyExcValue = ex.m_PyExcValue;
-	return *this;
-}
-// GCOVR_EXCL_STOP
-
-void JPypeException::from(const JPStackInfo& info)
-{
-	JP_TRACE("EXCEPTION FROM: ", info.getFile(), info.getLine());
-	m_Trace.push_back(info);
-}
-
-void JPypeException::restorePythonError()
-{
-	if (m_Type == JPError::_python_error && m_PyExcValue.get() != nullptr)
-		JPPyErr::restore(m_PyExcValue);
-}
 
 bool isJavaThrowable(PyObject* exceptionClass)
 {
@@ -117,10 +30,8 @@ bool isJavaThrowable(PyObject* exceptionClass)
 	return cls->isThrowable();
 }
 
-/** Shared conversion logic for a Java-originated exception, used by both the
- * legacy JPypeException and JPJavaError - factored out so both stay backed
- * by the exact same tested code path during the staged migration (see
- * plan/ExceptionRefactor.md).
+/** Shared conversion logic for a Java-originated exception, used by
+ * JPJavaError::toPython().
  */
 void convertJavaToPython(jthrowable th)
 {
@@ -227,14 +138,9 @@ void convertJavaToPython(jthrowable th)
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
-void JPypeException::convertJavaToPython()
-{
-	::convertJavaToPython(m_Throwable.get());
-}
-
 /** Shared conversion logic for a Python-originated exception (already set
- * on the thread state at call time). Factored out for the same reason as
- * convertJavaToPython() above; mesg is only used for the extremely early
+ * on the thread state at call time), used by JPPythonError::toJava() and
+ * JPInternalError::toJava(). mesg is only used for the extremely early
  * startup fallback where no JPContext exists yet to build a real exception.
  */
 void convertPythonToJava(const char* mesg)
@@ -277,14 +183,9 @@ void convertPythonToJava(const char* mesg)
 	JP_TRACE_OUT; // GCOVR_EXCL_LINE
 }
 
-void JPypeException::convertPythonToJava()
-{
-	::convertPythonToJava(what());
-}
-
 /**
  * Print a user-facing crash banner for the deliberate fail-fast crashes
- * below (JPypeException::toPython/toJava's catch blocks).
+ * below (each JPBaseError subclass's toPython()/toJava() catch(...) blocks).
  *
  * These crashes fire only when JPype's own exception-conversion code -
  * which is not allowed to fail - fails anyway, leaving interpreter/JNI
@@ -323,236 +224,9 @@ static void reportFatalFailFast(const char* detail)
 }
 // GCOVR_EXCL_STOP
 
-void JPypeException::toPython()
-{
-	const char* mesg = nullptr;
-	JP_TRACE_IN("JPypeException::toPython");
-	JP_TRACE("err", PyErr_Occurred());
-	try
-	{
-		// Check the signals before processing the exception
-		// It may be a signal when interrupted Java in which case
-		// the signal takes precedence.
-		if (PyErr_CheckSignals()!=0)
-			return;
-
-		mesg = std::runtime_error::what();
-		JP_TRACE(m_Error.l);
-		JP_TRACE(mesg);
-
-		// We already have a Python error on the stack.
-		if (PyErr_Occurred())
-			return;
-
-		if (m_Type == JPError::_java_error)
-		{
-			JP_TRACE("Java exception");
-			JPypeException::convertJavaToPython();
-			return;
-		} else if (m_Type == JPError::_python_error)
-		{
-			// Restore the exception fetched and normalized at the moment of
-			// the throw (see JPypeException's _python_error ctor). It was
-			// deliberately held off the thread state for the whole unwind so
-			// no incidental GC pass during that window could disturb it.
-			JPPyErr::restore(m_PyExcValue);
-		}// This section is only reachable during startup of the JVM.
-			// GCOVR_EXCL_START
-		else if (m_Type == JPError::_os_error_unix)
-		{
-			std::stringstream ss;
-			ss << "JVM DLL not found: " << mesg;
-			PyObject* val = Py_BuildValue("(iz)", m_Error.i,
-					ss.str().c_str());
-			if (val != nullptr)
-			{
-				PyObject* exc = PyObject_Call(PyExc_OSError, val, nullptr);
-				Py_DECREF(val);
-				if (exc != nullptr)
-				{
-					PyErr_SetObject(PyExc_OSError, exc);
-					Py_DECREF(exc);
-				}
-			}
-		} else if (m_Type == JPError::_os_error_windows)
-		{
-			std::stringstream ss;
-			ss << "JVM DLL not found: " << mesg;
-			PyObject* val = Py_BuildValue("(izzi)", 2,
-					ss.str().c_str(), NULL, m_Error.i);
-			if (val != nullptr)
-			{
-				PyObject* exc = PyObject_Call(PyExc_OSError, val, nullptr);
-				Py_DECREF(val);
-				if (exc != nullptr)
-				{
-					PyErr_SetObject(PyExc_OSError, exc);
-					Py_DECREF(exc);
-				}
-			}
-		}// GCOVR_EXCL_STOP
-
-		else if (m_Type == JPError::_python_exc)
-		{
-			// All others are Python errors
-			JP_TRACE(Py_TYPE(m_Error.l)->tp_name);
-			PyErr_SetString((PyObject*) m_Error.l, mesg);
-		} else
-		{
-			// This should not be possible unless we failed to cover one of the
-			// exception type codes.
-			JP_TRACE("Unknown error");
-			PyErr_SetString(PyExc_RuntimeError, mesg); // GCOVR_EXCL_LINE
-		}
-
-		// Attach our info as the cause
-		if (_jp_cpp_exceptions)
-		{
-			JPPyErrFrame eframe;
-			eframe.normalize();
-			JPPyObject args = JPPyObject::call(Py_BuildValue("(s)", "C++ Exception"));
-			JPPyObject trace = JPPyObject::call(PyTrace_FromJPStackTrace(m_Trace));
-			JPPyObject cause = JPPyObject::accept(PyObject_Call(PyExc_Exception, args.get(), nullptr));
-			// eframe.m_ExceptionValue can be null here - e.g. if the Python
-			// error state was already cleared by the time this runs (see
-			// JPPyErrFrame::normalize()'s own null-guard for the same class
-			// of issue) - PyException_SetCause requires a real exception
-			// instance as self and segfaults on null.
-			if (!cause.isNull() && eframe.m_ExceptionValue.get() != nullptr)
-			{
-				PyException_SetTraceback(cause.get(), trace.get());
-				PyException_SetCause(eframe.m_ExceptionValue.get(), cause.keep());
-			}
-		}
-	}// GCOVR_EXCL_START
-	catch (JPypeException& ex)
-	{
-		// Print our parting words
-		JPTracer::trace("Fatal error in exception handling");
-		JPTracer::trace("Handling:", mesg);
-		JPTracer::trace("Type:", m_Error.l);
-		if (ex.m_Type == JPError::_python_error)
-		{
-			// The inner exception was captured off the thread state at its
-			// own throw time (see JPypeException's _python_error ctor), not
-			// left sitting on the stack - trace from, then restore, the
-			// captured state directly rather than fetching.
-			JPTracer::trace("Inner Python:", ex.m_PyExcValue.get() != nullptr
-					? Py_TYPE(ex.m_PyExcValue.get())->tp_name : "(none!)");
-			JPPyErr::restore(ex.m_PyExcValue);
-			return;  // Let these go to Python, so we can see the error
-		} else if (ex.m_Type == JPError::_java_error)
-			JPTracer::trace("Inner Java:", ex.what());
-		else
-			JPTracer::trace("Inner:", ex.what());
-
-		JPStackInfo info = ex.m_Trace.front();
-		JPTracer::trace(info.getFile(), info.getFunction(), info.getLine());
-
-		// Heghlu'meH QaQ jajvam!
-		PyErr_SetString(PyExc_RuntimeError, "Fatal error occurred");
-		return;
-	} catch (...)
-	{
-		// urp?!
-		JPTracer::trace("Fatal error in exception handling");
-
-		// You shall not pass!
-		reportFatalFailFast("An unexpected error occurred while converting a Java exception "
-				"back to Python (JPypeException::toPython).");
-		int *i = nullptr;
-		*i = 0;
-	}
-	// GCOVR_EXCL_STOP
-	JP_TRACE_OUT; // GCOVR_EXCL_LINE
-}
-
-void JPypeException::toJava()
-{
-	JP_TRACE_IN("JPypeException::toJava");
-	JPContext* context = JPContext_global;
-	try
-	{
-		const char* mesg = what();
-		JPJavaFrame frame = JPJavaFrame::external(context->getEnv());
-		if (m_Type == JPError::_java_error)
-		{
-			JP_TRACE("Java exception");
-			//JP_TRACE(context->toString((jobject) frame.ExceptionOccurred()));
-			if (m_Throwable.get() != 0)
-			{
-				JP_TRACE("Java rethrow");
-				frame.Throw(m_Throwable.get());
-				return;
-			}
-			return;
-		}
-
-		if (m_Type == JPError::_python_error)
-		{
-			JPPyCallAcquire callback;
-			JP_TRACE("Python exception");
-			// Restore what was fetched off the thread state at throw time
-			// (see JPypeException's _python_error ctor) - convertPythonToJava()
-			// expects to find the exception live on the thread state.
-			JPPyErr::restore(m_PyExcValue);
-			convertPythonToJava();
-			return;
-		}
-
-		if (m_Type == JPError::_python_exc)
-		{
-			JPPyCallAcquire callback;
-			// All others are Python errors
-			JP_TRACE(Py_TYPE(m_Error.l)->tp_name);
-			PyErr_SetString((PyObject*) m_Error.l, mesg);
-			convertPythonToJava();
-			return;
-		}
-
-		// All others are issued as RuntimeExceptions
-		JP_TRACE("String exception");
-		frame.ThrowNew(context->m_RuntimeException.get(), mesg);
-		return;
-	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
-	{	// GCOVR_EXCL_START
-		// Print our parting words.
-		JPTracer::trace("Fatal error in exception handling");
-		JPStackInfo info = ex.m_Trace.front();
-		JPTracer::trace(info.getFile(), info.getFunction(), info.getLine());
-
-		// Take one for the team.
-		{
-			std::stringstream detail;
-			detail << "A second error (\"" << ex.what() << "\") occurred while JPype was "
-					"converting a Python exception into its Java equivalent, at "
-					<< info.getFile() << ":" << info.getFunction() << ":" << info.getLine()
-					<< " (JPypeException::toJava).";
-			reportFatalFailFast(detail.str().c_str());
-		}
-		int *i = nullptr;
-		*i = 0;
-		// GCOVR_EXCL_STOP
-	} catch (...) // GCOVR_EXCL_LINE
-	{
-		// GCOVR_EXCL_START
-		// urp?!
-		JPTracer::trace("Fatal error in exception handling");
-
-		// It is pointless, I can't go on.
-		reportFatalFailFast("An unexpected, non-Python error occurred while JPype was "
-				"converting a Python exception into its Java equivalent (JPypeException::toJava).");
-		int *i = nullptr;
-		*i = 0;
-		// GCOVR_EXCL_STOP
-	}
-	JP_TRACE_OUT; // GCOVR_EXCL_LINE
-}
-
 /** Shared "attach our C++ stack trace as the cause" tail behavior, common to
  * every JPBaseError::toPython() except JPJavaError's (which already attaches
- * its own Java-side cause inside convertJavaToPython()). Mirrors the tail of
- * the legacy JPypeException::toPython() above.
+ * its own Java-side cause inside convertJavaToPython()).
  */
 static void attachCppCause(const JPStackTrace& trace)
 {
@@ -621,9 +295,9 @@ void JPPythonError::toPython()
 		if (PyErr_Occurred())
 			return;
 		// Restore the exception fetched and normalized at throw time (see
-		// JPPythonError's ctor / the equivalent note on JPypeException's
-		// m_PyExcValue) - it was deliberately held off the thread state for
-		// the whole unwind so no incidental GC pass could disturb it.
+		// JPPythonError::fetch()) - it was deliberately held off the thread
+		// state for the whole unwind so no incidental GC pass could disturb
+		// it.
 		JPPyErr::restore(m_PyExcValue);
 		attachCppCause(trace());
 	} catch (...) // GCOVR_EXCL_LINE

--- a/native/common/jp_floattype.cpp
+++ b/native/common/jp_floattype.cpp
@@ -285,7 +285,7 @@ void JPFloatType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseFloatArrayElements((jfloatArray) view.m_Array->getJava(),
 				(jfloat*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_inttype.cpp
+++ b/native/common/jp_inttype.cpp
@@ -288,7 +288,7 @@ void JPIntType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseIntArrayElements((jintArray) view.m_Array->getJava(),
 				(jint*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_javaframe.cpp
+++ b/native/common/jp_javaframe.cpp
@@ -229,7 +229,7 @@ void JPJavaFrame::check()
 		JP_TRACE_JAVA("ExceptionOccurred", th);
 		m_Env->ExceptionClear();
 		JP_TRACE_JAVA("ExceptionClear", 0);
-		throw JPypeException(*this, th, JP_STACKINFO());
+		throw JPJavaError(*this, th, JP_STACKINFO());
 	}
 }
 
@@ -1088,7 +1088,7 @@ public:
 		try
 		{
 			frame_.ReleaseStringUTFChars(jstr_, cstr);
-		}		catch (JPypeException&)
+		}		catch (...)
 		{
 			// Error during release must be eaten.
 			// If Java does not accept a release of the buffer it

--- a/native/common/jp_longtype.cpp
+++ b/native/common/jp_longtype.cpp
@@ -287,7 +287,7 @@ void JPLongType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseLongArrayElements((jlongArray) view.m_Array->getJava(),
 				(jlong*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -142,6 +142,10 @@ extern "C" JNIEXPORT jobject JNICALL Java_org_jpype_proxy_JPypeProxy_hostInvoke(
 			JP_TRACE("Convert return to", returnClass->getCanonicalName());
 			jvalue res = returnMatch.convert();
 			return frame.keep(res.l);
+		} catch (JPBaseError& ex)
+		{
+			JP_TRACE("JPBaseError raised");
+			ex.toJava();
 		} catch (JPypeException& ex)
 		{
 			JP_TRACE("JPypeException raised");
@@ -195,7 +199,7 @@ JPProxy::~JPProxy()
 		{
 			JPContext_global->getEnv()->DeleteWeakGlobalRef(m_Ref);
 		}
-	} catch (JPypeException &ex)  // GCOVR_EXCL_LINE
+	} catch (...)  // GCOVR_EXCL_LINE
 	{
 		// Cannot throw
 	}

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -146,10 +146,6 @@ extern "C" JNIEXPORT jobject JNICALL Java_org_jpype_proxy_JPypeProxy_hostInvoke(
 		{
 			JP_TRACE("JPBaseError raised");
 			ex.toJava();
-		} catch (JPypeException& ex)
-		{
-			JP_TRACE("JPypeException raised");
-			ex.toJava();
 		} catch (...)  // GCOVR_EXCL_LINE
 		{
 			JP_TRACE("Other Exception raised");

--- a/native/common/jp_shorttype.cpp
+++ b/native/common/jp_shorttype.cpp
@@ -284,7 +284,7 @@ void JPShortType::releaseView(JPArrayView& view)
 		JPJavaFrame frame = JPJavaFrame::outer();
 		frame.ReleaseShortArrayElements((jshortArray) view.m_Array->getJava(),
 				(jshort*) view.m_Memory, view.m_Buffer.readonly ? JNI_ABORT : 0);
-	}	catch (JPypeException&)
+	}	catch (...)
 	{
 		// This is called as part of the cleanup routine and exceptions
 		// are not permitted

--- a/native/common/jp_typefactory.cpp
+++ b/native/common/jp_typefactory.cpp
@@ -48,9 +48,6 @@ void JPTypeFactory_rethrow(JPJavaFrame& frame)
 	} catch (JPBaseError& ex)
 	{
 		ex.toJava();
-	} catch (JPypeException& ex)
-	{
-		ex.toJava();
 	} catch (...)  // GCOVR_EXCL_LINE
 	{
 		// GCOVR_EXCL_START

--- a/native/common/jp_typefactory.cpp
+++ b/native/common/jp_typefactory.cpp
@@ -45,6 +45,9 @@ void JPTypeFactory_rethrow(JPJavaFrame& frame)
 	try
 	{
 		throw;
+	} catch (JPBaseError& ex)
+	{
+		ex.toJava();
 	} catch (JPypeException& ex)
 	{
 		ex.toJava();

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -303,10 +303,9 @@ int PyJPArray_getBuffer(PyJPArray *self, Py_buffer *view, int flags)
 	{
 		// Collect the members into a rectangular array if possible.
 		result = frame.collectRectangular(obj);
-	} catch (JPypeException &ex)
+	} catch (...)
 	{
 		// No matter what happens we are only allowed to throw BufferError
-		(void) ex;
 		PyErr_SetString(PyExc_BufferError, "Problem in Java buffer extraction");
 		return -1;
 	}
@@ -342,9 +341,8 @@ int PyJPArray_getBuffer(PyJPArray *self, Py_buffer *view, int flags)
 		view->obj = (PyObject*) self;
 		Py_INCREF(view->obj);
 		return 0;
-	} catch (JPypeException &ex) // GCOVR_EXCL_LINE
+	} catch (...) // GCOVR_EXCL_LINE
 	{
-		(void) ex;
 		// GCOVR_EXCL_START
 		// Release the partial buffer so we don't leak
 		PyJPArray_releaseBuffer(self, view);
@@ -403,9 +401,8 @@ int PyJPArrayPrimitive_getBuffer(PyJPArray *self, Py_buffer *view, int flags)
 		view->obj = (PyObject*) self;
 		Py_INCREF(view->obj);
 		return 0;
-	} catch (JPypeException &ex)
+	} catch (...)
 	{
-		(void) ex;
 		PyJPArray_releaseBuffer(self, view);
 
 		// We are only allowed to raise BufferError

--- a/native/python/pyjp_buffer.cpp
+++ b/native/python/pyjp_buffer.cpp
@@ -96,9 +96,8 @@ int PyJPBuffer_getBuffer(PyJPBuffer *self, Py_buffer *view, int flags)
 		view->obj = (PyObject*) self;
 		Py_INCREF(view->obj);
 		return 0;
-	} catch (JPypeException &ex)  // GCOVR_EXCL_LINE
+	} catch (...)  // GCOVR_EXCL_LINE
 	{
-		(void) ex;
 		// GCOVR_EXCL_START
 		PyJPBuffer_releaseBuffer(self, view);
 

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -143,13 +143,6 @@ void PyJPModule_loadResources(PyObject* module)
 		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
 		JP_RAISE_PYTHON();
 		// GCOVR_EXCL_STOP
-	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
-	{
-		// GCOVR_EXCL_START
-		ex.restorePythonError();
-		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
-		JP_RAISE_PYTHON();
-		// GCOVR_EXCL_STOP
 	}
 }
 
@@ -896,11 +889,6 @@ void PyJPModule_rethrow(const JPStackInfo& info)
 	{
 		throw;
 	} catch (JPBaseError& ex)
-	{
-		ex.from(info); // this likely wont be necessary, but for now we will add the entry point.
-		ex.toPython();
-		return;
-	} catch (JPypeException& ex)
 	{
 		ex.from(info); // this likely wont be necessary, but for now we will add the entry point.
 		ex.toPython();

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -888,6 +888,11 @@ void PyJPModule_rethrow(const JPStackInfo& info)
 	try
 	{
 		throw;
+	} catch (JPBaseError& ex)
+	{
+		ex.from(info); // this likely wont be necessary, but for now we will add the entry point.
+		ex.toPython();
+		return;
 	} catch (JPypeException& ex)
 	{
 		ex.from(info); // this likely wont be necessary, but for now we will add the entry point.

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -132,13 +132,20 @@ void PyJPModule_loadResources(PyObject* module)
 
 		_JObjectKey = PyCapsule_New(module, "constructor key", nullptr);
 
-	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
+	}	catch (JPBaseError& ex)  // GCOVR_EXCL_LINE
 	{
 		// GCOVR_EXCL_START
 		// PyJP_SetStringWithCause needs the original exception live on the
 		// thread state to chain it as a cause - restorePythonError() puts
 		// back what our throw-time-fetch fix (see jp_exception.cpp) deliberately
 		// held privately instead of leaving pending for the whole unwind.
+		ex.restorePythonError();
+		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
+		JP_RAISE_PYTHON();
+		// GCOVR_EXCL_STOP
+	}	catch (JPypeException& ex)  // GCOVR_EXCL_LINE
+	{
+		// GCOVR_EXCL_START
 		ex.restorePythonError();
 		PyJP_SetStringWithCause(PyExc_RuntimeError, "JPype resource is missing");
 		JP_RAISE_PYTHON();

--- a/native/python/pyjp_package.cpp
+++ b/native/python/pyjp_package.cpp
@@ -172,23 +172,6 @@ static PyObject *PyJPPackage_getattro(PyObject *self, PyObject *attr)
 			Py_DECREF(rc); // GCOVR_EXCL_LINE
 		}
 		throw; // GCOVR_EXCL_LINE
-	}		catch (JPypeException& ex)
-	{
-		JPPyObject h = JPPyObject::accept(PyObject_GetAttrString(self, "_handler"));
-		// If something fails, we need to go to a handler
-		if (!h.isNull())
-		{
-			ex.toPython();
-			JPPyErrFrame err;
-			err.normalize();
-			err.clear();
-			JPPyObject tuple0 = JPPyTuple_Pack(self, attr, err.m_ExceptionValue.get());
-			PyObject *rc = PyObject_Call(h.get(), tuple0.get(), nullptr);
-			if (rc == nullptr)
-				return nullptr;
-			Py_DECREF(rc); // GCOVR_EXCL_LINE
-		}
-		throw; // GCOVR_EXCL_LINE
 	}
 	if (obj == nullptr)
 	{

--- a/native/python/pyjp_package.cpp
+++ b/native/python/pyjp_package.cpp
@@ -155,6 +155,23 @@ static PyObject *PyJPPackage_getattro(PyObject *self, PyObject *attr)
 	try
 	{
 		obj = frame.getPackageObject(pkg, attrName);
+	}		catch (JPBaseError& ex)
+	{
+		JPPyObject h = JPPyObject::accept(PyObject_GetAttrString(self, "_handler"));
+		// If something fails, we need to go to a handler
+		if (!h.isNull())
+		{
+			ex.toPython();
+			JPPyErrFrame err;
+			err.normalize();
+			err.clear();
+			JPPyObject tuple0 = JPPyTuple_Pack(self, attr, err.m_ExceptionValue.get());
+			PyObject *rc = PyObject_Call(h.get(), tuple0.get(), nullptr);
+			if (rc == nullptr)
+				return nullptr;
+			Py_DECREF(rc); // GCOVR_EXCL_LINE
+		}
+		throw; // GCOVR_EXCL_LINE
 	}		catch (JPypeException& ex)
 	{
 		JPPyObject h = JPPyObject::accept(PyObject_GetAttrString(self, "_handler"));


### PR DESCRIPTION
Body:

## Depends on #1448

This branch is built on top of #1448 (shutdown-signal-handler fix) and
includes its commits. Please review/merge #1448 first — once it lands,
this diff will shrink to just the 7 commits below. Until then, ignore
`64023929`..`61c7d7b5` in the commit list; they belong to that PR.

## What

Replaces `JPypeException` — the single C++ class every exception crossing
the Java/Python/C++ boundary was carried as, tagged with a `JPError` enum
and a `void*`/`int` union payload — with one concrete type per exception
origin:

- `JPBaseError` — shared stack-trace bookkeeping, abstract `toPython()`/`toJava()`
- `JPJavaError` — a live `jthrowable`
- `JPPythonError` — an already-fetched, normalized Python exception
- `JPInternalError` — everything JPype raises directly (`JP_RAISE`, plus
  the startup-only OS-error paths)

Each type only carries (and only knows how t
for its own origin, instead of relying on comments to track which union
member goes with which tag value.

## Why

The tag-plus-union design directly contribut
project spent multiple days chasing (#1415, the GC-reentrancy crash, and
its `PyJP_SetStringWithCause` follow-on): `J
`_python_error`-tagged exception without an explicit type backing the
invariant "this holds an already-fetched Pyt
invariant existed only in a comment. A dedicated `JPPythonError` type
makes it a compile-time-checkable question i

## How it was done

Staged across 6 commits, each independently
test suite + a GC-reentrancy soak test (`project/bugs/gc_exception_race_soak.py`,
900+ iterations per stage) in an isolated ve

1. `10738693` — introduce the new classes, u
   `JPypeException`.
2. `dfd35fac`, `bf1bccd9`, `a07b802c` — migr
   (the `JP_RAISE*` macros and two direct throws) onto the new hierarchy.
3. `a987b918` — retarget the trace/stack-ann
   now-dead `catch (JPypeException&)` sites.
4. `7b126e53` — delete `JPypeException` once

**One real deviation from the original stagi
for review**: migrating the two hottest construction sites
(`JP_RAISE_PYTHON()` and `JPJavaFrame::check
call) ahead of schedule broke real functionality — proxy Java-calls-Python
dispatch and module resource loading both st
"unknown error occurred" instead of the real exception. Caught by the full
suite, not by inspection. Root cause: those
of the ~27 *scattered* direct `catch (JPypeException&)` sites (destructors,
buffer-protocol callbacks, resource cleanup)
two central "funnel" points. Fixed by migrating the affected catch sites
in the same commit (`bf1bccd9`) rather than
intermediate state.

## Test plan

- [x] Full suite green at every commit (1676/172 baseline, unchanged
      throughout; 1679/172 after picking up
      on rebase)
- [x] GC-reentrancy soak test clean at every
      no corruption)
- [x] Built and tested from a fresh clone in
      incrementally
- [x] `grep -rn "JPypeException"` returns no
      comments
- No user-facing behavior change; internal-o