### PR TITLE
Jvm destroy segfault

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -7,6 +7,18 @@ Latest Changes:
 
 - **1.7.2.dev0**
 
+  - Fixed a segmentation fault when a Python proxy (e.g. implementing
+    ``Runnable``) was invoked from a *daemon* Java thread and was still
+    blocked inside its Python callback when ``shutdownJVM()`` ran.
+    ``DestroyJavaVM()`` only waits for non-daemon Java threads, so shutdown
+    would complete - freeing every internal class/context resource - while
+    that thread was still parked underneath it; releasing the callback
+    afterwards resumed execution on top of a destroyed JVM. JPype now
+    detects this in the native proxy dispatcher as soon as the callback
+    returns, warns to stderr, and gets the thread off the JVM permanently
+    (hard-terminated where safe, parked forever otherwise) instead of
+    letting it touch freed state.
+
   - Fixed a random segmentation fault at JVM shutdown when Python tooling
     (such as pytest's built-in faulthandler plugin) restored pre-JVM signal
     handlers over HotSpot's, leaving safepoint polls in compiled code

--- a/native/common/jp_proxy.cpp
+++ b/native/common/jp_proxy.cpp
@@ -21,6 +21,15 @@
 #include "jp_primitive_accessor.h"
 #include "jp_boxedtype.h"
 #include "jp_functional.h"
+#include <chrono>
+#include <cstdio>
+#include <thread>
+#ifdef WIN32
+#include <Windows.h>
+#elif defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
 
 JPPyObject getArgs(jlongArray parameterTypePtrs,
 		jobjectArray args, PyObject* self, int addSelf)
@@ -51,6 +60,79 @@ JPPyObject getArgs(jlongArray parameterTypePtrs,
 	return pyargs;
 	JP_TRACE_OUT;
 }
+
+// GCOVR_EXCL_START
+// A daemon-thread proxy can still be blocked inside the Python call below
+// when shutdownJVM() runs: DestroyJavaVM() only waits for non-daemon Java
+// threads, so it returns - and JPContext::shutdownJVM() then frees every
+// JPClass/context resource - while this thread is still parked. Once that
+// has happened we can neither convert a return value/exception back to
+// Java (the classes needed to do so are gone) nor safely return into the
+// JNI call stack we were invoked from (it belongs to a destroyed JVM), so
+// this thread must never execute another instruction that touches JVM or
+// JPype state. Warn once, then get this thread off the JVM's corpse for
+// good - by hard-terminating it where that is safe, or parking it forever
+// where it is not.
+//
+// Coverage is excluded: exercising this requires destroying the JVM out
+// from under a live thread, which by design never returns.
+[[noreturn]] static void abandonThreadAfterShutdown(PyObject* rawReturn)
+{
+	Py_XDECREF(rawReturn);
+	fprintf(stderr, "JPype: Application error, blocked python proxy attached "
+			"as a daemon thread and called after JVM shutdown. %s\n",
+#if defined(WIN32) || defined(__linux__)
+			"Terminating thread."
+#else
+			"Parking thread permanently."
+#endif
+			);
+	fflush(stderr);
+
+	// Release the GIL we are still holding (via the caller's outer
+	// JPPyCallAcquire) with a direct C-API call rather than letting that
+	// RAII object's destructor do it during a stack unwind. Skipping this
+	// step entirely and terminating while still holding the GIL would hard
+	// freeze the rest of the interpreter forever, since no other Python
+	// thread could ever acquire it again.
+	PyEval_SaveThread();
+
+	// pthread_exit() is deliberately not used here: on glibc it unwinds the
+	// C++ stack via the same forced-unwind mechanism as pthread_cancel(),
+	// which would run JPJavaFrame's/JPPyCallAcquire's destructors (touching
+	// the destroyed JVM) as it passes through them - and, independently of
+	// that, JNI flatly forbids letting any exception cross back out through
+	// the JVM's own native-method call stub beneath us, which a forced
+	// unwind would attempt to do. We must not unwind through that stack at
+	// all, only step around it.
+#if defined(WIN32)
+	// Terminates only this thread - no destructors run, no SEH unwinding -
+	// and unlike a pthread stack, Windows itself reclaims the thread's
+	// stack on the way out. Clean and safe for exactly this "abandon
+	// everything left on this stack" situation.
+	ExitThread(1);
+#elif defined(__linux__)
+	// The raw exit syscall (as opposed to glibc's exit()/exit_group()
+	// wrapper, which would tear down the whole process) terminates only the
+	// calling thread, with no unwinding and no cleanup handlers run. The
+	// trade-off is that it also skips NPTL's own stack teardown, so this
+	// thread's stack is leaked for the remaining life of the process - a
+	// small, bounded, one-time cost, and the only way on this platform to
+	// guarantee we never execute another instruction on top of a destroyed
+	// JVM. Not extended to other POSIX platforms (e.g. macOS): raw syscall
+	// numbers are not a stable ABI there, and getting this wrong risks
+	// tearing down the whole process instead of just this thread.
+	syscall(SYS_exit, 0);
+#endif
+
+	// Either this thread was just terminated above, or (on platforms
+	// without a verified-safe hard-terminate primitive) fall back to
+	// parking: it must never execute another instruction that touches JVM
+	// or JPype state, but it is safe to simply never do so again.
+	for (;;)
+		std::this_thread::sleep_for(std::chrono::hours(24));
+}
+// GCOVR_EXCL_STOP
 
 extern "C" JNIEXPORT jobject JNICALL Java_org_jpype_proxy_JPypeProxy_hostInvoke(
 		JNIEnv *env, jclass clazz,
@@ -102,7 +184,14 @@ extern "C" JNIEXPORT jobject JNICALL Java_org_jpype_proxy_JPypeProxy_hostInvoke(
 			JPPyObject pyargs = getArgs(parameterTypePtrs, args, proxy->m_Instance->m_Target, addSelf);
 
 			JP_TRACE("Call Python");
-			JPPyObject returnValue = JPPyObject::call(PyObject_Call(callable.get(), pyargs.get(), nullptr));
+			PyObject* rawReturn = PyObject_Call(callable.get(), pyargs.get(), nullptr);
+
+			// The JVM may have been destroyed while we were blocked in the
+			// call above (see abandonThreadAfterShutdown()).
+			if (!JPContext_global->isRunning())
+				abandonThreadAfterShutdown(rawReturn); // GCOVR_EXCL_LINE
+
+			JPPyObject returnValue = JPPyObject::call(rawReturn);
 
 			JP_TRACE("Handle return", Py_TYPE(returnValue.get())->tp_name);
 			if (returnClass == JPContext_global->_void)

--- a/test/jpypetest/test_shutdown.py
+++ b/test/jpypetest/test_shutdown.py
@@ -89,17 +89,44 @@ class ShutdownSignalWarningTest(unittest.TestCase):
 
 
 class ShutdownParkedDaemonProxyTest(unittest.TestCase):
-    """A Python proxy invoked from a *daemon* Java thread can still be
-    blocked inside its Python callback when shutdownJVM() runs:
-    DestroyJavaVM() only waits for non-daemon Java threads, so it returns -
-    and frees every JPClass/context resource - while that thread is still
-    parked underneath it. Releasing the callback afterwards used to resume
+    """A Python proxy invoked from a *daemon* thread can still be blocked
+    inside its Python callback when shutdownJVM() runs: DestroyJavaVM()
+    only waits for non-daemon Java threads, so it returns - and frees every
+    JPClass/context resource - while that thread is still parked
+    underneath it. Releasing the callback afterwards used to resume
     execution on top of a destroyed JVM and segfault. JPype must instead
     detect this in hostInvoke() and get the thread off the JVM permanently
     (terminate it, or park it forever) rather than let it touch freed
-    state.  Run out-of-process since a regression here is a hard crash."""
+    state.  Run out-of-process since a regression here is a hard crash.
 
-    def _run(self, action):
+    Covers both ways a thread can end up daemon-attached and parked inside
+    hostInvoke():
+      - java.lang.Thread(runnable): a JVM-native thread, never previously
+        seen by Python, that calls straight into the proxy (Java -> Python).
+      - a plain Python threading.Thread that calls into Java through a
+        Java-typed reference to the same proxy, which routes back into the
+        same callback on that same OS thread (Python -> Java -> Python).
+        This thread auto-attaches as a daemon via JPContext::getEnv()'s
+        AttachCurrentThreadAsDaemon fallback the first time it touches
+        Java, so it is exposed to the same race, but arrives at
+        hostInvoke() with GIL/thread-state history a java.lang.Thread never
+        has (it already had a live PyThreadState before touching Java)."""
+
+    _SPAWN_JAVA_THREAD = (
+        "jthread = jpype.java.lang.Thread(runnable)\n"
+        "jthread.setDaemon(True)\n"
+        "jthread.start()\n"
+    )
+
+    _SPAWN_PYTHON_THREAD = (
+        "jrunnable = jpype.java.lang.Runnable @ runnable\n"
+        "def worker():\n"
+        "    jrunnable.run()\n"
+        "jthread = threading.Thread(target=worker, daemon=True)\n"
+        "jthread.start()\n"
+    )
+
+    def _run(self, action, spawn):
         script = (
             "import threading, time, jpype\n"
             "from jpype import JImplements, JOverride\n"
@@ -114,9 +141,7 @@ class ShutdownParkedDaemonProxyTest(unittest.TestCase):
             "        release.wait()\n"
             f"        {action}\n"
             "runnable = Parked()\n"
-            "jthread = jpype.java.lang.Thread(runnable)\n"
-            "jthread.setDaemon(True)\n"
-            "jthread.start()\n"
+            f"{spawn}"
             "assert started.wait(timeout=10)\n"
             "time.sleep(0.2)\n"
             "jpype.shutdownJVM()\n"
@@ -133,17 +158,27 @@ class ShutdownParkedDaemonProxyTest(unittest.TestCase):
                       b"a daemon thread and called after JVM shutdown",
                       result.stderr)
 
-    def testRaiseAfterShutdown(self):
+    def testRaiseAfterShutdownJavaThread(self):
         # Callback resumes and raises - exercises the exception-conversion
         # path (JPPythonError::toJava), which needs the freed exception
         # classes.
-        self._run("raise RuntimeError('boom after JVM destroyed')")
+        self._run("raise RuntimeError('boom after JVM destroyed')",
+                  self._SPAWN_JAVA_THREAD)
 
-    def testCallAfterShutdown(self):
+    def testCallAfterShutdownJavaThread(self):
         # Callback resumes and makes a fresh JNI call - exercises the case
         # where the callback doesn't merely return but tries to use the
         # (destroyed) JVM again.
-        self._run("jpype.java.lang.System.currentTimeMillis()")
+        self._run("jpype.java.lang.System.currentTimeMillis()",
+                  self._SPAWN_JAVA_THREAD)
+
+    def testRaiseAfterShutdownPythonThread(self):
+        self._run("raise RuntimeError('boom after JVM destroyed')",
+                  self._SPAWN_PYTHON_THREAD)
+
+    def testCallAfterShutdownPythonThread(self):
+        self._run("jpype.java.lang.System.currentTimeMillis()",
+                  self._SPAWN_PYTHON_THREAD)
 
 
 @subrun.TestCase

--- a/test/jpypetest/test_shutdown.py
+++ b/test/jpypetest/test_shutdown.py
@@ -88,6 +88,64 @@ class ShutdownSignalWarningTest(unittest.TestCase):
         self.assertIn(b"PRE-JVM-RESTORED", result.stdout)
 
 
+class ShutdownParkedDaemonProxyTest(unittest.TestCase):
+    """A Python proxy invoked from a *daemon* Java thread can still be
+    blocked inside its Python callback when shutdownJVM() runs:
+    DestroyJavaVM() only waits for non-daemon Java threads, so it returns -
+    and frees every JPClass/context resource - while that thread is still
+    parked underneath it. Releasing the callback afterwards used to resume
+    execution on top of a destroyed JVM and segfault. JPype must instead
+    detect this in hostInvoke() and get the thread off the JVM permanently
+    (terminate it, or park it forever) rather than let it touch freed
+    state.  Run out-of-process since a regression here is a hard crash."""
+
+    def _run(self, action):
+        script = (
+            "import threading, time, jpype\n"
+            "from jpype import JImplements, JOverride\n"
+            "jpype.startJVM(convertStrings=False)\n"
+            "started = threading.Event()\n"
+            "release = threading.Event()\n"
+            "@JImplements(jpype.java.lang.Runnable)\n"
+            "class Parked:\n"
+            "    @JOverride\n"
+            "    def run(self):\n"
+            "        started.set()\n"
+            "        release.wait()\n"
+            f"        {action}\n"
+            "runnable = Parked()\n"
+            "jthread = jpype.java.lang.Thread(runnable)\n"
+            "jthread.setDaemon(True)\n"
+            "jthread.start()\n"
+            "assert started.wait(timeout=10)\n"
+            "time.sleep(0.2)\n"
+            "jpype.shutdownJVM()\n"
+            "release.set()\n"
+            "time.sleep(1)\n"
+            "print('SURVIVED')\n"
+        )
+        result = subprocess.run([sys.executable, "-c", script],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                timeout=60)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"SURVIVED", result.stdout)
+        self.assertIn(b"Application error, blocked python proxy attached as "
+                      b"a daemon thread and called after JVM shutdown",
+                      result.stderr)
+
+    def testRaiseAfterShutdown(self):
+        # Callback resumes and raises - exercises the exception-conversion
+        # path (JPPythonError::toJava), which needs the freed exception
+        # classes.
+        self._run("raise RuntimeError('boom after JVM destroyed')")
+
+    def testCallAfterShutdown(self):
+        # Callback resumes and makes a fresh JNI call - exercises the case
+        # where the callback doesn't merely return but tries to use the
+        # (destroyed) JVM again.
+        self._run("jpype.java.lang.System.currentTimeMillis()")
+
+
 @subrun.TestCase
 class ShutdownTest(unittest.TestCase):
 


### PR DESCRIPTION
This fixes a rare segfault on shutdown where a daemon thread is still blocked during the JVM and then attempts to return to Java.

Fixes #1454 