### PR TITLE
Codescan

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,7 +213,7 @@ html_theme = 'default'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
+    import sphinx_rtd_theme  # import-for-side-effect: registers the theme with Sphinx  # lgtm[py/unused-import]
     html_theme = 'sphinx_rtd_theme'
 
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -213,7 +213,9 @@ html_theme = 'default'
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme  # import-for-side-effect: registers the theme with Sphinx  # lgtm[py/unused-import]
+    # import-for-side-effect: registers the theme with Sphinx
+    # codeql[py/unused-import]
+    import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
 
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it

--- a/doc/java/lang.py
+++ b/doc/java/lang.py
@@ -32,4 +32,5 @@ class AutoCloseable:
         # Input stream closes at the end of the block.
 
     """
-    ...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    ...

--- a/doc/java/lang.py
+++ b/doc/java/lang.py
@@ -32,4 +32,4 @@ class AutoCloseable:
         # Input stream closes at the end of the block.
 
     """
-    ...
+    ...  # lgtm[py/ineffectual-statement]

--- a/doc/java/util.py
+++ b/doc/java/util.py
@@ -1,4 +1,3 @@
-import jpype
 from typing import Union
 
 

--- a/doc/java/util.py
+++ b/doc/java/util.py
@@ -10,7 +10,8 @@ class Iterable:
 
     def __iter__(self):
         """ Iterate over the members on this collect. """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
 
 class Collection:
@@ -26,11 +27,13 @@ class Collection:
         collection.
 
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __delitem__(self, item):
         """ Collections do not support remove by index. """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __contains__(self, item) -> bool:
         """ Check if this collection contains this item.
@@ -46,7 +49,8 @@ class Collection:
         Returns:
            bool: True if the item is in the collection.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
 
 class List(Collection):
@@ -64,7 +68,8 @@ class List(Collection):
         alter the original list.  Slice stepping is not supported for Java
         lists.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __setitem__(self, index: Union[int, slice], value):
         """ Set an item on the list.
@@ -73,7 +78,8 @@ class List(Collection):
         ``list[i0:i1] = values`` to replace a section of a list with
         another list of values.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __delitem__(self, idx: Union[int, slice]):
         """ Delete an item by index.
@@ -81,14 +87,16 @@ class List(Collection):
         Use ``del list[idx]`` to remove ont itme from the list or
         ``del list[i0:i1]`` to remove a section of the list.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __reversed__(self):
         """ Obtain an iterator that walks the list in reverse order.
 
         Use ``reversed(list)`` to traverse a list backwards.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def index(self, obj) -> int:
         """ Find the index that an item appears.
@@ -103,7 +111,8 @@ class List(Collection):
         Raises:
            ValueError: If the item is not on the list.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def count(self, obj):
         """ Count the number of times an object appears in a list.
@@ -115,7 +124,8 @@ class List(Collection):
         Returns:
             int: The number of times this object appears.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def insert(self, idx: int, obj):
         """ Insert an object at a specific position.
@@ -127,7 +137,8 @@ class List(Collection):
         Raises:
             TypeError: If the object cannot be converted to Java.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def append(self, obj):
         """ Append an object to the list.
@@ -138,7 +149,8 @@ class List(Collection):
         Raises:
             TypeError: If the object cannot be converted to Java.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def reverse(self):
         """ Reverse the order of the list in place.
@@ -155,7 +167,8 @@ class List(Collection):
         Raises:
            TypeError: If the list to be added cannot be converted to Java.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def pop(self, idx=-1):
         """ Remove an item from the list.
@@ -167,7 +180,8 @@ class List(Collection):
         Returns:
            The item or raises if index is outside of the list.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __iadd__(self, obj):
         """ Add an items to the end of the list.
@@ -175,7 +189,8 @@ class List(Collection):
         Use ``list += obj`` to append one item.  This is simply an alias
         for add.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __add__(self, obj):
         """ Combine two lists.
@@ -183,7 +198,8 @@ class List(Collection):
         Use ``list + seq`` to create a new list with additional members.
         This is only supported if the list can be cloned.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def remove(self, obj):
         """ Remove an item from the list by finding the first
@@ -199,7 +215,8 @@ class List(Collection):
         Raises:
             ValueError: If the item is not present on the list.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
 
 class Map:
@@ -214,12 +231,14 @@ class Map:
 
         Use ``len(map)`` to get the number of items in the map.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __iter__(self):
         """ Iterate the keys of the map.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __delitem__(self, i):
         """ Remove an item by its key.
@@ -227,7 +246,8 @@ class Map:
         Raises:
            TypeError: If the key cannot be converted to Java.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __getitem__(self, ndx):
         """ Get a value by its key.
@@ -238,7 +258,8 @@ class Map:
            KeyError: If the key is not found in the map or the key
              cannot be converted to Java.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __setitem__(self, key, value):
         """ Set a value associated with a key..
@@ -248,7 +269,8 @@ class Map:
         Raises:
            TypeError: If the key or value cannot be converted to Java.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def items(self):
         """ Get a list of entries in the map.
@@ -256,7 +278,8 @@ class Map:
         The map entries are customized to appear as tuples with two 
         items.  Maps can traversed as key value pairs using ``map.items()``
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def keys(self) -> list:
         """ Get a list of keys for this map.
@@ -266,7 +289,8 @@ class Map:
         Returns:
            list: A Python list holding all of the items.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
     def __contains__(self, item):
         """ Check if a key is in the map.
@@ -278,7 +302,8 @@ class Map:
         Returns:
           True is the key is found.
         """
-        ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        ...
 
 
 class Set(object):
@@ -286,7 +311,8 @@ class Set(object):
 
     Java sets only provide the ability to delete items.
     """
-    ...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    ...
 
 
 class Iterator:
@@ -295,7 +321,8 @@ class Iterator:
     Java iterators act just like Python iterators for the 
     purposed of list comprehensions and foreach loops.
     """
-    ...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    ...
 
 
 class Enumeration:
@@ -304,4 +331,5 @@ class Enumeration:
     Enumerations are used rarely in Java, but can be iterated like a Java
     iterable using Python.
     """
-    ...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    ...

--- a/doc/java/util.py
+++ b/doc/java/util.py
@@ -11,7 +11,7 @@ class Iterable:
 
     def __iter__(self):
         """ Iterate over the members on this collect. """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
 
 class Collection:
@@ -27,11 +27,11 @@ class Collection:
         collection.
 
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __delitem__(self, item):
         """ Collections do not support remove by index. """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __contains__(self, item) -> bool:
         """ Check if this collection contains this item.
@@ -47,7 +47,7 @@ class Collection:
         Returns:
            bool: True if the item is in the collection.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
 
 class List(Collection):
@@ -65,7 +65,7 @@ class List(Collection):
         alter the original list.  Slice stepping is not supported for Java
         lists.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __setitem__(self, index: Union[int, slice], value):
         """ Set an item on the list.
@@ -74,7 +74,7 @@ class List(Collection):
         ``list[i0:i1] = values`` to replace a section of a list with
         another list of values.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __delitem__(self, idx: Union[int, slice]):
         """ Delete an item by index.
@@ -82,14 +82,14 @@ class List(Collection):
         Use ``del list[idx]`` to remove ont itme from the list or
         ``del list[i0:i1]`` to remove a section of the list.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __reversed__(self):
         """ Obtain an iterator that walks the list in reverse order.
 
         Use ``reversed(list)`` to traverse a list backwards.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def index(self, obj) -> int:
         """ Find the index that an item appears.
@@ -104,7 +104,7 @@ class List(Collection):
         Raises:
            ValueError: If the item is not on the list.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def count(self, obj):
         """ Count the number of times an object appears in a list.
@@ -116,7 +116,7 @@ class List(Collection):
         Returns:
             int: The number of times this object appears.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def insert(self, idx: int, obj):
         """ Insert an object at a specific position.
@@ -128,7 +128,7 @@ class List(Collection):
         Raises:
             TypeError: If the object cannot be converted to Java.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def append(self, obj):
         """ Append an object to the list.
@@ -139,7 +139,7 @@ class List(Collection):
         Raises:
             TypeError: If the object cannot be converted to Java.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def reverse(self):
         """ Reverse the order of the list in place.
@@ -156,7 +156,7 @@ class List(Collection):
         Raises:
            TypeError: If the list to be added cannot be converted to Java.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def pop(self, idx=-1):
         """ Remove an item from the list.
@@ -168,7 +168,7 @@ class List(Collection):
         Returns:
            The item or raises if index is outside of the list.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __iadd__(self, obj):
         """ Add an items to the end of the list.
@@ -176,7 +176,7 @@ class List(Collection):
         Use ``list += obj`` to append one item.  This is simply an alias
         for add.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __add__(self, obj):
         """ Combine two lists.
