### PR TITLE
[ci] run pyinstaller test only on Linux Python 3.10

### DIFF
--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -74,6 +74,7 @@ steps:
     cd empty
     python -m PyInstaller.utils.run_tests --include_only jpype._pyinstaller.
   displayName: 'Test PyInstaller result'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['python.version'], '3.10'))
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()

--- a/.azure/scripts/test.yml
+++ b/.azure/scripts/test.yml
@@ -46,7 +46,7 @@ steps:
 - bash: |
     [ "$(Agent.OS)" = "Linux" ] && ulimit -c unlimited
     cd test
-    python -m pytest -v --junit-xml=test.xml jpypetest --checkjni
+    python -m pytest -v --junit-xml=test.xml jpypetest --checkjni -n2 --dist loadfile
   displayName: 'Test JDK $(jdk.version) and Python $(python.version)'
   condition: eq(variables['jpypetest.fast'], 'false')
 

--- a/project/conda_recipe/meta.yaml
+++ b/project/conda_recipe/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - cmake
     - ninja  # [win]
     - make  # [not win]
+    # for readelf (dynamic libstdc++ linkage check)
+    - binutils # [linux]
 
   host:
     - python

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-randomly
+pytest-xdist
 pyinstaller
 jedi==0.18.0
 numpy


### PR DESCRIPTION
We do not need to test for every CI matrix job, that PyInstaller is doing its job correctly. We just test it once on Linux and Python 3.10.
This saves one extra minute for all the other jobs.