@@ -184,7 +184,7 @@ class List(Collection):
         Use ``list + seq`` to create a new list with additional members.
         This is only supported if the list can be cloned.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def remove(self, obj):
         """ Remove an item from the list by finding the first
@@ -200,7 +200,7 @@ class List(Collection):
         Raises:
             ValueError: If the item is not present on the list.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
 
 class Map:
@@ -215,12 +215,12 @@ class Map:
 
         Use ``len(map)`` to get the number of items in the map.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __iter__(self):
         """ Iterate the keys of the map.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __delitem__(self, i):
         """ Remove an item by its key.
@@ -228,7 +228,7 @@ class Map:
         Raises:
            TypeError: If the key cannot be converted to Java.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __getitem__(self, ndx):
         """ Get a value by its key.
@@ -239,7 +239,7 @@ class Map:
            KeyError: If the key is not found in the map or the key
              cannot be converted to Java.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __setitem__(self, key, value):
         """ Set a value associated with a key..
@@ -249,7 +249,7 @@ class Map:
         Raises:
            TypeError: If the key or value cannot be converted to Java.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def items(self):
         """ Get a list of entries in the map.
@@ -257,7 +257,7 @@ class Map:
         The map entries are customized to appear as tuples with two 
         items.  Maps can traversed as key value pairs using ``map.items()``
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def keys(self) -> list:
         """ Get a list of keys for this map.
@@ -267,7 +267,7 @@ class Map:
         Returns:
            list: A Python list holding all of the items.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
     def __contains__(self, item):
         """ Check if a key is in the map.
@@ -279,7 +279,7 @@ class Map:
         Returns:
           True is the key is found.
         """
-        ...
+        ...  # lgtm[py/ineffectual-statement]
 
 
 class Set(object):
@@ -287,7 +287,7 @@ class Set(object):
 
     Java sets only provide the ability to delete items.
     """
-    ...
+    ...  # lgtm[py/ineffectual-statement]
 
 
 class Iterator:
@@ -296,7 +296,7 @@ class Iterator:
     Java iterators act just like Python iterators for the 
     purposed of list comprehensions and foreach loops.
     """
-    ...
+    ...  # lgtm[py/ineffectual-statement]
 
 
 class Enumeration:
@@ -305,4 +305,4 @@ class Enumeration:
     Enumerations are used rarely in Java, but can be iterated like a Java
     iterable using Python.
     """
-    ...
+    ...  # lgtm[py/ineffectual-statement]

--- a/jpype/__init__.py
+++ b/jpype/__init__.py
@@ -25,21 +25,29 @@ from ._gui import *
 from ._classpath import *
 from ._jclass import *
 from ._jobject import *
-# There is a bug in lgtm with __init__ imports.  It will be fixed next month.
-from . import _jarray       # lgtm [py/import-own-module]
-from . import _jexception   # lgtm [py/import-own-module]
+# codeql[py/import-own-module]
+from . import _jarray
+# codeql[py/import-own-module]
+from . import _jexception
 from .types import *
 from ._jcustomizer import *
-from . import nio           # lgtm [py/import-own-module]
-from . import types         # lgtm [py/import-own-module]
+# codeql[py/import-own-module]
+from . import nio
+# codeql[py/import-own-module]
+from . import types
 from ._jcustomizer import *
 # Import all the class customizers
 # Customizers are applied in the order that they are defined currently.
-from . import _jmethod      # lgtm [py/import-own-module]
-from . import _jcollection  # lgtm [py/import-own-module]
-from . import _jio          # lgtm [py/import-own-module]
-from . import protocol      # lgtm [py/import-own-module]
-from . import _jthread      # lgtm [py/import-own-module]
+# codeql[py/import-own-module]
+from . import _jmethod
+# codeql[py/import-own-module]
+from . import _jcollection
+# codeql[py/import-own-module]
+from . import _jio
+# codeql[py/import-own-module]
+from . import protocol
+# codeql[py/import-own-module]
+from . import _jthread
 
 __all__ = ['java', 'javax']
 __all__.extend(_jinit.__all__)  # type: ignore[name-defined]

--- a/jpype/_core.py
+++ b/jpype/_core.py
@@ -379,7 +379,7 @@ def startJVM(
             try:
                 locale.setlocale(i, j)
             except locale.Error:
-                pass
+                pass  # best-effort restore; a category we can't restore isn't fatal
 
         if minimum_version is not None:
             version = _jpype.JClass("java.lang.System").getProperty("java.version")
@@ -515,7 +515,7 @@ def _JTerminate():
         if jpype.config.onexit:
             _jpype.shutdown(jpype.config.destroy_jvm, False)
     except RuntimeError:
-        pass
+        pass  # we are exiting anyway, nothing to do about a shutdown failure here
 
 
 atexit.register(_JTerminate)

--- a/jpype/_jcollection.py
+++ b/jpype/_jcollection.py
@@ -112,7 +112,9 @@ class _JList(object):
         elif hasattr(ndx, '__index__'):
             if ndx < 0:
                 ndx += self.size()
-            return self.remove_(_jtypes.JInt(ndx))
+            # __delitem__'s return value is never used by Python's `del`
+            # protocol; call for effect only.
+            self.remove_(_jtypes.JInt(ndx))
         else:
             raise TypeError("Incorrect arguments to del")
 
@@ -179,7 +181,7 @@ class _JList(object):
             if rc is True:
                 return
         except TypeError:
-            pass
+            pass  # wrong type can't be in the list either; fall through to the same error
         raise ValueError("item not in list")
 
 
@@ -209,7 +211,7 @@ class _JMap(object):
             if item is not None or self.containsKey(ndx):
                 return item
         except TypeError:
-            pass
+            pass  # wrong key type can't be present either; fall through to the same error
         raise KeyError('%s' % ndx)
 
     def __setitem__(self, ndx, v):

--- a/jpype/_jproxy.py
+++ b/jpype/_jproxy.py
@@ -42,7 +42,7 @@ def _classOverrides(cls):
             attr = object.__getattribute__(v, "__joverride__")
             overrides[k] = (v, attr)
         except AttributeError:
-            pass
+            pass  # not an override, just a normal class member
     return overrides
 
 

--- a/jpype/_jstring.py
+++ b/jpype/_jstring.py
@@ -39,7 +39,13 @@ class JString(_jpype._JObject, internal=True):  # type: ignore[call-arg]
 
 
 @_jcustomizer.JImplementationFor("java.lang.String")
-class _JStringProto:
+class _JStringProto:  # lgtm[py/equals-hash-mismatch]
+    # No __eq__ here deliberately: JImplementationFor mixes this class's
+    # __hash__ into the real wrapped-String type alongside _jpype._JObject,
+    # which supplies a content-based (java.lang.String.equals) __eq__ -
+    # confirmed consistent by direct test: two distinct String objects with
+    # equal content (`a is b` False) compare equal and hash equal, including
+    # against a plain Python str of the same content.
     def __add__(self, other: str) -> str:
         return self.concat(other)  # type: ignore[attr-defined]
 

--- a/jpype/_jstring.py
+++ b/jpype/_jstring.py
@@ -62,7 +62,10 @@ class _JStringProto:
         return self.contains(other)  # type: ignore[attr-defined]
 
     def __hash__(self):
-        if self == None:  # lgtm [py/test-equals-none]
+        # Deliberately == not is: this checks whether the wrapped Java
+        # string is null, not Python identity (self can never literally be
+        # the Python None singleton here).
+        if self == None:  # lgtm[py/test-equals-none]
             return hash(None)
         return self.__str__().__hash__()
 

--- a/jpype/_jstring.py
+++ b/jpype/_jstring.py
@@ -39,7 +39,8 @@ class JString(_jpype._JObject, internal=True):  # type: ignore[call-arg]
 
 
 @_jcustomizer.JImplementationFor("java.lang.String")
-class _JStringProto:  # lgtm[py/equals-hash-mismatch]
+# codeql[py/equals-hash-mismatch]
+class _JStringProto:
     # No __eq__ here deliberately: JImplementationFor mixes this class's
     # __hash__ into the real wrapped-String type alongside _jpype._JObject,
     # which supplies a content-based (java.lang.String.equals) __eq__ -
@@ -71,7 +72,8 @@ class _JStringProto:  # lgtm[py/equals-hash-mismatch]
         # Deliberately == not is: this checks whether the wrapped Java
         # string is null, not Python identity (self can never literally be
         # the Python None singleton here).
-        if self == None:  # lgtm[py/test-equals-none]
+        # codeql[py/test-equals-none]
+        if self == None:
             return hash(None)
         return self.__str__().__hash__()
 

--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -225,6 +225,7 @@ class JVMFinder:
 
             # Look for the library file
             return self.find_libjvm(java_home)
+        return None
 
     def _get_from_known_locations(self):
         """
@@ -238,6 +239,7 @@ class JVMFinder:
             jvm = self.find_libjvm(home)
             if jvm is not None:
                 return jvm
+        return None
 
 
 class LinuxJVMFinder(JVMFinder):
@@ -255,8 +257,10 @@ class LinuxJVMFinder(JVMFinder):
     def __init__(self):
         super().__init__()
 
-        # Search methods
-        self._methods = (self._get_from_java_home,
+        # Deliberately replaces JVMFinder's default _methods with this
+        # platform's own search order (see also DarwinJVMFinder and
+        # WindowsJVMFinder below) - not an accidental clobber.
+        self._methods = (self._get_from_java_home,  # lgtm[py/overwritten-inherited-attribute]
                          self._get_from_bin,
                          self._get_from_known_locations)
 
@@ -276,6 +280,7 @@ class LinuxJVMFinder(JVMFinder):
 
             # Look for the JVM library
             return self.find_libjvm(java_home)
+        return None
 
 
 class DarwinJVMFinder(LinuxJVMFinder):
@@ -293,7 +298,8 @@ class DarwinJVMFinder(LinuxJVMFinder):
         """
         super().__init__()
 
-        self._methods = list(self._methods)
+        # Extends (not clobbers) LinuxJVMFinder's _methods list.
+        self._methods = list(self._methods)  # lgtm[py/overwritten-inherited-attribute]
         self._methods.append(self._javahome_binary)
 
     def _javahome_binary(self):
@@ -310,6 +316,7 @@ class DarwinJVMFinder(LinuxJVMFinder):
         if Version('10.6') <= current:  # < Version('10.9'):
             return subprocess.check_output(
                 ['/usr/libexec/java_home']).strip()
+        return None
 
 
 def _checkJVMArch(jvmPath, maxsize=sys.maxsize):
@@ -356,8 +363,9 @@ class WindowsJVMFinder(JVMFinder):
     def __init__(self):
         super().__init__()
 
-        # Search methods
-        self._methods = (self._get_from_java_home, self._get_from_registry)
+        # Deliberately replaces JVMFinder's default _methods with this
+        # platform's own search order (see also LinuxJVMFinder above).
+        self._methods = (self._get_from_java_home, self._get_from_registry)  # lgtm[py/overwritten-inherited-attribute]
 
     def check(self, jvm):
         _checkJVMArch(jvm)

--- a/jpype/_jvmfinder.py
+++ b/jpype/_jvmfinder.py
@@ -260,7 +260,8 @@ class LinuxJVMFinder(JVMFinder):
         # Deliberately replaces JVMFinder's default _methods with this
         # platform's own search order (see also DarwinJVMFinder and
         # WindowsJVMFinder below) - not an accidental clobber.
-        self._methods = (self._get_from_java_home,  # lgtm[py/overwritten-inherited-attribute]
+        # codeql[py/overwritten-inherited-attribute]
+        self._methods = (self._get_from_java_home,
                          self._get_from_bin,
                          self._get_from_known_locations)
 
@@ -299,7 +300,8 @@ class DarwinJVMFinder(LinuxJVMFinder):
         super().__init__()
 
         # Extends (not clobbers) LinuxJVMFinder's _methods list.
-        self._methods = list(self._methods)  # lgtm[py/overwritten-inherited-attribute]
+        # codeql[py/overwritten-inherited-attribute]
+        self._methods = list(self._methods)
         self._methods.append(self._javahome_binary)
 
     def _javahome_binary(self):
@@ -365,7 +367,8 @@ class WindowsJVMFinder(JVMFinder):
 
         # Deliberately replaces JVMFinder's default _methods with this
         # platform's own search order (see also LinuxJVMFinder above).
-        self._methods = (self._get_from_java_home, self._get_from_registry)  # lgtm[py/overwritten-inherited-attribute]
+        # codeql[py/overwritten-inherited-attribute]
+        self._methods = (self._get_from_java_home, self._get_from_registry)
 
     def check(self, jvm):
         _checkJVMArch(jvm)

--- a/jpype/_pyinstaller/test_jpype_pyinstaller.py
+++ b/jpype/_pyinstaller/test_jpype_pyinstaller.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from subprocess import run
 
-import jpype
+import jpype  # sanity check jpype imports before the slow PyInstaller build  # lgtm[py/unused-import]
 import PyInstaller.__main__
 
 

--- a/jpype/_pyinstaller/test_jpype_pyinstaller.py
+++ b/jpype/_pyinstaller/test_jpype_pyinstaller.py
@@ -2,7 +2,9 @@ import os
 from pathlib import Path
 from subprocess import run
 
-import jpype  # sanity check jpype imports before the slow PyInstaller build  # lgtm[py/unused-import]
+# sanity check jpype imports before the slow PyInstaller build
+# codeql[py/unused-import]
+import jpype
 import PyInstaller.__main__
 
 

--- a/jpype/dbapi2.py
+++ b/jpype/dbapi2.py
@@ -40,8 +40,8 @@ paramstyle = 'qmark'
 
 
 class JDBCTypeProtocol(typing.Protocol):
-    def get(self, rs, column, st):...
-    def set(self, ps, column, value):...
+    def get(self, rs, column, st):...  # lgtm[py/ineffectual-statement]
+    def set(self, ps, column, value):...  # lgtm[py/ineffectual-statement]
 
 _SQLException = None
 _SQLTimeoutException = None

--- a/jpype/dbapi2.py
+++ b/jpype/dbapi2.py
@@ -44,7 +44,7 @@ class JDBCTypeProtocol(typing.Protocol):
     def set(self, ps, column, value):...  # lgtm[py/ineffectual-statement]
 
 _SQLException = None
-_SQLTimeoutException = None
+_SQLTimeoutException = None  # not currently used, kept paired with _SQLException above  # lgtm[py/unused-global-variable]
 _registry: typing.Dict[str, JDBCTypeProtocol] = {}
 _types: typing.List[JDBCTypeProtocol] = []
 
@@ -1409,13 +1409,12 @@ def Binary(data):
 
 
 #  SQL NULL values are represented by the Python None singleton on input and output.
-_accepted = {"exact", "implicit"}
 
 
 def _populateTypes():
     global _SQLException, _SQLTimeoutException
     _SQLException = _jpype.JClass("java.sql.SQLException")
-    _SQLTimeoutException = _jpype.JClass("java.sql.SQLTimeoutException")
+    _SQLTimeoutException = _jpype.JClass("java.sql.SQLTimeoutException")  # lgtm[py/unused-global-variable]
     cs = _jpype.JClass("java.sql.CallableStatement")
     ps = _jpype.JClass("java.sql.PreparedStatement")
     rs = _jpype.JClass("java.sql.ResultSet")

--- a/jpype/dbapi2.py
+++ b/jpype/dbapi2.py
@@ -40,11 +40,15 @@ paramstyle = 'qmark'
 
 
 class JDBCTypeProtocol(typing.Protocol):
-    def get(self, rs, column, st):...  # lgtm[py/ineffectual-statement]
-    def set(self, ps, column, value):...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    def get(self, rs, column, st):...
+    # codeql[py/ineffectual-statement]
+    def set(self, ps, column, value):...
 
 _SQLException = None
-_SQLTimeoutException = None  # not currently used, kept paired with _SQLException above  # lgtm[py/unused-global-variable]
+# not currently used, kept paired with _SQLException above
+# codeql[py/unused-global-variable]
+_SQLTimeoutException = None
 _registry: typing.Dict[str, JDBCTypeProtocol] = {}
 _types: typing.List[JDBCTypeProtocol] = []
 
@@ -1414,7 +1418,8 @@ def Binary(data):
 def _populateTypes():
     global _SQLException, _SQLTimeoutException
     _SQLException = _jpype.JClass("java.sql.SQLException")
-    _SQLTimeoutException = _jpype.JClass("java.sql.SQLTimeoutException")  # lgtm[py/unused-global-variable]
+    # codeql[py/unused-global-variable]
+    _SQLTimeoutException = _jpype.JClass("java.sql.SQLTimeoutException")
     cs = _jpype.JClass("java.sql.CallableStatement")
     ps = _jpype.JClass("java.sql.PreparedStatement")
     rs = _jpype.JClass("java.sql.ResultSet")

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -77,8 +77,10 @@ def _keywordWrap(name):
 
 
 class JImportCustomizerProtocol(Protocol):
-    def canCustomize(self, name: str) -> bool: ...  # lgtm[py/ineffectual-statement]
-    def getSpec(self, name: str): ...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    def canCustomize(self, name: str) -> bool: ...
+    # codeql[py/ineffectual-statement]
+    def getSpec(self, name: str): ...
 
 
 # %% Customizer

--- a/jpype/imports.py
+++ b/jpype/imports.py
@@ -77,8 +77,8 @@ def _keywordWrap(name):
 
 
 class JImportCustomizerProtocol(Protocol):
-    def canCustomize(self, name: str) -> bool: ...
-    def getSpec(self, name: str): ...
+    def canCustomize(self, name: str) -> bool: ...  # lgtm[py/ineffectual-statement]
+    def getSpec(self, name: str): ...  # lgtm[py/ineffectual-statement]
 
 
 # %% Customizer

--- a/jpype/protocol.py
+++ b/jpype/protocol.py
@@ -42,7 +42,7 @@ if sys.version_info < (3, 8):  # pragma: no cover
 
     @runtime_checkable
     class SupportsIndex(Protocol):
-        def __index__(self) -> int: ...
+        def __index__(self) -> int: ...  # lgtm[py/ineffectual-statement]
 
 
 else:
@@ -57,7 +57,7 @@ else:
 
 @runtime_checkable
 class SupportsPath(Protocol):
-    def __fspath__(self) -> str: ...
+    def __fspath__(self) -> str: ...  # lgtm[py/ineffectual-statement]
 
 
 @_jcustomizer.JConversion("java.nio.file.Path", instanceof=SupportsPath)

--- a/jpype/protocol.py
+++ b/jpype/protocol.py
@@ -24,21 +24,21 @@ from . import _jclass
 from . import _jcustomizer
 
 # Copies of all private base types for reference
-_JClass = _jpype._JClass
-_JObject = _jpype._JObject
-_JException = _jpype._JException
-_JNumberLong = _jpype._JNumberLong
-_JNumberFloat = _jpype._JNumberFloat
-_JComparable = _jpype._JComparable
-_JChar = _jpype._JChar
-_JBoolean = _jpype._JBoolean
-_JArray = _jpype._JArray
-_JBuffer = _jpype._JBuffer
+_JClass = _jpype._JClass  # lgtm[py/unused-global-variable]
+_JObject = _jpype._JObject  # lgtm[py/unused-global-variable]
+_JException = _jpype._JException  # lgtm[py/unused-global-variable]
+_JNumberLong = _jpype._JNumberLong  # lgtm[py/unused-global-variable]
+_JNumberFloat = _jpype._JNumberFloat  # lgtm[py/unused-global-variable]
+_JComparable = _jpype._JComparable  # lgtm[py/unused-global-variable]
+_JChar = _jpype._JChar  # lgtm[py/unused-global-variable]
+_JBoolean = _jpype._JBoolean  # lgtm[py/unused-global-variable]
+_JArray = _jpype._JArray  # lgtm[py/unused-global-variable]
+_JBuffer = _jpype._JBuffer  # lgtm[py/unused-global-variable]
 
 if sys.version_info < (3, 8):  # pragma: no cover
     from typing_extensions import Protocol, runtime_checkable
-    from typing import Sequence, Mapping, Set  # lgtm [py/unused-import]
-    from typing import SupportsFloat, Callable  # lgtm [py/unused-import]
+    from typing import Sequence, Mapping, Set  # lgtm[py/unused-import]
+    from typing import SupportsFloat, Callable  # lgtm[py/unused-import]
 
     @runtime_checkable
     class SupportsIndex(Protocol):
@@ -48,9 +48,8 @@ if sys.version_info < (3, 8):  # pragma: no cover
 else:
     # 3.8 onward
     from typing import Protocol, runtime_checkable
-    from typing import SupportsIndex, SupportsFloat  # lgtm [py/unused-import]
-    # lgtm [py/unused-import]
-    from typing import Sequence, Mapping, Set, Callable
+    from typing import SupportsIndex, SupportsFloat  # lgtm[py/unused-import]
+    from typing import Sequence, Mapping, Set, Callable  # lgtm[py/unused-import]
 
 # Types we need
 

--- a/jpype/protocol.py
+++ b/jpype/protocol.py
@@ -24,39 +24,55 @@ from . import _jclass
 from . import _jcustomizer
 
 # Copies of all private base types for reference
-_JClass = _jpype._JClass  # lgtm[py/unused-global-variable]
-_JObject = _jpype._JObject  # lgtm[py/unused-global-variable]
-_JException = _jpype._JException  # lgtm[py/unused-global-variable]
-_JNumberLong = _jpype._JNumberLong  # lgtm[py/unused-global-variable]
-_JNumberFloat = _jpype._JNumberFloat  # lgtm[py/unused-global-variable]
-_JComparable = _jpype._JComparable  # lgtm[py/unused-global-variable]
-_JChar = _jpype._JChar  # lgtm[py/unused-global-variable]
-_JBoolean = _jpype._JBoolean  # lgtm[py/unused-global-variable]
-_JArray = _jpype._JArray  # lgtm[py/unused-global-variable]
-_JBuffer = _jpype._JBuffer  # lgtm[py/unused-global-variable]
+# codeql[py/unused-global-variable]
+_JClass = _jpype._JClass
+# codeql[py/unused-global-variable]
+_JObject = _jpype._JObject
+# codeql[py/unused-global-variable]
+_JException = _jpype._JException
+# codeql[py/unused-global-variable]
+_JNumberLong = _jpype._JNumberLong
+# codeql[py/unused-global-variable]
+_JNumberFloat = _jpype._JNumberFloat
+# codeql[py/unused-global-variable]
+_JComparable = _jpype._JComparable
+# codeql[py/unused-global-variable]
+_JChar = _jpype._JChar
+# codeql[py/unused-global-variable]
+_JBoolean = _jpype._JBoolean
+# codeql[py/unused-global-variable]
+_JArray = _jpype._JArray
+# codeql[py/unused-global-variable]
+_JBuffer = _jpype._JBuffer
 
 if sys.version_info < (3, 8):  # pragma: no cover
     from typing_extensions import Protocol, runtime_checkable
-    from typing import Sequence, Mapping, Set  # lgtm[py/unused-import]
-    from typing import SupportsFloat, Callable  # lgtm[py/unused-import]
+    # codeql[py/unused-import]
+    from typing import Sequence, Mapping, Set
+    # codeql[py/unused-import]
+    from typing import SupportsFloat, Callable
 
     @runtime_checkable
     class SupportsIndex(Protocol):
-        def __index__(self) -> int: ...  # lgtm[py/ineffectual-statement]
+        # codeql[py/ineffectual-statement]
+        def __index__(self) -> int: ...
 
 
 else:
     # 3.8 onward
     from typing import Protocol, runtime_checkable
-    from typing import SupportsIndex, SupportsFloat  # lgtm[py/unused-import]
-    from typing import Sequence, Mapping, Set, Callable  # lgtm[py/unused-import]
+    # codeql[py/unused-import]
+    from typing import SupportsIndex, SupportsFloat
+    # codeql[py/unused-import]
+    from typing import Sequence, Mapping, Set, Callable
 
 # Types we need
 
 
 @runtime_checkable
 class SupportsPath(Protocol):
-    def __fspath__(self) -> str: ...  # lgtm[py/ineffectual-statement]
+    # codeql[py/ineffectual-statement]
+    def __fspath__(self) -> str: ...
 
 
 @_jcustomizer.JConversion("java.nio.file.Path", instanceof=SupportsPath)

--- a/native/common/include/jp_methoddispatch.h
+++ b/native/common/include/jp_methoddispatch.h
@@ -23,7 +23,7 @@ class JPMethodDispatch : public JPResource
 {
 public:
 
-	// lgtm[cpp/commented-out-code] - false positive, this is a docstring
+	// codeql[cpp/commented-out-code] - false positive, this is a docstring
 	/**
 	 * Create a new method based on class and a name;
 	 */

--- a/native/common/include/jp_methoddispatch.h
+++ b/native/common/include/jp_methoddispatch.h
@@ -23,6 +23,7 @@ class JPMethodDispatch : public JPResource
 {
 public:
 
+	// lgtm[cpp/commented-out-code] - false positive, this is a docstring
 	/**
 	 * Create a new method based on class and a name;
 	 */

--- a/native/common/include/jp_tracer.h
+++ b/native/common/include/jp_tracer.h
@@ -66,7 +66,7 @@ public:
 		m_Error = true;
 		try
 		{
-			throw; // lgtm [cpp/rethrow-no-exception]
+			throw; // lgtm[cpp/rethrow-no-exception]
 		} catch (JPypeException& ex)
 		{
 			ex.from(info);

--- a/native/common/include/jp_tracer.h
+++ b/native/common/include/jp_tracer.h
@@ -66,7 +66,8 @@ public:
 		m_Error = true;
 		try
 		{
-			throw; // lgtm[cpp/rethrow-no-exception]
+			// codeql[cpp/rethrow-no-exception]
+			throw;
 		} catch (JPypeException& ex)
 		{
 			ex.from(info);

--- a/native/common/jp_chartype.cpp
+++ b/native/common/jp_chartype.cpp
@@ -48,15 +48,9 @@ JPValue JPCharType::newInstance(JPJavaFrame& frame, JPPyObjectVector& args)
 
 JPPyObject JPCharType::convertToPythonObject(JPJavaFrame& frame, jvalue val, bool cast)
 {
-	//	if (!cast)
-	//	{
 	JPPyObject out = JPPyObject::call(PyJPChar_Create((PyTypeObject*) _JChar, val.c));
 	PyJPValue_assignJavaSlot(frame, out.get(), JPValue(this, val));
 	return out;
-	//	}
-	//	JPPyObject tmp = JPPyObject::call(PyLong_FromLong(field(val)));
-	//	JPPyObject out = JPPyObject::call(convertLong(getHost(), (PyLongObject*) tmp.get()));
-	//	return out;
 }
 
 JPValue JPCharType::getValueFromObject(JPJavaFrame& frame, const JPValue& obj)

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -48,7 +48,7 @@ JPypeException::JPypeException(int type, void* error, const JPStackInfo& stackIn
 		// for why). JPPyErrFrame::fetch() already removes it from the thread
 		// state; clear() below just stops its destructor from putting it
 		// straight back before we are ready for that in toPython()/toJava().
-		JPPyErrFrame eframe;
+		JPPyErrFrame eframe;  // lgtm[cpp/commented-out-code] - false positive, prose mentioning a method name
 		eframe.normalize();
 		m_PyExcValue = eframe.m_ExceptionValue;
 		eframe.clear();
@@ -383,7 +383,7 @@ void JPypeException::toPython()
 		{
 			// This should not be possible unless we failed to cover one of the
 			// exception type codes.
-			JP_TRACE("Unknown error");
+			JP_TRACE("Unknown error");  // lgtm[cpp/commented-out-code] - false positive, plain prose
 			PyErr_SetString(PyExc_RuntimeError, mesg); // GCOVR_EXCL_LINE
 		}
 

--- a/native/common/jp_exception.cpp
+++ b/native/common/jp_exception.cpp
@@ -48,7 +48,8 @@ JPypeException::JPypeException(int type, void* error, const JPStackInfo& stackIn
 		// for why). JPPyErrFrame::fetch() already removes it from the thread
 		// state; clear() below just stops its destructor from putting it
 		// straight back before we are ready for that in toPython()/toJava().
-		JPPyErrFrame eframe;  // lgtm[cpp/commented-out-code] - false positive, prose mentioning a method name
+		// codeql[cpp/commented-out-code] - false positive, prose mentioning a method name
+		JPPyErrFrame eframe;
 		eframe.normalize();
 		m_PyExcValue = eframe.m_ExceptionValue;
 		eframe.clear();
@@ -383,7 +384,8 @@ void JPypeException::toPython()
 		{
 			// This should not be possible unless we failed to cover one of the
 			// exception type codes.
-			JP_TRACE("Unknown error");  // lgtm[cpp/commented-out-code] - false positive, plain prose
+			// codeql[cpp/commented-out-code] - false positive, plain prose
+			JP_TRACE("Unknown error");
 			PyErr_SetString(PyExc_RuntimeError, mesg); // GCOVR_EXCL_LINE
 		}
 

--- a/native/common/jp_method.cpp
+++ b/native/common/jp_method.cpp
@@ -287,8 +287,8 @@ JPPyObject JPMethod::invokeCallerSensitive(JPMethodMatch& match, JPPyObjectVecto
 			JPMatch conv(&frame, u);
 			JPClass *boxed = type->getBoxedClass(frame);
 			boxed->findJavaConversion(conv);
-			jvalue v = conv.convert();
-			frame.SetObjectArrayElement(ja, i, v.l);
+			jvalue boxedVal = conv.convert();
+			frame.SetObjectArrayElement(ja, i, boxedVal.l);
 		} else
 		{
 			frame.SetObjectArrayElement(ja, i, v[i].l);
@@ -315,9 +315,9 @@ JPPyObject JPMethod::invokeCallerSensitive(JPMethodMatch& match, JPPyObjectVecto
 	} else
 	{
 		JP_TRACE("Return object");
-		jvalue v;
-		v.l = o;
-		return retType->convertToPythonObject(frame, v, false);
+		jvalue rv;
+		rv.l = o;
+		return retType->convertToPythonObject(frame, rv, false);
 	}
 	JP_TRACE_OUT;
 }

--- a/native/jpype_module/src/main/java/exclude/org/jpype/Reflector0.java
+++ b/native/jpype_module/src/main/java/exclude/org/jpype/Reflector0.java
@@ -23,6 +23,7 @@ public class Reflector0 implements JPypeReflector
    * @throws java.lang.Throwable throws whatever type the called method
    * produces.
    */
+  @Override
   public Object callMethod(Method method, Object obj, Object[] args)
           throws Throwable
   {

--- a/native/jpype_module/src/main/java/org/jpype/html/AttrGrammar.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/AttrGrammar.java
@@ -42,7 +42,7 @@ public class AttrGrammar implements Parser.Grammar
   }
 
 //<editor-fold desc="tokens">
-  enum Token implements Parser.Token
+  enum Token implements Parser.Token  // lgtm[java/class-name-matches-super-class]
   {
     TEXT,
     QUOTE("\""),
@@ -117,7 +117,7 @@ public class AttrGrammar implements Parser.Grammar
 //</editor-fold>
 //<editor-fold desc="state">
 
-  enum State implements Parser.State
+  enum State implements Parser.State  // lgtm[java/class-name-matches-super-class]
   {
     FREE(freeTokens, freeRules),
     IN_QUOTE(qtTokens, qtRules),

--- a/native/jpype_module/src/main/java/org/jpype/html/AttrGrammar.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/AttrGrammar.java
@@ -216,7 +216,7 @@ public class AttrGrammar implements Parser.Grammar
     public void execute(Parser parser)
     {
       Entity e2 = (Entity) parser.stack.removeLast();
-      Entity e1 = (Entity) parser.stack.removeLast();
+      parser.stack.removeLast();  // consumes the '=' token, value unused
       Entity e0 = (Entity) parser.stack.removeLast();
       AttrParser aparser = (AttrParser) parser;
       Attr attr = aparser.doc.createAttribute((String) e0.value);

--- a/native/jpype_module/src/main/java/org/jpype/html/AttrGrammar.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/AttrGrammar.java
@@ -42,7 +42,8 @@ public class AttrGrammar implements Parser.Grammar
   }
 
 //<editor-fold desc="tokens">
-  enum Token implements Parser.Token  // lgtm[java/class-name-matches-super-class]
+  // codeql[java/class-name-matches-super-class]
+  enum Token implements Parser.Token
   {
     TEXT,
     QUOTE("\""),
@@ -117,7 +118,8 @@ public class AttrGrammar implements Parser.Grammar
 //</editor-fold>
 //<editor-fold desc="state">
 
-  enum State implements Parser.State  // lgtm[java/class-name-matches-super-class]
+  // codeql[java/class-name-matches-super-class]
+  enum State implements Parser.State
   {
     FREE(freeTokens, freeRules),
     IN_QUOTE(qtTokens, qtRules),

--- a/native/jpype_module/src/main/java/org/jpype/html/Html.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/Html.java
@@ -151,13 +151,17 @@ public class Html
       } else if (c < 0x0800)
       {
         b[i1++] = (byte) (0xc0 + ((c >> 6) & 0x1f));
-        if (i1 < b.length) // lgtm[java/constant-comparison]
-          b[i1++] = (byte) (0x80 + (c & 0x3f)); // lgtm [java/index-out-of-bounds]
+        // codeql[java/constant-comparison]
+        if (i1 < b.length)
+          // codeql[java/index-out-of-bounds]
+          b[i1++] = (byte) (0x80 + (c & 0x3f));
       } else
       {
         b[i1++] = (byte) (0xe0 + ((c >> 12) & 0x0f));
-        if (i1 < b.length) // lgtm[java/constant-comparison]
-          b[i1++] = (byte) (0x80 + ((c >> 6) & 0x3f)); // lgtm [java/index-out-of-bounds]
+        // codeql[java/constant-comparison]
+        if (i1 < b.length)
+          // codeql[java/index-out-of-bounds]
+          b[i1++] = (byte) (0x80 + ((c >> 6) & 0x3f));
         if (i1 < b.length)
           b[i1++] = (byte) (0x80 + (c & 0x3f));
       }

--- a/native/jpype_module/src/main/java/org/jpype/html/Html.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/Html.java
@@ -85,7 +85,7 @@ public class Html
         String[] parts = line.split("\\s+");
         ENTITIES.put(parts[0], Integer.parseInt(parts[1]));
       }
-    } catch (IOException ex)
+    } catch (IOException | NumberFormatException ex)
     {
       throw new RuntimeException(ex);
     }

--- a/native/jpype_module/src/main/java/org/jpype/html/Html.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/Html.java
@@ -151,12 +151,12 @@ public class Html
       } else if (c < 0x0800)
       {
         b[i1++] = (byte) (0xc0 + ((c >> 6) & 0x1f));
-        if (i1 < b.length) // lgtm [java/constant-comparison]
+        if (i1 < b.length) // lgtm[java/constant-comparison]
           b[i1++] = (byte) (0x80 + (c & 0x3f)); // lgtm [java/index-out-of-bounds]
       } else
       {
         b[i1++] = (byte) (0xe0 + ((c >> 12) & 0x0f));
-        if (i1 < b.length) // lgtm [java/constant-comparison]
+        if (i1 < b.length) // lgtm[java/constant-comparison]
           b[i1++] = (byte) (0x80 + ((c >> 6) & 0x3f)); // lgtm [java/index-out-of-bounds]
         if (i1 < b.length)
           b[i1++] = (byte) (0x80 + (c & 0x3f));

--- a/native/jpype_module/src/main/java/org/jpype/html/HtmlGrammar.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/HtmlGrammar.java
@@ -413,9 +413,9 @@ public class HtmlGrammar implements Parser.Grammar
     public void execute(Parser parser)
     {
       LinkedList<Entity> stack = parser.stack;
-      Entity e2 = stack.removeLast();
+      stack.removeLast();  // consumes '>', value unused
       Entity e1 = stack.removeLast();
-      Entity e0 = stack.removeLast();
+      stack.removeLast();  // consumes '<' + '/', value unused
       String content = e1.value.toString();
       getGrammar(parser).flushText(parser);
       getHandler(parser).endElement(content);
@@ -435,9 +435,9 @@ public class HtmlGrammar implements Parser.Grammar
     public void execute(Parser parser)
     {
       LinkedList<Entity> stack = parser.stack;
-      Entity e2 = stack.removeLast();
+      stack.removeLast();  // consumes '>', value unused
       Entity e1 = stack.removeLast();
-      Entity e0 = stack.removeLast();
+      stack.removeLast();  // consumes the directive marker, value unused
       String content = e1.value.toString();
       getGrammar(parser).flushText(parser);
       getHandler(parser).directive(content);

--- a/native/jpype_module/src/main/java/org/jpype/html/HtmlGrammar.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/HtmlGrammar.java
@@ -83,7 +83,7 @@ public class HtmlGrammar implements Parser.Grammar
   }
 
 //<editor-fold desc="state">
-  enum State implements Parser.State
+  enum State implements Parser.State  // lgtm[java/class-name-matches-super-class]
   {
     FREE(freeTokens, freeRules),
     ELEMENT(elementTokens, elementRules),
@@ -115,7 +115,7 @@ public class HtmlGrammar implements Parser.Grammar
 
 //</editor-fold>
 //<editor-fold desc="tokens" defaultstate="collapsed">
-  enum Token implements Parser.Token
+  enum Token implements Parser.Token  // lgtm[java/class-name-matches-super-class]
   {
     TEXT,
     BANG("!"),

--- a/native/jpype_module/src/main/java/org/jpype/html/HtmlGrammar.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/HtmlGrammar.java
@@ -83,7 +83,8 @@ public class HtmlGrammar implements Parser.Grammar
   }
 
 //<editor-fold desc="state">
-  enum State implements Parser.State  // lgtm[java/class-name-matches-super-class]
+  // codeql[java/class-name-matches-super-class]
+  enum State implements Parser.State
   {
     FREE(freeTokens, freeRules),
     ELEMENT(elementTokens, elementRules),
@@ -115,7 +116,8 @@ public class HtmlGrammar implements Parser.Grammar
 
 //</editor-fold>
 //<editor-fold desc="tokens" defaultstate="collapsed">
-  enum Token implements Parser.Token  // lgtm[java/class-name-matches-super-class]
+  // codeql[java/class-name-matches-super-class]
+  enum Token implements Parser.Token
   {
     TEXT,
     BANG("!"),

--- a/native/jpype_module/src/main/java/org/jpype/html/HtmlTreeHandler.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/HtmlTreeHandler.java
@@ -63,7 +63,6 @@ public class HtmlTreeHandler implements HtmlHandler
   public void startElement(String name, String attr)
   {
     name = name.toLowerCase().trim();
-    String attr0 = attr;
 
     // Html has irregular end rules.
     while (Html.OPTIONAL_ELEMENTS.contains(name))

--- a/native/jpype_module/src/main/java/org/jpype/html/Parser.java
+++ b/native/jpype_module/src/main/java/org/jpype/html/Parser.java
@@ -57,7 +57,6 @@ public class Parser<T>
         int rc = channel.read(incoming);
         if (rc < 0)
           break;
-        int p = incoming.position();
         incoming.rewind();
         process(incoming, outgoing, rc);
       }

--- a/native/jpype_module/src/main/java/org/jpype/manager/TypeFactoryNative.java
+++ b/native/jpype_module/src/main/java/org/jpype/manager/TypeFactoryNative.java
@@ -29,6 +29,7 @@ public class TypeFactoryNative implements TypeFactory
 
   public long context;
 
+  @Override
   public native void newWrapper(long context, long cls);
 
   @Override

--- a/native/jpype_module/src/main/java/org/jpype/manager/TypeManager.java
+++ b/native/jpype_module/src/main/java/org/jpype/manager/TypeManager.java
@@ -245,7 +245,8 @@ public class TypeManager
         // this exact line has been caught between two static checkers
         // before - one flags the unused variable, the other flags a call
         // whose result isn't captured. Suppressed, not fixed, deliberately.
-        Class<?> cls = Class.forName(sb.toString());  // lgtm[java/local-variable-is-never-read]
+        // codeql[java/local-variable-is-never-read]
+        Class<?> cls = Class.forName(sb.toString());
         for (int j = i + 1; j < parts.length; ++j)
         {
           sb.append("$");

--- a/native/jpype_module/src/main/java/org/jpype/manager/TypeManager.java
+++ b/native/jpype_module/src/main/java/org/jpype/manager/TypeManager.java
@@ -237,7 +237,15 @@ public class TypeManager
       {
         sb.append(".");
         sb.append(parts[i]);
-        Class<?> cls = Class.forName(sb.toString());
+        // The 1-arg Class.forName forces a full class load (runs static
+        // initializers) as a needed side effect before the nested-class
+        // scan below can proceed correctly - the returned Class<?> itself
+        // is not what's needed here, and neither is the exception path
+        // alone. Do not "simplify" this to a bare Class.forName(...) call:
+        // this exact line has been caught between two static checkers
+        // before - one flags the unused variable, the other flags a call
+        // whose result isn't captured. Suppressed, not fixed, deliberately.
+        Class<?> cls = Class.forName(sb.toString());  // lgtm[java/local-variable-is-never-read]
         for (int j = i + 1; j < parts.length; ++j)
         {
           sb.append("$");

--- a/native/jpype_module/src/main/java/org/jpype/pkg/JPypePackage.java
+++ b/native/jpype_module/src/main/java/org/jpype/pkg/JPypePackage.java
@@ -15,6 +15,7 @@
 **************************************************************************** */
 package org.jpype.pkg;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
@@ -134,6 +135,55 @@ public class JPypePackage
   }
 
   /**
+   * Read exactly buf.length bytes from is, looping over short reads.
+   *
+   * InputStream.read(byte[]) is allowed by contract to return fewer bytes
+   * than requested even before EOF; ignoring that would silently desync
+   * the constant-pool walk below on any stream that does.
+   *
+   * @throws EOFException if the stream ends before buf is filled.
+   */
+  private static void readFully(InputStream is, byte[] buf) throws IOException
+  {
+    int off = 0;
+    while (off < buf.length)
+    {
+      int n = is.read(buf, off, buf.length - off);
+      if (n < 0)
+        throw new EOFException("Unexpected end of class file");
+      off += n;
+    }
+  }
+
+  /**
+   * Skip exactly n bytes from is, looping over short skips.
+   *
+   * InputStream.skip(long) is allowed by contract to skip fewer bytes than
+   * requested for reasons other than EOF; a skip() that makes no progress
+   * falls back to reading (and discarding) a single byte to tell a stalled
+   * stream apart from one that is genuinely at EOF.
+   *
+   * @throws EOFException if the stream ends before n bytes are skipped.
+   */
+  private static void skipFully(InputStream is, long n) throws IOException
+  {
+    long remaining = n;
+    while (remaining > 0)
+    {
+      long skipped = is.skip(remaining);
+      if (skipped <= 0)
+      {
+        if (is.read() < 0)
+          throw new EOFException("Unexpected end of class file");
+        remaining--;
+      } else
+      {
+        remaining -= skipped;
+      }
+    }
+  }
+
+  /**
    * Determine if a class is public.
    *
    * This checks if a class file contains a public class. When importing classes
@@ -161,7 +211,7 @@ public class JPypePackage
 
       // Check the magic
       ByteBuffer header = ByteBuffer.allocate(4 + 2 + 2 + 2);
-      is.read(header.array());
+      readFully(is, header.array());
       ((Buffer) header).rewind();
       int magic = header.getInt();
       if (magic != (int) 0xcafebabe)
@@ -173,7 +223,7 @@ public class JPypePackage
       // Traverse the cp pool
       for (int i = 0; i < cpitems - 1; ++i)
       {
-        is.read(buffer3.array());
+        readFully(is, buffer3.array());
         ((Buffer) buffer3).rewind();
         byte type = buffer3.get(); // First byte is the type
 
@@ -181,7 +231,7 @@ public class JPypePackage
         switch (type)
         {
           case 1:  // Strings are variable length
-            is.skip(buffer3.getShort());
+            skipFully(is, buffer3.getShort());
             break;
           case 7:
           case 8:
@@ -190,7 +240,7 @@ public class JPypePackage
           case 20:
             break;
           case 15:
-            is.skip(1);
+            skipFully(is, 1);
             break;
           case 3:
           case 4:
@@ -200,11 +250,11 @@ public class JPypePackage
           case 12:
           case 17:
           case 18:
-            is.skip(2);
+            skipFully(is, 2);
             break;
           case 5:
           case 6:
-            is.skip(6); // double and long are special as they are double entries
+            skipFully(is, 6); // double and long are special as they are double entries
             i++; // long and double take two slots
             break;
           default:
@@ -213,7 +263,7 @@ public class JPypePackage
       }
 
       // Get the flags
-      is.read(buffer3.array());
+      readFully(is, buffer3.array());
       ((Buffer) buffer3).rewind();
       short flags = buffer3.getShort();
       return (flags & 1) == 1; // it is public if bit zero is set

--- a/native/python/pyjp_array.cpp
+++ b/native/python/pyjp_array.cpp
@@ -224,7 +224,8 @@ static int PyJPArray_assignSubscript(PyJPArray *self, PyObject *item, PyObject *
 	{
 		JPValue *v1 = PyJPValue_getJavaSlot((PyObject*) self);
 		JPValue *v2 = PyJPValue_getJavaSlot((PyObject*) value);
-		if (frame.equals(v1->getJavaObject(), v2->getJavaObject()))
+		if (v1 != nullptr && v2 != nullptr
+				&& frame.equals(v1->getJavaObject(), v2->getJavaObject()))
 			JP_RAISE(PyExc_ValueError, "self assignment not support currently");
 	}
 

--- a/native/python/pyjp_char.cpp
+++ b/native/python/pyjp_char.cpp
@@ -109,7 +109,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		_PyUnicode_STATE(self).ascii = 1;
 		_PyUnicode_STATE(self).kind = PyUnicode_1BYTE_KIND;
 
-		char *data = (char*) (((PyASCIIObject*) self) + 1);
+		char *data = (char*) &(((PyASCIIObject*) self)[1]);
 		data[0] = (char) p;
 		data[1] = 0;
 	} else if (p < 256)
@@ -117,7 +117,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		_PyUnicode_STATE(self).ascii = 0;
 		_PyUnicode_STATE(self).kind = PyUnicode_1BYTE_KIND;
 
-		char *data = (char*) ( ((PyCompactUnicodeObject*) self) + 1);
+		char *data = (char*) &(((PyCompactUnicodeObject*) self)[1]);
 		data[0] = (char) p;
 		data[1] = 0;
 
@@ -132,7 +132,7 @@ PyObject *PyJPChar_Create(PyTypeObject *type, Py_UCS2 p)
 		_PyUnicode_STATE(self).ascii = 0;
 		_PyUnicode_STATE(self).kind = PyUnicode_2BYTE_KIND;
 
-		auto *data = (Py_UCS2*) ( ((PyCompactUnicodeObject*) self) + 1);
+		auto *data = (Py_UCS2*) &(((PyCompactUnicodeObject*) self)[1]);
 		data[0] = p;
 		data[1] = 0;
 #if PY_VERSION_HEX < 0x030c0000
@@ -174,15 +174,15 @@ Py_UCS2 fromJPChar(PyJPChar *self)
 {
 	if (_PyUnicode_STATE(self).ascii == 1)
 	{
-		auto *data = (Py_UCS1*) (((PyASCIIObject*) self) + 1);
+		auto *data = (Py_UCS1*) &(((PyASCIIObject*) self)[1]);
 		return data[0];
 	}
 	if (_PyUnicode_STATE(self).kind == PyUnicode_1BYTE_KIND)
 	{
-		auto *data = (Py_UCS1*) ( ((PyCompactUnicodeObject*) self) + 1);
+		auto *data = (Py_UCS1*) &(((PyCompactUnicodeObject*) self)[1]);
 		return data[0];
 	}
-	auto *data = (Py_UCS2*) ( ((PyCompactUnicodeObject*) self) + 1);
+	auto *data = (Py_UCS2*) &(((PyCompactUnicodeObject*) self)[1]);
 	return data[0];
 }
 

--- a/native/python/pyjp_class.cpp
+++ b/native/python/pyjp_class.cpp
@@ -1216,7 +1216,6 @@ void PyJPClass_hook(JPJavaFrame &frame, JPClass* cls)
 
 	// Attach the javaSlot
 	self->m_Class = cls;
-	//	self->m_Class->postLoad();
 	PyJPValue_assignJavaSlot(frame, (PyObject*) self, JPValue(context->_java_lang_Class,
 			(jobject) self->m_Class->getJavaClass()));
 

--- a/native/python/pyjp_module.cpp
+++ b/native/python/pyjp_module.cpp
@@ -787,7 +787,6 @@ static PyMethodDef moduleMethods[] = {
 	{"bootstrap", (PyCFunction) PyJPModule_bootstrap, METH_NOARGS, ""},
 #else
 	{"startup", (PyCFunction) PyJPModule_startup, METH_VARARGS, ""},
-	//	{"attach", (PyCFunction) (&PyJPModule_attach), METH_VARARGS, ""},
 	{"shutdown", (PyCFunction) PyJPModule_shutdown, METH_VARARGS, ""},
 #endif
 	{"_getClass", (PyCFunction) PyJPModule_getClass, METH_O, ""},
@@ -803,8 +802,6 @@ static PyMethodDef moduleMethods[] = {
 	{"detachThreadFromJVM", (PyCFunction) PyJPModule_detachThread, METH_NOARGS, ""},
 	{"attachThreadAsDaemon", (PyCFunction) PyJPModule_attachThreadAsDaemon, METH_NOARGS, ""},
 #endif
-
-	//{"dumpJVMStats", (PyCFunction) (&PyJPModule_dumpJVMStats), METH_NOARGS, ""},
 
 	{"convertToDirectBuffer", (PyCFunction) PyJPModule_convertToDirectByteBuffer, METH_VARARGS, ""},
 	{"arrayFromBuffer", (PyCFunction) PyJPModule_arrayFromBuffer, METH_VARARGS, ""},

--- a/native/python/pyjp_object.cpp
+++ b/native/python/pyjp_object.cpp
@@ -298,6 +298,8 @@ static PyObject* PyJPException_expandStacktrace(PyObject* self)
 	JP_PY_TRY("PyJPModule_expandStackTrace");
 	JPJavaFrame frame = JPJavaFrame::outer();
 	JPValue *val = PyJPValue_getJavaSlot(self);
+	if (val == nullptr)
+		JP_RAISE(PyExc_TypeError, "Java slot is not set on exception");
 
 	// These two are loop invariants and must match each time
 	auto th = (jthrowable) val->getValue().l;

--- a/project/utility/testMemoryExh.py
+++ b/project/utility/testMemoryExh.py
@@ -8,12 +8,11 @@
 # verify function (<1k, 10k, >1Mb) as different behaviors occur at different
 # usage points.
 
-from os import path
 import _jpype
 import jpype
 from jpype.types import *
 import numpy as np
-import gc
+import gc  # kept for the commented-out gc.callbacks debug hook below  # lgtm[py/unused-import]
 import time
 
 # print(gc.callbacks)
@@ -52,7 +51,7 @@ if __name__ == '__main__':
 
     print()
     kB = (1024 / 8)
-    MB = (1024**2 / 8)
+    MB = (1024**2 / 8)  # swap in for kB above to test the >1Mb block size  # lgtm[py/unused-global-variable]
 
     fixture = JClass("jpype.common.Fixture")()
     for i in range(trials):
@@ -60,7 +59,8 @@ if __name__ == '__main__':
 
         interface = jpype.JProxy("java.io.Serializable",
                                  dict={'callback': DestructionTracker(i, x).callback})
-        interface_container = fixture.callObject(interface)
+        # Held (not "read") to keep it alive until the explicit del below.
+        interface_container = fixture.callObject(interface)  # lgtm[py/unused-global-variable]
 
         if (i % 1000) == 0:
             stats = _jpype.gcStats()

--- a/project/utility/testMemoryExh.py
+++ b/project/utility/testMemoryExh.py
@@ -75,6 +75,7 @@ if __name__ == '__main__':
             time.sleep(1)
 #        print(_jpype.gcStats())
         del interface, interface_container
+        # Manual debug toggles below - uncomment when tuning by hand.  # lgtm[py/commented-out-code]
 #        if DestructionTracker.del_calls != 0:
 #            print(f'{i} We have deleted something: {DestructionTracker.del_calls}')
 #        else:

--- a/project/utility/testMemoryExh.py
+++ b/project/utility/testMemoryExh.py
@@ -12,7 +12,9 @@ import _jpype
 import jpype
 from jpype.types import *
 import numpy as np
-import gc  # kept for the commented-out gc.callbacks debug hook below  # lgtm[py/unused-import]
+# kept for the commented-out gc.callbacks debug hook below
+# codeql[py/unused-import]
+import gc
 import time
 
 # print(gc.callbacks)
@@ -51,7 +53,9 @@ if __name__ == '__main__':
 
     print()
     kB = (1024 / 8)
-    MB = (1024**2 / 8)  # swap in for kB above to test the >1Mb block size  # lgtm[py/unused-global-variable]
+    # swap in for kB above to test the >1Mb block size
+    # codeql[py/unused-global-variable]
+    MB = (1024**2 / 8)
 
     fixture = JClass("jpype.common.Fixture")()
     for i in range(trials):
@@ -60,7 +64,8 @@ if __name__ == '__main__':
         interface = jpype.JProxy("java.io.Serializable",
                                  dict={'callback': DestructionTracker(i, x).callback})
         # Held (not "read") to keep it alive until the explicit del below.
-        interface_container = fixture.callObject(interface)  # lgtm[py/unused-global-variable]
+        # codeql[py/unused-global-variable]
+        interface_container = fixture.callObject(interface)
 
         if (i % 1000) == 0:
             stats = _jpype.gcStats()
@@ -75,7 +80,8 @@ if __name__ == '__main__':
             time.sleep(1)
 #        print(_jpype.gcStats())
         del interface, interface_container
-        # Manual debug toggles below - uncomment when tuning by hand.  # lgtm[py/commented-out-code]
+        # Manual debug toggles below - uncomment when tuning by hand.
+        # codeql[py/commented-out-code]
 #        if DestructionTracker.del_calls != 0:
 #            print(f'{i} We have deleted something: {DestructionTracker.del_calls}')
 #        else:

--- a/test/jpypetest/test_array.py
+++ b/test/jpypetest/test_array.py
@@ -129,7 +129,8 @@ class ArrayTestCase(common.JPypeTestCase):
         with self.assertRaisesRegex(SystemError, "fault"):
             ja = JArray(JInt, 2)(5)
             m = memoryview(ja)
-            del m  # lgtm [py/unnecessary-delete]
+            # codeql[py/unnecessary-delete]
+            del m
 
     @common.requireInstrumentation
     def testJPArrayPrimitive_getBuffer(self):
@@ -138,7 +139,8 @@ class ArrayTestCase(common.JPypeTestCase):
         def f():
             ja = JArray(JInt)(5)
             m = memoryview(ja)
-            del m  # lgtm [py/unnecessary-delete]
+            # codeql[py/unnecessary-delete]
+            del m
         with self.assertRaisesRegex(SystemError, "fault"):
             f()
         with self.assertRaises(BufferError):

--- a/test/jpypetest/test_fault.py
+++ b/test/jpypetest/test_fault.py
@@ -445,7 +445,8 @@ class FaultTestCase(common.JPypeTestCase):
     def testJPValue_finalize(self):
         _jpype.fault("PyJPValue_finalize")
         a = JInt(1)
-        del a  # lgtm [py/unnecessary-delete]
+        # codeql[py/unnecessary-delete]
+        del a
 
     @common.requireInstrumentation
     def testJPValue_str(self):

--- a/test/jpypetest/test_jboolean.py
+++ b/test/jpypetest/test_jboolean.py
@@ -44,7 +44,8 @@ class JBooleanTestCase(common.JPypeTestCase):
 
     @common.requireInstrumentation
     def testJPBooleanType(self):
-        ja = JArray(JBoolean)(5)  # lgtm [py/similar-function]
+        # codeql[py/similar-function]
+        ja = JArray(JBoolean)(5)
         _jpype.fault("JPBooleanType::setArrayRange")
         with self.assertRaisesRegex(SystemError, "fault"):
             ja[1:3] = [0, 0]

--- a/test/jpypetest/test_jchar.py
+++ b/test/jpypetest/test_jchar.py
@@ -90,7 +90,8 @@ class JChar2TestCase(common.JPypeTestCase):
             # Special case no fault is allowed
             memoryview(ja[0:3])
         f()
-        ja = JArray(JChar)(5)  # lgtm [py/similar-function]
+        # codeql[py/similar-function]
+        ja = JArray(JChar)(5)
         _jpype.fault("JPCharType::setArrayRange")
         with self.assertRaisesRegex(SystemError, "fault"):
             ja[1:3] = [0, 0]


### PR DESCRIPTION
This branch is built on top of #1448 (shutdown-signal-handler fix) and
  includes its commits. Please review/merge #1448 first — once it lands,
  this diff will shrink to just the 7 commits below.

  ## What

  Resolves 115 of the 117 open alerts on the Security → Code scanning tab,
  across Python, Java, and C++. Every alert was individually triaged, not
  blanket-suppressed — each commit below explains the reasoning per
  category. Roughly three outcomes:

  - **Genuinely dead/orphaned code** — removed outright, each confirmed via
    `grep` to have zero other references anywhere in the tree before
    deletion (e.g. two `PyMethodDef` entries whose backing functions no
    longer existed, a commented-out call to a method that was never
    defined, unused imports/variables/locals).
  - **Real bugs, fixed** — a few alerts turned out to be legitimate:
    - `java/ignored-error-status-of-call`: `JPypePackage.isPublic()`'s
      hand-rolled `.class` file parser ignored `InputStream.read`/`.skip`
      return values, which can legally be short reads even before EOF -
      added `readFully`/`skipFully` helpers.
    - `cpp/inconsistent-null-check`: two call sites skipped a null check
      that 88% of other callers of the same function make. Added the
      checks (verified empirically where the fix needed to be behavioral,
      not just defensive).
    - `py/mixed-returns`: made an implicit-None return explicit in 4
      documented "returns X or None" functions; removed a pointless
      `return` on a value Python's `del` protocol never uses.
  - **False positives** — suppressed with `# lgtm[rule-id]`, each with a
    comment explaining *why* it's safe, not just marking it resolved.
    Along the way, found and fixed a real, previously-invisible bug: several
    **pre-existing** suppression comments across the codebase used
    `// lgtm [rule]` (a space after `lgtm`) and had **never actually been
    honored** by GitHub's scanner - silently broken since whenever they were
    added. Fixed every instance found.

  Two cases were explicitly tested rather than guessed at:
    - `py/equals-hash-mismatch`: ran a real JVM test to confirm two distinct
      `java.lang.String` objects with equal content compare equal *and*
  - `py/equals-hash-mismatch`: ran a real JVM test to confirm two distinct
    `java.lang.String` objects with equal content compare equal *and*
    hash equal through JPype's `@JImplementationFor` composition, before
    trusting that the missing `__eq__` wasn't a real bug.
  - `cpp/suspicious-pointer-scaling`: confirmed via `test_jchar.py`'s full
    79-case suite (all three char storage paths) that rewriting
    `((T*) self) + 1` as `&(((T*) self)[1])` for clarity is behaviorally
    identical - same CPython compact-Unicode-object trick, clearer intent.

## Not resolved (deliberately)

- `cpp/fixme-comment` — a real outstanding TODO ("find a way to call this
  from instrumentation"). Left as-is; resolving it means either doing
  that work or a maintainer explicitly deciding to dismiss it, not
  something to silently mark fixed.
- `cpp/poorly-documented-function` — would require deeply understanding a
  338-line function to document accurately. Left for a maintainer with
  the right context rather than a rubber-stamp docstring.

## Test plan

- [x] Every commit individually gated on the full suite (1679/172
      throughout) + `ant` Java build, isolated venv per CLAUDE.md
- [x] `test_jchar.py`, `test_jpackage.py`, `test_javadoc.py`,
      `test_jstring.py` specifically exercised (touched by the
      pointer-arithmetic, classfile-parsing, HTML-parser, and
      equals/hash changes respectively)
- [x] No user-facing behavior change intended anywhere except the two
      confirmed-real bug fixes (`isPublic()`'s short-read handling,
      the two null-check additions)